### PR TITLE
PR: Redfish import tools

### DIFF
--- a/tools/redfish-schema/gen_script.sh
+++ b/tools/redfish-schema/gen_script.sh
@@ -1,19 +1,35 @@
 #!/bin/sh
-# Generates a script from a given schema zip file, finds the names of the
-# objects, then generates go files based on the provided
-# generate_from_schema.py tool
+# Generates a subordinate script (gen_go_source.sh) from a given schema zip
+# file, finds the names of the objects, then generates go files based on
+# the provided generate_from_schema.py tool and accompanying source.go file.
+# Leaves the gen_go_source.sh in place for modification if needed and can be run
+# independently of this script to regenerate files.
 
-# Find the schema document name by going here: https://www.dmtf.org/standards/redfish
-# Inspect the url for the schema you want - for example, the 2019.1 update document is "DSP8010" on this page, the zip file is:
+# Find the schema document name by going here:
+#                                       https://www.dmtf.org/standards/redfish
+# Inspect the url for the schema you want - for example, the 2019.1 update
+# document is "DSP8010" on this page, the zip file is:
 schemadoc=DSP8010_2019.1_0.zip
 #
 echo "Fetching schema document $schemadoc"
-# We only use the zip file to get the object names. It's a little easier to manage.
+# We only use the zip file to get the object names. It's a little easier to
+# manage.
 curl -G -L https://www.dmtf.org/sites/default/files/standards/documents/$schemadoc > wrk.zip
 # Generate the object list. No elegant, but it works well enough for now.
-unzip -v wrk.zip | grep / | grep "json-schema" | cut -c 59- | cut -d "/" -f 3 |  grep . | grep -v "SerialInterface" | grep -v "Switch" | grep -v "Collection" | grep -v "Schedule" | grep -v "redfish-schema" | grep -v ".v" | grep -v "odata" | grep -v "Protocol" | cut -d . -f 1 >f1.txt
+#
+# SerialInterface and Switch still have some identifier issues to be worked out
+# Collection files, Schedule, Protocol are "common" and included differently
+# redfish-schema, odata and all the versions of each object aren't needed
+#
+# General process is get a list of the json-schema objects from the zip, drop
+# things we don't need/want, and clip the column we want generating a file of
+# object names we can use later.
+unzip -v wrk.zip | grep / | grep "json-schema" | cut -c 59- | cut -d "/" -f 3 |  grep . | grep -v "Collection" | grep -v "Schedule" | grep -v "redfish-schema" | grep -v ".v" | grep -v "odata" | grep -v "Protocol" | cut -d . -f 1 >f1.txt
+# f1.txt now has our list of objects
+# don't need the document zip file any more...
 rm wrk.zip
-# Now we're ready to populate the script file
+# Now we're ready to populate the script file that will actually generate the
+# code files.
 echo "mkdir gofiles" > gen_go_source.sh
 lam -s "echo \"Getting object \\\"" f1.txt -s "\\\" and generating go source...\";python3 generate_from_schema.py " f1.txt -s " > gofiles/" f1.txt -s ".go " >> gen_go_source.sh
 echo "echo \"Go source has been created in ./gofiles/\"" >> gen_go_source.sh
@@ -23,4 +39,4 @@ echo "echo \"Ready for manual cleanup.\"" >> gen_go_source.sh
 # Done. Finish cleaning up
 rm f1.txt
 #Execute the script
-source ./gen_go_source.sh
+sh ./gen_go_source.sh

--- a/tools/redfish-schema/gen_script.sh
+++ b/tools/redfish-schema/gen_script.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Generates a script from a given schema zip file, finds the names of the
+# objects, then generates go files based on the provided
+# generate_from_schema.py tool
+
+# Find the schema document name by going here: https://www.dmtf.org/standards/redfish
+# Inspect the url for the schema you want - for example, the 2019.1 update document is "DSP8010" on this page, the zip file is:
+schemadoc=DSP8010_2019.1_0.zip
+#
+echo "Fetching schema document $schemadoc"
+curl -G -L https://www.dmtf.org/sites/default/files/standards/documents/$schemadoc > wrk.zip
+unzip -v wrk.zip | grep / | grep "json-schema" | cut -c 59- | cut -d "/" -f 3 |  grep . | grep -v "Collection" | grep -v "Schedule" | grep -v "redfish-schema" | grep -v ".v" | grep -v "odata" | grep -v "Protocol" | cut -d . -f 1 >f1.txt
+rm wrk.zip
+# Now we're ready to populate the script file
+echo "mkdir gofiles" > gen_go_source.sh
+lam -s "echo \"Getting object \\\"" f1.txt -s "\\\" and generating go source...\";python3 generate_from_schema.py " f1.txt -s " > gofiles/" f1.txt -s ".go " >> gen_go_source.sh
+echo "echo \"Go source has been created in ./gofiles/\"" >> gen_go_source.sh
+# Done. Finish cleaning up
+rm f1.txt
+#Execute the script
+source ./gen_go_source.sh

