### PR TITLE
Remove Default.*Path and update ComputerSystem to match the redfish spec

### DIFF
--- a/school/client.go
+++ b/school/client.go
@@ -102,6 +102,7 @@ func (c *ApiClient) Post(url string, payload []byte) (*http.Response, error) {
 
 	req.Header.Set("User-Agent", "gofish/1.0.0")
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
 	if c.Token != "" {
 		req.Header.Set("X-Auth-Token", c.Token)
 	}

--- a/school/redfish/accounts.go
+++ b/school/redfish/accounts.go
@@ -18,12 +18,6 @@ import (
 	"github.com/stmcginnis/gofish/school/common"
 )
 
-// DefaultAccountServicePath is the default URI for AccountService collections.
-const DefaultAccountServicePath = "/redfish/v1/AccountService"
-
-// DefaultAccountsPath is the default URI for Accounts collections.
-const DefaultAccountsPath = "/redfish/v1/AccountService/Accounts"
-
 // AccountService contains properties for managing user accounts. The
 // properties are common to all user accounts, such as password requirements,
 // and control features such as account lockout. The schema also contains links
@@ -166,11 +160,6 @@ func ListReferencedAccounts(c common.Client, link string) ([]*Account, error) {
 	return result, nil
 }
 
-// ListAccounts gets all Accounts in the system
-func ListAccounts(c common.Client) ([]*Account, error) {
-	return ListReferencedAccounts(c, DefaultAccountsPath)
-}
-
 // Role is a Redfish role
 type Role struct {
 	common.Entity
@@ -215,9 +204,4 @@ func ListReferencedRoles(c common.Client, link string) ([]*Role, error) {
 	}
 
 	return result, nil
-}
-
-// ListRoles gets all Roles in the system
-func ListRoles(c common.Client) ([]*Role, error) {
-	return ListReferencedRoles(c, DefaultAccountsPath)
 }

--- a/school/redfish/chassis.go
+++ b/school/redfish/chassis.go
@@ -18,9 +18,6 @@ import (
 	"github.com/stmcginnis/gofish/school/common"
 )
 
-// DefaultChassisPath is the default URI for Chassis collections.
-const DefaultChassisPath = "/redfish/v1/Chassis"
-
 // ChassisType is a physical form of the chassis
 type ChassisType string
 
@@ -173,11 +170,6 @@ func ListReferencedChassis(c common.Client, link string) ([]*Chassis, error) {
 	}
 
 	return result, nil
-}
-
-// ListChassis gets all Chassis in the system.
-func ListChassis(c common.Client) ([]*Chassis, error) {
-	return ListReferencedChassis(c, DefaultChassisPath)
 }
 
 // ThermalInfo is reference to the thermal properties (fans, cooling, sensors)

--- a/school/redfish/compositionservice.go
+++ b/school/redfish/compositionservice.go
@@ -18,8 +18,6 @@ import (
 	"github.com/stmcginnis/gofish/school/common"
 )
 
-// DefaultCompositionServicePath is the default URI for CompositionService collections.
-const DefaultCompositionServicePath = "/redfish/v1/CompositionService"
 
 // CompositionService defines a Composition Service which represents the
 // properties for the service and links to the resources available for

--- a/school/redfish/events.go
+++ b/school/redfish/events.go
@@ -18,8 +18,6 @@ import (
 	"github.com/stmcginnis/gofish/school/common"
 )
 
-// DefaultEventServicePath is the default URI for EventService collections.
-const DefaultEventServicePath = "/redfish/v1/EventService"
 
 // EventService contains properties for managing event subcriptions and
 // generates the events sent to subscribers.  The resource has links to the

--- a/school/redfish/hostinterface.go
+++ b/school/redfish/hostinterface.go
@@ -18,9 +18,7 @@ import (
 	"github.com/stmcginnis/gofish/school/common"
 )
 
-// DefaultHostInterfacePath is the default URI for the HostInterface
 // object.
-const DefaultHostInterfacePath = "/redfish/v1/HostInterface"
 
 // AuthenticationMode is
 type AuthenticationMode string

--- a/school/redfish/manager.go
+++ b/school/redfish/manager.go
@@ -18,9 +18,6 @@ import (
 	"github.com/stmcginnis/gofish/school/common"
 )
 
-// DefaultManagerPath is the default URI for Manager collections.
-const DefaultManagerPath = "/redfish/v1/Managers"
-
 // UIConsoleInfo contains information about GUI services.
 type UIConsoleInfo struct {
 	ServiceEnabled        string
@@ -128,9 +125,4 @@ func ListReferencedManagers(c common.Client, link string) ([]*Manager, error) {
 	}
 
 	return result, nil
-}
-
-// ListManagers gets all Manager in the system
-func ListManagers(c common.Client) ([]*Manager, error) {
-	return ListReferencedManagers(c, DefaultManagerPath)
 }

--- a/school/redfish/protocol.go
+++ b/school/redfish/protocol.go
@@ -12,9 +12,7 @@
 
 package redfish
 
-// DefaultProtocolPath is the default URI for the Protocol
 // object.
-const DefaultProtocolPath = "/redfish/v1/Protocol"
 
 // Protocol is
 type Protocol string

--- a/school/redfish/session.go
+++ b/school/redfish/session.go
@@ -18,9 +18,6 @@ import (
 	"github.com/stmcginnis/gofish/school/common"
 )
 
-// DefaultSessionPath is the default URI for SessionService collections.
-const DefaultSessionPath = "/redfish/v1/Sessions"
-
 // Session describes a single connection (session) between a client and a
 // Redfish service instance.
 type Session struct {
@@ -42,7 +39,7 @@ type authPayload struct {
 }
 
 // CreateSession creates a new session and returns the token and id
-func CreateSession(c common.Client, username string, password string) (auth *AuthToken, err error) {
+func CreateSession(c common.Client, uri string, username string, password string) (auth *AuthToken, err error) {
 	a := &authPayload{
 		Username: username,
 		Password: password,
@@ -53,7 +50,7 @@ func CreateSession(c common.Client, username string, password string) (auth *Aut
 		return auth, err
 	}
 
-	resp, err := c.Post(DefaultSessionPath, payload)
+	resp, err := c.Post(uri, payload)
 	if err != nil {
 		return auth, err
 	}
@@ -104,9 +101,4 @@ func ListReferencedSessions(c common.Client, link string) ([]*Session, error) {
 	}
 
 	return result, nil
-}
-
-// ListSessions gets all Session in the system
-func ListSessions(c common.Client) ([]*Session, error) {
-	return ListReferencedSessions(c, DefaultSessionPath)
 }

--- a/school/redfish/tasks.go
+++ b/school/redfish/tasks.go
@@ -18,9 +18,6 @@ import (
 	"github.com/stmcginnis/gofish/school/common"
 )
 
-// DefaultTaskServicePath is the default URI for TaskService collections.
-const DefaultTaskServicePath = "/redfish/v1/TaskService"
-
 // TaskState indicates the state of a task
 type TaskState string
 
@@ -99,9 +96,4 @@ func ListReferencedTasks(c common.Client, link string) ([]*Task, error) {
 	}
 
 	return result, nil
-}
-
-// ListTasks gets all Task in the system
-func ListTasks(c common.Client) ([]*Task, error) {
-	return ListReferencedTasks(c, DefaultTaskServicePath)
 }

--- a/school/service.go
+++ b/school/service.go
@@ -127,7 +127,7 @@ func (s *Service) Tasks() ([]*redfish.Task, error) {
 
 // CreateSession creates a new session and returns the token and id
 func (s *Service) CreateSession(username string, password string) (*redfish.AuthToken, error) {
-	return redfish.CreateSession(s.Client, username, password)
+	return redfish.CreateSession(s.Client, s.sessions, username, password)
 }
 
 // Sessions gets the system's active sessions

--- a/school/swordfish/datastoragelineofservice.go
+++ b/school/swordfish/datastoragelineofservice.go
@@ -18,10 +18,6 @@ import (
 	"github.com/stmcginnis/gofish/school/common"
 )
 
-// DefaultDataStorageLineOfServicePath is the default URI for the DataStorageLineOfService
-// object.
-const DefaultDataStorageLineOfServicePath = "/redfish/v1/DataStorageLineOfService"
-
 // DataStorageLineOfService is used to describe a service option covering
 // storage provisioning and availability.
 type DataStorageLineOfService struct {
@@ -124,9 +120,4 @@ func ListReferencedDataStorageLineOfServices(c common.Client, link string) ([]*D
 	}
 
 	return result, nil
-}
-
-// ListDataStorageLineOfServices gets all DataStorageLineOfService in the system.
-func ListDataStorageLineOfServices(c common.Client) ([]*DataStorageLineOfService, error) {
-	return ListReferencedDataStorageLineOfServices(c, DefaultDataStorageLineOfServicePath)
 }

--- a/school/swordfish/endpointgroup.go
+++ b/school/swordfish/endpointgroup.go
@@ -19,10 +19,6 @@ import (
 	"github.com/stmcginnis/gofish/school/redfish"
 )
 
-// DefaultEndpointGroupPath is the default URI for the EndpointGroup
-// object.
-const DefaultEndpointGroupPath = "/redfish/v1/EndpointGroup"
-
 // AccessState is used for associated resources through all
 // aggregated endpoints shall share this access state.
 type AccessState string
@@ -150,11 +146,6 @@ func ListReferencedEndpointGroups(c common.Client, link string) ([]*EndpointGrou
 	}
 
 	return result, nil
-}
-
-// ListEndpointGroups gets all EndpointGroup in the system.
-func ListEndpointGroups(c common.Client) ([]*EndpointGroup, error) {
-	return ListReferencedEndpointGroups(c, DefaultEndpointGroupPath)
 }
 
 // Endpoints gets the group's endpoints.

--- a/school/swordfish/storageservice.go
+++ b/school/swordfish/storageservice.go
@@ -19,10 +19,6 @@ import (
 	"github.com/stmcginnis/gofish/school/redfish"
 )
 
-// DefaultStorageServicePath is the default URI for the StorageService
-// object.
-const DefaultStorageServicePath = "/redfish/v1/StorageService"
-
 // StorageService is a collection of resources that the system can make
 // available to one or more host systems. The collection can contain:
 // block, file, or object storage; local system access points through
@@ -202,11 +198,6 @@ func ListReferencedStorageServices(c common.Client, link string) ([]*StorageServ
 	}
 
 	return result, nil
-}
-
-// ListStorageServices gets all StorageService in the system.
-func ListStorageServices(c common.Client) ([]*StorageService, error) {
-	return ListReferencedStorageServices(c, DefaultStorageServicePath)
 }
 
 // ClassesOfService gets the storage service's classes of service.

--- a/school/swordfish/storagesystem.go
+++ b/school/swordfish/storagesystem.go
@@ -19,9 +19,6 @@ import (
 	"github.com/stmcginnis/gofish/school/redfish"
 )
 
-// DefaultStorageSystemPath is the default URI for StorageSystem collections.
-const DefaultStorageSystemPath = "/redfish/v1/StorageSystems"
-
 // StorageSystem is a Swordfish storage system instance.
 type StorageSystem struct {
 	redfish.ComputerSystem
@@ -62,9 +59,4 @@ func ListReferencedStorageSystems(c common.Client, link string) ([]*StorageSyste
 	}
 
 	return result, nil
-}
-
-// ListStorageSystems gets all StorageSystem in the system.
-func ListStorageSystems(c common.Client) ([]*StorageSystem, error) {
-	return ListReferencedStorageSystems(c, DefaultStorageSystemPath)
 }

--- a/tools/source.go
+++ b/tools/source.go
@@ -18,9 +18,6 @@ import (
 	"github.com/stmcginnis/gofish/school/common"
 )
 
-// Default{{ object_name }}Path is the default URI for the {{ object_name }}
-// object.
-const Default{{ object_name }}Path = "/redfish/v1/{{ object_name }}"
 {% for enum in enums %}
 
 {{ enum.description }}
@@ -104,11 +101,6 @@ func ListReferenced{{ class.name }}s(c common.Client, link string) ([]*{{ class.
     }
 
     return result, nil
-}
-
-// List{{ class.name }}s gets all {{ class.name }} in the system.
-func List{{ class.name }}s(c common.Client) ([]*{{ class.name }}, error) {
-    return ListReferenced{{ class.name }}s(c, Default{{ class.name }}Path)
 }
 
 {% endif %}


### PR DESCRIPTION
I've also started testing the code against a few different vendors and multiple versions of RedFish to ensure compatibility and also that I won't break anything :).

These changes have been tested against:
      // HP Gen10
      // Supermicro X10
      // Dell M630
      // Intel S2600WF0
      // Dell M640

The only tricky part for me is to test the swordfish side, because I don't have any device capable a this moment.

----

Adds Actions and create a list of possible ResetType

It's now possible to use the target from Actions to issue a reboot
action. Next step is to work on the boot once action

Update computersystem types to unpack as expected

Dell M640s also require the Accept Header, not only the Content-Type