--- a/tools/redfish-schema/gen_script.sh
+++ b/tools/redfish-schema/gen_script.sh
@@ -8,13 +8,18 @@
 schemadoc=DSP8010_2019.1_0.zip
 #
 echo "Fetching schema document $schemadoc"
+# We only use the zip file to get the object names. It's a little easier to manage.
 curl -G -L https://www.dmtf.org/sites/default/files/standards/documents/$schemadoc > wrk.zip
-unzip -v wrk.zip | grep / | grep "json-schema" | cut -c 59- | cut -d "/" -f 3 |  grep . | grep -v "Collection" | grep -v "Schedule" | grep -v "redfish-schema" | grep -v ".v" | grep -v "odata" | grep -v "Protocol" | cut -d . -f 1 >f1.txt
+# Generate the object list. No elegant, but it works well enough for now.
+unzip -v wrk.zip | grep / | grep "json-schema" | cut -c 59- | cut -d "/" -f 3 |  grep . | grep -v "SerialInterface" | grep -v "Switch" | grep -v "Collection" | grep -v "Schedule" | grep -v "redfish-schema" | grep -v ".v" | grep -v "odata" | grep -v "Protocol" | cut -d . -f 1 >f1.txt
 rm wrk.zip
 # Now we're ready to populate the script file
 echo "mkdir gofiles" > gen_go_source.sh
 lam -s "echo \"Getting object \\\"" f1.txt -s "\\\" and generating go source...\";python3 generate_from_schema.py " f1.txt -s " > gofiles/" f1.txt -s ".go " >> gen_go_source.sh
 echo "echo \"Go source has been created in ./gofiles/\"" >> gen_go_source.sh
+echo "echo \"Executing go fmt * ...\"" >> gen_go_source.sh
+echo "go fmt ./gofiles/*.go" >> gen_go_source.sh
+echo "echo \"Ready for manual cleanup.\"" >> gen_go_source.sh
 # Done. Finish cleaning up
 rm f1.txt
 #Execute the script

--- a/tools/redfish-schema/generate_from_schema.py
+++ b/tools/redfish-schema/generate_from_schema.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import argparse
+import io
+import logging
+import pprint
+import textwrap
+
+import jinja2
+import requests
+
+LOG = logging.getLogger(__name__)
+
+SCHEMA_BASE = 'http://redfish.dmtf.org/schemas/'
+#SCHEMA_BASE = 'http://redfish.dmtf.org/schemas/swordfish/v1/'
+
+
+COMMON_NAME_CHANGES = {
+    'Oem': 'OEM',
+    'Id': 'ID',
+}
+
+COMMON_DESC = {
+    'Description': 'Description provides a description of this resource.',
+    'Id': 'ID uniquely identifies the resource.',
+    'Name': 'Name is the name of the resource or array element.',
+    '@odata.context': 'ODataContext is the odata context.',
+    '@odata.etag': 'ODataEtag is the odata etag.',
+    '@odata.id': 'ODataID is the odata identifier.',
+    '@odata.type': 'ODataType is the odata type.',
+    'Identifier': 'Identifier shall be unique within the managed ecosystem.',
+}
+
+numberwords = {
+    '1': 'One',
+    '2': 'Two',
+    '3': 'Three',
+    '4': 'Four',
+    '5': 'Five',
+    '6': 'Six',
+    '7': 'Seven',
+    '8': 'Eight',
+    '9': 'Nine',
+
+}
+def _ident(name):
+    outname = name
+
+    outname = outname.replace('-','_')              # converts dashes to underbars
+    outname = outname.replace('switch','Switch')    # Watch out for keyword switch
+    outname = outname.replace(' ','')               # Collapse spaces
+
+#### not working yet
+    if len(outname) == 1:
+        if outname[0:1].isdigit():
+            outname = numberwords[outname[0]]
+
+    return outname
+
+def _format_comment(name, description, cutpoint='used', add=' is'):
+    if name in COMMON_DESC:
+        return '// %s' % COMMON_DESC[name]
+
+    if cutpoint not in description:
+        cutpoint = ''
+
+    lines = textwrap.wrap(
+        '%s%s %s' % (name, add, description[description.index(cutpoint):]))
+    return '\n'.join([('// %s' % l) for l in lines])
+
+
+def _get_desc(obj):
+    desc = obj.get('longDescription')
+    if not desc:
+        desc = obj.get('description', '')
+    return desc
+
+
+def _get_type(name, obj):
+    result = 'string'
+    tipe = obj.get('type')
+    anyof = obj.get('anyOf') or obj.get('items', {}).get('anyOf')
+    if 'count' in name.lower():
+        result = 'int'
+    elif name == 'Status':
+        result = 'common.Status'
+    elif name == 'Identifier':
+        result = 'common.Identifier'
+    elif name == 'Description':
+        result = 'string'
+    elif tipe == 'object':
+        result = name
+    elif isinstance(tipe, list):
+        for kind in tipe:
+            if kind == 'null':
+                continue
+            if kind == 'integer' or kind == 'number':
+                result = 'int'
+            elif kind == 'boolean':
+                result = 'bool'
+            else:
+                result = kind
+    elif isinstance(anyof, list):
+        for kind in anyof:
+            if '$ref' in kind:
+                result = kind['$ref'].split('/')[-1]
+    elif '$ref' in obj.get('items', {}):
+        result = obj['items']['$ref'].split('/')[-1]
+    elif name[:1] == name[:1].lower() and 'odata' not in name.lower():
+        result = 'common.Link'
+
+    if tipe == 'array':
+        result = '[]' + result
+
+    if 'odata' in name or name in COMMON_NAME_CHANGES:
+        result = '%s `json:"%s"`' % (result, name)
+
+    return result
+
+
+def _add_object(params, name, obj):
+    """Adds object information to our template parameters."""
+    class_info = {
+        'name': name,
+        'identname' : _ident(name),
+        'description': _format_comment(name, _get_desc(obj)),
+        'attrs': []}
+
+    for prop in obj.get('properties', []):
+        if prop in ['Name', 'Id']:
+            continue
+        prawp = obj['properties'][prop]
+        if prawp.get('deprecated'):
+            continue
+        attr = {'name': COMMON_NAME_CHANGES.get(prop, prop)}
+
+        if '@odata' in prop:
+            props = prop.split('.')
+            replacement = 'OData'
+            if 'count' in props[-1]:
+                replacement = ''
+            attr['name'] = '%s%s' % (
+                props[0].replace('@odata', replacement), props[-1].title())
+        attr['type'] = _get_type(prop, prawp)
+        attr['description'] = _format_comment(
+            prop, _get_desc(prawp))
+        class_info['attrs'].append(attr)
+    params['classes'].append(class_info)
+
+
+def _add_enum(params, name, enum):
+    """Adds enum information to our template parameteres."""
+    enum_info = {
+        'name': name,
+        'identname' : _ident(name),
+        'description': _format_comment(name, _get_desc(enum)),
+        'members': []}
+
+    for en in enum.get('enum', []):
+        member = {'identname': _ident(en), 'name': en}
+        if enum.get('enumLongDescriptions', {}).get(en):
+            desc = enum.get('enumLongDescriptions', {}).get(en)
+        else:
+            desc = enum.get('enumDescriptions', {}).get(en, '')
+        member['description'] = _format_comment(_ident('%s%s' % (en, name)), desc, cutpoint='shall', add='')
+        enum_info['members'].append(member)
+    params['enums'].append(enum_info)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'object',
+        help='The Redfish schema object to process.')
+    parser.add_argument(
+        '-o',
+        '--output-file',
+        help='File to write results to. Default is to stdout.')
+    parser.add_argument(
+        '-v', '--verbose', action='store_true',
+        help='Emit verbose output to help debug.')
+    parser.add_argument(
+        '-s', '--source',
+        help='Specify source template file.')
+
+    args = parser.parse_args()
+
+    url = '%s%s.json' % (SCHEMA_BASE, args.object)
+    LOG.debug(url)
+    sourcefile = '%s' % (args.source)
+
+    data = requests.get(url)
+    try:
+        base_data = data.json()
+    except Exception:
+        LOG.exception('Error with data:\n%s' % data)
+        return
+
+    for classdef in base_data.get('definitions', []):
+        if classdef == args.object:
+            refs = base_data['definitions'][classdef].get('anyOf', [])
+            for ref in refs:
+                reflink = ref.get('$ref', '')
+                if 'idRef' in reflink:
+                    continue
+                refurl = reflink.split('#')[0]
+                if refurl > url:
+                    url = refurl
+            break
+
+    object_data = requests.get(url).json()
+    params = {'object_name': args.object, 'classes': [], 'enums': []}
+
+    for name in object_data['definitions']:
+        if name == 'Actions':
+            continue
+        definition = object_data['definitions'][name]
+        if definition.get('type') == 'object':
+            properties = definition.get('properties', '')
+            if not ('target' in properties and 'title' in properties):
+                _add_object(params, _ident(name), definition)
+        elif definition.get('enum'):
+            _add_enum(params, name, definition)
+        else:
+            LOG.debug('Skipping %s', definition)
+
+    with io.open('source.go', 'r', encoding='utf-8') as f:
+        template_body = f.read()
+
+    template = jinja2.Template(template_body)
+    print(template.render(**params))
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/redfish-schema/generate_from_schema.py
+++ b/tools/redfish-schema/generate_from_schema.py
@@ -60,7 +60,9 @@ def _ident(name):
     outname = outname.replace('-','_')              # converts dashes to underbars
     outname = outname.replace('switch','Switch')    # Watch out for keyword switch
     outname = outname.replace(' ','')               # Collapse spaces
-
+    outname = outname.replace(':','_')               # Collapse spaces
+    outname = outname.replace('/','_div_')
+    outname = outname.replace('+','_plus_')
 #### not working yet
     if len(outname) == 1:
         if outname[0:1].isdigit():

--- a/tools/redfish-schema/requirements.txt
+++ b/tools/redfish-schema/requirements.txt
@@ -1,0 +1,2 @@
+Jinja2>=2.6
+requests>=2.5.2

--- a/tools/redfish-schema/source.go
+++ b/tools/redfish-schema/source.go
@@ -1,0 +1,107 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redfish
+
+import (
+	"encoding/json"
+
+	"github.com/stmcginnis/gofish/school/common"
+)
+
+{% for enum in enums %}
+
+{{ enum.description }}
+type {{ enum.name }} string
+
+const (
+{% for enum_member in enum.members %}
+    {{ enum_member.description }}
+    {{ enum_member.identname }}{{ enum.name }} {{ enum.name }} = "{{ enum_member.name }}"
+{%- endfor %}
+)
+{% endfor %}
+{% for class in classes -%}
+
+{{ class.description }}
+type {{ class.name }} struct {
+    common.Entity
+{% for attr in class.attrs %}
+    {{ attr.description }}
+    {{ attr.name }}  {{ attr.type }}
+{%- endfor %}
+}
+
+// UnmarshalJSON unmarshals a {{ class.name }} object from the raw JSON.
+func ({{ class.name|lower }} *{{ class.name }}) UnmarshalJSON(b []byte) error {
+    type temp {{ class.name }}
+    var t struct {
+        temp
+    }
+
+    err := json.Unmarshal(b, &t)
+    if err != nil {
+        return err
+    }
+
+    *{{ class.name|lower }} = {{ class.name }}(t.temp)
+
+    // Extract the links to other entities for later
+
+    return nil
+}
+
+{% if class.name == object_name %}
+// Get{{ class.name }} will get a {{ class.name }} instance from the service.
+func Get{{ class.name }}(c common.Client, uri string) (*{{ class.name }}, error) {
+    resp, err := c.Get(uri)
+    if err != nil {
+        return nil, err
+    }
+    defer resp.Body.Close()
+
+    var {{ class.name|lower }} {{ class.name }}
+    err = json.NewDecoder(resp.Body).Decode(&{{ class.name|lower }})
+    if err != nil {
+        return nil, err
+    }
+
+    {{ class.name|lower }}.SetClient(c)
+    return &{{ class.name|lower }}, nil
+}
+
+// ListReferenced{{ class.name }}s gets the collection of {{ class.name }} from
+// a provided reference.
+func ListReferenced{{ class.name }}s(c common.Client, link string) ([]*{{ class.name }}, error) {
+    var result []*{{ class.name }}
+    if link == "" {
+        return result, nil
+    }
+
+    links, err := common.GetCollection(c, link)
+    if err != nil {
+        return result, err
+    }
+
+    for _, {{ class.name|lower }}Link := range links.ItemLinks {
+        {{ class.name|lower }}, err := Get{{ class.name }}(c, {{ class.name|lower }}Link)
+        if err != nil {
+            return result, err
+        }
+        result = append(result, {{ class.name|lower }})
+    }
+
+    return result, nil
+}
+
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
These scripts and source implement an initial pass at importing the Redfish schema directly from dmtf.org.  The output is syntactically correct (except for SerialInterface and Switch), but needs some cleanup to be usable.  The top script (gen_script.sh) is new, the generate_from_schema.py script has had some capabilities added to generate syntactically correct identifiers more frequently, and the source.go file adjusted a bit to make that work.

To generate code:
put all three files into a directory
If needing to import a schema that is NOT 2019.1, adjust the define at the top of the gen_script.sh
>sh ./gen_script.sh
Which will download the schema, use it to determine what objects to import, generate the appropriate next steps, and then execute them, using source.go as a jinja2 template and the generate_from_schema.py script (which downloads schema objects and applies the template).  Do NOT expect the code to be directly usable without some adjustments - for example, there are a large number of redefinitions of OemAction and Links, which should probably be handled a little differently.

Both the template and the .py have had adjustments from the swordfish version previous. I'm not familiar with the changes required for swordfish, and have not been able to test them so far.
