### PR TITLE
Moar updates :)

### DIFF
--- a/school/redfish/chassis.go
+++ b/school/redfish/chassis.go
@@ -98,6 +98,7 @@ type Chassis struct {
 	Status          common.Status `json:"Status"`
 	thermal         string
 	power           string
+	networkAdapters string
 	computerSystems []string
 	resourceBlocks  []string
 	managedBy       []string
@@ -113,9 +114,10 @@ func (c *Chassis) UnmarshalJSON(b []byte) error {
 	}
 	var t struct {
 		temp
-		Thermal common.Link
-		Power   common.Link
-		Links   linkReference
+		Thermal         common.Link
+		Power           common.Link
+		NetworkAdapters common.Link
+		Links           linkReference
 	}
 
 	err := json.Unmarshal(b, &t)
@@ -128,6 +130,7 @@ func (c *Chassis) UnmarshalJSON(b []byte) error {
 	// Extract the links to other entities for later
 	c.thermal = string(t.Thermal)
 	c.power = string(t.Power)
+	c.networkAdapters = string(t.NetworkAdapters)
 	c.computerSystems = t.Links.ComputerSystems.ToStrings()
 	c.resourceBlocks = t.Links.ResourceBlocks.ToStrings()
 	c.managedBy = t.Links.ManagedBy.ToStrings()
@@ -352,4 +355,9 @@ func (c *Chassis) ManagedBy() ([]*Manager, error) {
 	}
 
 	return result, nil
+}
+
+// NetworkAdapters gets the collection of network adapters of this chassis
+func (c *Chassis) NetworkAdapters() ([]*NetworkAdapter, error) {
+	return ListReferencedNetworkAdapter(c.Client, c.networkAdapters)
 }

--- a/school/redfish/chassis.go
+++ b/school/redfish/chassis.go
@@ -273,15 +273,15 @@ type PowerInfo struct {
 		Name                      string
 		SensorNumber              int
 		Status                    common.Status
-		ReadingVolts              int
+		ReadingVolts              float32
 		UpperThresholdNonCritical float32
 		UpperThresholdCritical    float32
 		UpperThresholdFatal       float32
 		LowerThresholdNonCritical float32
 		LowerThresholdCritical    float32
 		LowerThresholdFatal       float32
-		MinReadingRange           int
-		MaxReadingRange           int
+		MinReadingRange           float32
+		MaxReadingRange           float32
 		PhysicalContext           string
 		RelatedItem               []common.Link
 	}

--- a/school/redfish/computersystem.go
+++ b/school/redfish/computersystem.go
@@ -319,18 +319,18 @@ func (boot *Boot) UnmarshalJSON(b []byte) error {
 type ResetType string
 
 const (
-	// On shall be used to power on the machine
-	On ResetType = "On"
-	// ForceOff shall be used to power off the machine without wait the OS to shutdown
-	ForceOff ResetType = "ForceOff"
-	// ForceRestart shall be used to restart the machine without wait the OS to shutdown
-	ForceRestart ResetType = "ForceRestart"
-	// GracefulShutdown shall be used to restart the machine waiting the OS shutdown gracefully
-	GracefulShutdown ResetType = "GracefulShutdown"
-	// PushPowerButton shall be used to emulate pushing the power button
-	PushPowerButton ResetType = "PushPowerButton"
-	// Nmi shall be used to trigger a crash/core dump file
-	Nmi ResetType = "Nmi"
+	// OnResetType shall be used to power on the machine
+	OnResetType ResetType = "On"
+	// ForceOffResetType shall be used to power off the machine without wait the OS to shutdown
+	ForceOffResetType ResetType = "ForceOff"
+	// ForceRestartResetType shall be used to restart the machine without wait the OS to shutdown
+	ForceRestartResetType ResetType = "ForceRestart"
+	// GracefulShutdownResetType shall be used to restart the machine waiting the OS shutdown gracefully
+	GracefulShutdownResetType ResetType = "GracefulShutdown"
+	// PushPowerButtonResetType shall be used to emulate pushing the power button
+	PushPowerButtonResetType ResetType = "PushPowerButton"
+	// NmiResetType shall be used to trigger a crash/core dump file
+	NmiResetType ResetType = "Nmi"
 )
 
 type Actions struct {

--- a/school/redfish/computersystem.go
+++ b/school/redfish/computersystem.go
@@ -495,8 +495,8 @@ func (computersystem *ComputerSystem) UnmarshalJSON(b []byte) error {
 		NetworkInterfaces  common.Link
 		LogServices        common.Link
 		MemoryDomains      common.Link
-		PCIeDevices        []common.Link
-		PCIeFunctions      []common.Link
+		PCIeDevices        common.Links
+		PCIeFunctions      common.Links
 		Links              CSLinks
 	}
 
@@ -518,12 +518,8 @@ func (computersystem *ComputerSystem) UnmarshalJSON(b []byte) error {
 	computersystem.storage = string(t.Storage)
 	computersystem.logServices = string(t.LogServices)
 	computersystem.memoryDomains = string(t.MemoryDomains)
-	for _, p := range t.PCIeDevices {
-		computersystem.pcieDevices = append(computersystem.pcieDevices, string(p))
-	}
-	for _, p := range t.PCIeFunctions {
-		computersystem.pcieFunctions = append(computersystem.pcieFunctions, string(p))
-	}
+	computersystem.pcieDevices = t.PCIeDevices.ToStrings()
+	computersystem.pcieFunctions = t.PCIeFunctions.ToStrings()
 
 	return nil
 }

--- a/school/redfish/computersystem.go
+++ b/school/redfish/computersystem.go
@@ -524,6 +524,22 @@ func (computersystem *ComputerSystem) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// Processors return a collection of processors from this system
+func (computersystem *ComputerSystem) Processors() ([]*Processor, error) {
+	return ListReferencedProcessors(computersystem.Client, computersystem.processors)
+	//var result []*Processor
+	//for _, uri := range computersystem.processors {
+	//	cs, err := GetProcessor(computersystem.Client, uri)
+	//	if err != nil {
+	//		return nil, err
+	//	}
+	//
+	//	result = append(result, cs)
+	//}
+	//
+	//return result, nil
+}
+
 // GetComputerSystem will get a ComputerSystem instance from the service.
 func GetComputerSystem(c common.Client, uri string) (*ComputerSystem, error) {
 	resp, err := c.Get(uri)

--- a/school/redfish/manager.go
+++ b/school/redfish/manager.go
@@ -25,12 +25,29 @@ type UIConsoleInfo struct {
 	ConnectTypesSupported []string
 }
 
+type ManagerType string
+
+const (
+	// AuxiliaryController a controller which provides management functions for a particular subsystem or group of devices
+	AuxiliaryController ManagerType = "AuxiliaryController"
+	// BMC a controller which provides management functions for a single computer system
+	BMC ManagerType = "BMC"
+	// EnclosureManager a controller which provides management functions for a chassis or group of devices or systems
+	EnclosureManager ManagerType = "EnclosureManager"
+	// ManagementController a controller used primarily to monitor or manage the operation of a device or system
+	ManagementController ManagerType = "ManagementController"
+	// RackManager a controller which provides management functions for a whole or part of a rack
+	RackManager ManagerType = "RackManager"
+	// Service a software-based service which provides management functions
+	Service ManagerType = "Service"
+)
+
 // Manager is a management subsystem. Examples of managers are BMCs, Enclosure
 // Managers, Management Controllers and other subsystems assigned managability
 // functions.
 type Manager struct {
 	common.Entity
-	ManagerType           string
+	ManagerType           ManagerType
 	Description           string
 	ServiceEntryPointUUID string
 	UUID                  string

--- a/school/redfish/manager.go
+++ b/school/redfish/manager.go
@@ -28,18 +28,18 @@ type UIConsoleInfo struct {
 type ManagerType string
 
 const (
-	// AuxiliaryController a controller which provides management functions for a particular subsystem or group of devices
-	AuxiliaryController ManagerType = "AuxiliaryController"
-	// BMC a controller which provides management functions for a single computer system
-	BMC ManagerType = "BMC"
-	// EnclosureManager a controller which provides management functions for a chassis or group of devices or systems
-	EnclosureManager ManagerType = "EnclosureManager"
-	// ManagementController a controller used primarily to monitor or manage the operation of a device or system
-	ManagementController ManagerType = "ManagementController"
-	// RackManager a controller which provides management functions for a whole or part of a rack
-	RackManager ManagerType = "RackManager"
-	// Service a software-based service which provides management functions
-	Service ManagerType = "Service"
+	// AuxiliaryControllerManagerType a controller which provides management functions for a particular subsystem or group of devices
+	AuxiliaryControllerManagerType ManagerType = "AuxiliaryController"
+	// BMCManagerType a controller which provides management functions for a single computer system
+	BMCManagerType ManagerType = "BMC"
+	// EnclosureManagerManagerType a controller which provides management functions for a chassis or group of devices or systems
+	EnclosureManagerManagerType ManagerType = "EnclosureManager"
+	// ManagementControllerManagerType a controller used primarily to monitor or manage the operation of a device or system
+	ManagementControllerManagerType ManagerType = "ManagementController"
+	// RackManagerManagerType a controller which provides management functions for a whole or part of a rack
+	RackManagerManagerType ManagerType = "RackManager"
+	// ServiceManagerType a software-based service which provides management functions
+	ServiceManagerType ManagerType = "Service"
 )
 
 // Manager is a management subsystem. Examples of managers are BMCs, Enclosure

--- a/school/redfish/manager.go
+++ b/school/redfish/manager.go
@@ -20,7 +20,7 @@ import (
 
 // UIConsoleInfo contains information about GUI services.
 type UIConsoleInfo struct {
-	ServiceEnabled        string
+	ServiceEnabled        bool
 	MaxConcurrentSessions uint
 	ConnectTypesSupported []string
 }

--- a/school/redfish/networkadapter.go
+++ b/school/redfish/networkadapter.go
@@ -21,18 +21,34 @@ import (
 // ControllerCapabilities is This type shall describe the capabilities of
 // a controller.
 type ControllerCapabilities struct {
-	common.Entity
-
 	// DataCenterBridging is This object shall contain capability, status,
 	// and configuration values related to Data Center Bridging (DCB) for
 	// this controller.
-	DataCenterBridging string
+	DataCenterBridging struct {
+		Capable bool
+	}
 	// NPAR is This object shall contain capability, status, and
 	// configuration values related to NIC partitioning for this controller.
-	NPAR string
+	NPAR struct {
+		// NparCapable is This property shall indicate the ability of a
+		// controller to support NIC function partitioning.
+		NparCapable bool
+		// NparEnabled is This property shall indicate whether or not NIC
+		// function partitioning is active on this controller.
+		NparEnabled bool
+	}
 	// NPIV is This object shall contain N_Port ID Virtualization (NPIV)
 	// capabilties for this controller.
-	NPIV string
+	NPIV struct {
+		// MaxDeviceLogins is The value of this property shall be the maximum
+		// number of N_Port ID Virtualization (NPIV) logins allowed
+		// simultaneously from all ports on this controller.
+		MaxDeviceLogins int
+		// MaxPortLogins is The value of this property shall be the maximum
+		// number of N_Port ID Virtualization (NPIV) logins allowed per physical
+		// port on this controller.
+		MaxPortLogins int
+	}
 	// NetworkDeviceFunctionCount is The value of this property shall be the
 	// number of physical functions available on this controller.
 	NetworkDeviceFunctionCount int
@@ -42,7 +58,33 @@ type ControllerCapabilities struct {
 	// VirtualizationOffload is This object shall contain capability, status,
 	// and configuration values related to virtualization offload for this
 	// controller.
-	VirtualizationOffload string
+	VirtualizationOffload struct {
+		// SRIOV is This object shall contain Single-Root Input/Output
+		// Virtualization (SR-IOV) capabilities.
+		SRIOV struct {
+			// SRIOVVEPACapable is The value of this property shall be a boolean
+			// indicating whether this controller supports Single Root Input/Output
+			// Virtualization (SR-IOV) in Virtual Ethernet Port Aggregator (VEPA)
+			// mode.
+			SRIOVVEPACapable bool
+		}
+		// VirtualFunction is This property shall describe the capability,
+		// status, and configuration values related to the virtual function for
+		// this controller.
+		VirtualFunction struct {
+			// DeviceMaxCount is The value of this property shall be the maximum
+			// number of Virtual Functions (VFs) supported by this controller.
+			DeviceMaxCount int
+			// MinAssignmentGroupSize is The value of this property shall be the
+			// minimum number of Virtual Functions (VFs) that can be allocated or
+			// moved between physical functions for this controller.
+			MinAssignmentGroupSize int
+			// NetworkPortMaxCount is The value of this property shall be the maximum
+			// number of Virtual Functions (VFs) supported per network port for this
+			// controller.
+			NetworkPortMaxCount int
+		}
+	}
 }
 
 // UnmarshalJSON unmarshals a ControllerCapabilities object from the raw JSON.
@@ -64,68 +106,35 @@ func (controllercapabilities *ControllerCapabilities) UnmarshalJSON(b []byte) er
 	return nil
 }
 
-// ControllerLinks is This type, as described by the Redfish
-// Specification, shall contain references to resources that are related
-// to, but not contained by (subordinate to), this resource.
-type ControllerLinks struct {
-	common.Entity
-
-	// NetworkDeviceFunctions is The value of this property shall be an array
-	// of references of type NetworkDeviceFunction that represent the Network
-	// Device Functions associated with this Network Controller.
-	NetworkDeviceFunctions []NetworkDeviceFunction
-	// NetworkDeviceFunctions@odata.count is
-	NetworkDeviceFunctionsCount int `json:"NetworkDeviceFunctions@odata.count"`
-	// NetworkPorts is The value of this property shall be an array of
-	// references of type NetworkPort that represent the Network Ports
-	// associated with this Network Controller.
-	NetworkPorts []NetworkPort
-	// NetworkPorts@odata.count is
-	NetworkPortsCount int `json:"NetworkPorts@odata.count"`
-	// Oem is This object represents the Oem property.  All values for
-	// resources described by this schema shall comply to the requirements as
-	// described in the Redfish specification.
-	OEM string `json:"Oem"`
-	// PCIeDevices is The value of this property shall be an array of
-	// references of type PCIeDevice that represent the PCI-e Devices
-	// associated with this Network Controller.
-	PCIeDevices []PCIeDevice
-	// PCIeDevices@odata.count is
-	PCIeDevicesCount int `json:"PCIeDevices@odata.count"`
-}
-
-// UnmarshalJSON unmarshals a ControllerLinks object from the raw JSON.
-func (controllerlinks *ControllerLinks) UnmarshalJSON(b []byte) error {
-	type temp ControllerLinks
-	var t struct {
-		temp
-	}
-
-	err := json.Unmarshal(b, &t)
-	if err != nil {
-		return err
-	}
-
-	*controllerlinks = ControllerLinks(t.temp)
-
-	// Extract the links to other entities for later
-
-	return nil
-}
-
-// Controllers is This type shall describe a network controller ASIC that
+// Controller is This type shall describe a network controller ASIC that
 // makes up part of a NetworkAdapter.
-type Controllers struct {
+type Controller struct {
 	common.Entity
 
 	// ControllerCapabilities is The value of this property shall contain the
 	// capabilities of this controller.
-	ControllerCapabilities string
+	ControllerCapabilities ControllerCapabilities
 	// FirmwarePackageVersion is The value of this property shall be the
 	// version number of the user-facing firmware package.
 	FirmwarePackageVersion string
-	// Links is Links for this controller.
-	Links string
+	// NetworkDeviceFunctions is The value of this property shall be an array
+	// of references of type NetworkDeviceFunction that represent the Network
+	// Device Functions associated with this Network Controller.
+	networkDeviceFunctions []string
+	// NetworkDeviceFunctions@odata.count is
+	NetworkDeviceFunctionsCount int
+	// NetworkPorts is The value of this property shall be an array of
+	// references of type NetworkPort that represent the Network Ports
+	// associated with this Network Controller.
+	networkPorts []string
+	// NetworkPorts@odata.count is
+	NetworkPortsCount int
+	// PCIeDevices is The value of this property shall be an array of
+	// references of type PCIeDevice that represent the PCI-e Devices
+	// associated with this Network Controller.
+	pcieDevices []string
+	// PCIeDevices@odata.count is
+	PCIeDevicesCount int
 	// Location is This property shall contain location information of the
 	// associated network adapter controller.
 	Location string
@@ -134,11 +143,21 @@ type Controllers struct {
 	PCIeInterface string
 }
 
-// UnmarshalJSON unmarshals a Controllers object from the raw JSON.
-func (controllers *Controllers) UnmarshalJSON(b []byte) error {
-	type temp Controllers
+// UnmarshalJSON unmarshals a Controller object from the raw JSON.
+func (controller *Controller) UnmarshalJSON(b []byte) error {
+	type temp Controller
+	type links struct {
+		NetworkPorts                common.Links
+		NetworkPortsCount           int `json:"EthernetInterfaces@odata.count"`
+		NetworkDeviceFunctions      common.Links
+		NetworkDeviceFunctionsCount int `json:"NetworkDeviceFunctions@odata.count"`
+		PCIeDevice                  common.Link
+		PCIeDevicesCount            int `json:"PCIeDevices@odata.count"`
+	}
+
 	var t struct {
 		temp
+		Links links
 	}
 
 	err := json.Unmarshal(b, &t)
@@ -146,56 +165,74 @@ func (controllers *Controllers) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	*controllers = Controllers(t.temp)
+	*controller = Controller(t.temp)
 
 	// Extract the links to other entities for later
+	controller.networkPorts = t.Links.NetworkPorts.ToStrings()
+	controller.NetworkPortsCount = t.Links.NetworkPortsCount
+	controller.networkDeviceFunctions = t.Links.NetworkDeviceFunctions.ToStrings()
+	controller.NetworkDeviceFunctionsCount = t.Links.NetworkDeviceFunctionsCount
+	controller.pcieDevices = t.Links.NetworkDeviceFunctions.ToStrings()
+	controller.PCIeDevicesCount = t.Links.NetworkDeviceFunctionsCount
 
 	return nil
 }
 
-// DataCenterBridging is This type shall describe the capability, status,
-// and configuration values related to Data Center Bridging (DCB) for a
-// controller.
-type DataCenterBridging struct {
-	common.Entity
+func (controller *Controller) NetworkDeviceFunctions() ([]*NetworkDeviceFunction, error) {
+	var result []*NetworkDeviceFunction
+	for _, uri := range controller.networkDeviceFunctions {
+		n, err := GetNetworkDeviceFunction(controller.Client, uri)
+		if err != nil {
+			return nil, err
+		}
 
-	// Capable is The value of this property shall be a boolean indicating
-	// whether this controller is capable of Data Center Bridging (DCB).
-	Capable bool
-}
-
-// UnmarshalJSON unmarshals a DataCenterBridging object from the raw JSON.
-func (datacenterbridging *DataCenterBridging) UnmarshalJSON(b []byte) error {
-	type temp DataCenterBridging
-	var t struct {
-		temp
+		result = append(result, n)
 	}
 
-	err := json.Unmarshal(b, &t)
+	return result, nil
+}
+
+// GetControllers will get a NetworkAdapter instance from the Redfish service.
+func GetControllers(c common.Client, uri string) (*Controller, error) {
+	resp, err := c.Get(uri)
 	if err != nil {
-		return err
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var controller Controller
+	err = json.NewDecoder(resp.Body).Decode(&controller)
+	if err != nil {
+		return nil, err
 	}
 
-	*datacenterbridging = DataCenterBridging(t.temp)
+	controller.SetClient(c)
+	return &controller, nil
+}
 
-	// Extract the links to other entities for later
+// ListReferencedControllers gets the collection of controllers from a provided reference.
+func ListReferencedControllers(c common.Client, link string) ([]*Controller, error) {
+	var result []*Controller
+	links, err := common.GetCollection(c, link)
+	if err != nil {
+		return result, err
+	}
 
-	return nil
+	for _, controllerLink := range links.ItemLinks {
+		controller, err := GetControllers(c, controllerLink)
+		if err != nil {
+			return result, err
+		}
+		result = append(result, controller)
+	}
+
+	return result, nil
 }
 
 // NPIV is This type shall contain N_Port ID Virtualization (NPIV)
 // capabilties for a controller.
 type NPIV struct {
 	common.Entity
-
-	// MaxDeviceLogins is The value of this property shall be the maximum
-	// number of N_Port ID Virtualization (NPIV) logins allowed
-	// simultaneously from all ports on this controller.
-	MaxDeviceLogins int
-	// MaxPortLogins is The value of this property shall be the maximum
-	// number of N_Port ID Virtualization (NPIV) logins allowed per physical
-	// port on this controller.
-	MaxPortLogins int
 }
 
 // UnmarshalJSON unmarshals a NPIV object from the raw JSON.
@@ -238,9 +275,9 @@ type NetworkAdapter struct {
 	// Assembly is The value of this property shall be a link to a resource
 	// of type Assembly.
 	assembly string
-	// Controllers is The value of this property shall contain the set of
+	// Controller is The value of this property shall contain the set of
 	// network controllers ASICs that make up this NetworkAdapter.
-	controllers []string
+	Controllers []Controller
 	// Description provides a description of this resource.
 	Description string
 	// Manufacturer is The value of this property shall contain a value that
@@ -255,9 +292,6 @@ type NetworkAdapter struct {
 	// NetworkPorts is The value of this property shall be a link to a
 	// collection of type NetworkPortCollection.
 	networkPorts string
-	// Oem is The value of this string shall be of the format for the
-	// reserved word *Oem*.
-	OEM string `json:"Oem"`
 	// PartNumber is The value of this property shall contain the part number
 	// for the network adapter as defined by the manufacturer.
 	PartNumber string
@@ -275,15 +309,11 @@ type NetworkAdapter struct {
 // UnmarshalJSON unmarshals a NetworkAdapter object from the raw JSON.
 func (networkadapter *NetworkAdapter) UnmarshalJSON(b []byte) error {
 	type temp NetworkAdapter
-	type linkReference struct {
-		Controllers common.Links
-	}
 	var t struct {
 		temp
 		Assembly               common.Link
 		NetworkDeviceFunctions common.Link
 		NetworkPorts           common.Link
-		Links                  linkReference
 	}
 
 	err := json.Unmarshal(b, &t)
@@ -293,13 +323,32 @@ func (networkadapter *NetworkAdapter) UnmarshalJSON(b []byte) error {
 
 	// Extract the links to other entities for later
 	*networkadapter = NetworkAdapter(t.temp)
-	networkadapter.controllers = t.Links.Controllers.ToStrings()
 	networkadapter.assembly = string(t.Assembly)
 	networkadapter.networkDeviceFunctions = string(t.NetworkDeviceFunctions)
 	networkadapter.networkPorts = string(t.NetworkPorts)
 
 	return nil
 }
+
+// NetworkDeviceFunctions gets the collection of NetworkDeviceFunctions of this network adapter
+func (networkadapter *NetworkAdapter) NetworkDeviceFunctions() ([]*NetworkDeviceFunction, error) {
+	return ListReferencedNetworkDeviceFunctions(networkadapter.Client, networkadapter.networkDeviceFunctions)
+}
+
+//// Controller gets the collection of controllers of this network adapter
+//func (networkadapter *NetworkAdapter) Controller() ([]*Controller, error) {
+//	var result []*Controller
+//	for _, uri := range networkadapter.controllers {
+//		c, err := GetControllers(networkadapter.Client, uri)
+//		if err != nil {
+//			return nil, err
+//		}
+//
+//		result = append(result, c)
+//	}
+//
+//	return result, nil
+//}
 
 // GetNetworkAdapter will get a NetworkAdapter instance from the Redfish service.
 func GetNetworkAdapter(c common.Client, uri string) (*NetworkAdapter, error) {
@@ -342,13 +391,6 @@ func ListReferencedNetworkAdapter(c common.Client, link string) ([]*NetworkAdapt
 // configuration values for a controller.
 type NicPartitioning struct {
 	common.Entity
-
-	// NparCapable is This property shall indicate the ability of a
-	// controller to support NIC function partitioning.
-	NparCapable bool
-	// NparEnabled is This property shall indicate whether or not NIC
-	// function partitioning is active on this controller.
-	NparEnabled bool
 }
 
 // UnmarshalJSON unmarshals a NicPartitioning object from the raw JSON.
@@ -364,109 +406,6 @@ func (nicpartitioning *NicPartitioning) UnmarshalJSON(b []byte) error {
 	}
 
 	*nicpartitioning = NicPartitioning(t.temp)
-
-	// Extract the links to other entities for later
-
-	return nil
-}
-
-// SRIOV is This type shall contain Single-Root Input/Output
-// Virtualization (SR-IOV) capabilities.
-type SRIOV struct {
-	common.Entity
-
-	// SRIOVVEPACapable is The value of this property shall be a boolean
-	// indicating whether this controller supports Single Root Input/Output
-	// Virtualization (SR-IOV) in Virtual Ethernet Port Aggregator (VEPA)
-	// mode.
-	SRIOVVEPACapable bool
-}
-
-// UnmarshalJSON unmarshals a SRIOV object from the raw JSON.
-func (sriov *SRIOV) UnmarshalJSON(b []byte) error {
-	type temp SRIOV
-	var t struct {
-		temp
-	}
-
-	err := json.Unmarshal(b, &t)
-	if err != nil {
-		return err
-	}
-
-	*sriov = SRIOV(t.temp)
-
-	// Extract the links to other entities for later
-
-	return nil
-}
-
-// VirtualFunction is This type shall describe the capability, status,
-// and configuration values related to a virtual function for a
-// controller.
-type VirtualFunction struct {
-	common.Entity
-
-	// DeviceMaxCount is The value of this property shall be the maximum
-	// number of Virtual Functions (VFs) supported by this controller.
-	DeviceMaxCount int
-	// MinAssignmentGroupSize is The value of this property shall be the
-	// minimum number of Virtual Functions (VFs) that can be allocated or
-	// moved between physical functions for this controller.
-	MinAssignmentGroupSize int
-	// NetworkPortMaxCount is The value of this property shall be the maximum
-	// number of Virtual Functions (VFs) supported per network port for this
-	// controller.
-	NetworkPortMaxCount int
-}
-
-// UnmarshalJSON unmarshals a VirtualFunction object from the raw JSON.
-func (virtualfunction *VirtualFunction) UnmarshalJSON(b []byte) error {
-	type temp VirtualFunction
-	var t struct {
-		temp
-	}
-
-	err := json.Unmarshal(b, &t)
-	if err != nil {
-		return err
-	}
-
-	*virtualfunction = VirtualFunction(t.temp)
-
-	// Extract the links to other entities for later
-
-	return nil
-}
-
-// VirtualizationOffload is This type shall describe the capability,
-// status, and configuration values related to a virtualization offload
-// for a controller.
-type VirtualizationOffload struct {
-	common.Entity
-
-	// SRIOV is This object shall contain Single-Root Input/Output
-	// Virtualization (SR-IOV) capabilities.
-	SRIOV string
-	// VirtualFunction is This property shall describe the capability,
-	// status, and configuration values related to the virtual function for
-	// this controller.
-	VirtualFunction string
-}
-
-// UnmarshalJSON unmarshals a VirtualizationOffload object from the raw JSON.
-func (virtualizationoffload *VirtualizationOffload) UnmarshalJSON(b []byte) error {
-	type temp VirtualizationOffload
-	var t struct {
-		temp
-	}
-
-	err := json.Unmarshal(b, &t)
-	if err != nil {
-		return err
-	}
-
-	*virtualizationoffload = VirtualizationOffload(t.temp)
 
 	// Extract the links to other entities for later
 

--- a/school/redfish/networkadapter.go
+++ b/school/redfish/networkadapter.go
@@ -1,0 +1,474 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redfish
+
+import (
+	"encoding/json"
+
+	"github.com/stmcginnis/gofish/school/common"
+)
+
+// ControllerCapabilities is This type shall describe the capabilities of
+// a controller.
+type ControllerCapabilities struct {
+	common.Entity
+
+	// DataCenterBridging is This object shall contain capability, status,
+	// and configuration values related to Data Center Bridging (DCB) for
+	// this controller.
+	DataCenterBridging string
+	// NPAR is This object shall contain capability, status, and
+	// configuration values related to NIC partitioning for this controller.
+	NPAR string
+	// NPIV is This object shall contain N_Port ID Virtualization (NPIV)
+	// capabilties for this controller.
+	NPIV string
+	// NetworkDeviceFunctionCount is The value of this property shall be the
+	// number of physical functions available on this controller.
+	NetworkDeviceFunctionCount int
+	// NetworkPortCount is The value of this property shall be the number of
+	// physical ports on this controller.
+	NetworkPortCount int
+	// VirtualizationOffload is This object shall contain capability, status,
+	// and configuration values related to virtualization offload for this
+	// controller.
+	VirtualizationOffload string
+}
+
+// UnmarshalJSON unmarshals a ControllerCapabilities object from the raw JSON.
+func (controllercapabilities *ControllerCapabilities) UnmarshalJSON(b []byte) error {
+	type temp ControllerCapabilities
+	var t struct {
+		temp
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	*controllercapabilities = ControllerCapabilities(t.temp)
+
+	// Extract the links to other entities for later
+
+	return nil
+}
+
+// ControllerLinks is This type, as described by the Redfish
+// Specification, shall contain references to resources that are related
+// to, but not contained by (subordinate to), this resource.
+type ControllerLinks struct {
+	common.Entity
+
+	// NetworkDeviceFunctions is The value of this property shall be an array
+	// of references of type NetworkDeviceFunction that represent the Network
+	// Device Functions associated with this Network Controller.
+	NetworkDeviceFunctions []NetworkDeviceFunction
+	// NetworkDeviceFunctions@odata.count is
+	NetworkDeviceFunctionsCount int `json:"NetworkDeviceFunctions@odata.count"`
+	// NetworkPorts is The value of this property shall be an array of
+	// references of type NetworkPort that represent the Network Ports
+	// associated with this Network Controller.
+	NetworkPorts []NetworkPort
+	// NetworkPorts@odata.count is
+	NetworkPortsCount int `json:"NetworkPorts@odata.count"`
+	// Oem is This object represents the Oem property.  All values for
+	// resources described by this schema shall comply to the requirements as
+	// described in the Redfish specification.
+	OEM string `json:"Oem"`
+	// PCIeDevices is The value of this property shall be an array of
+	// references of type PCIeDevice that represent the PCI-e Devices
+	// associated with this Network Controller.
+	PCIeDevices []PCIeDevice
+	// PCIeDevices@odata.count is
+	PCIeDevicesCount int `json:"PCIeDevices@odata.count"`
+}
+
+// UnmarshalJSON unmarshals a ControllerLinks object from the raw JSON.
+func (controllerlinks *ControllerLinks) UnmarshalJSON(b []byte) error {
+	type temp ControllerLinks
+	var t struct {
+		temp
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	*controllerlinks = ControllerLinks(t.temp)
+
+	// Extract the links to other entities for later
+
+	return nil
+}
+
+// Controllers is This type shall describe a network controller ASIC that
+// makes up part of a NetworkAdapter.
+type Controllers struct {
+	common.Entity
+
+	// ControllerCapabilities is The value of this property shall contain the
+	// capabilities of this controller.
+	ControllerCapabilities string
+	// FirmwarePackageVersion is The value of this property shall be the
+	// version number of the user-facing firmware package.
+	FirmwarePackageVersion string
+	// Links is Links for this controller.
+	Links string
+	// Location is This property shall contain location information of the
+	// associated network adapter controller.
+	Location string
+	// PCIeInterface is used to connect this PCIe-based controller to its
+	// host.
+	PCIeInterface string
+}
+
+// UnmarshalJSON unmarshals a Controllers object from the raw JSON.
+func (controllers *Controllers) UnmarshalJSON(b []byte) error {
+	type temp Controllers
+	var t struct {
+		temp
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	*controllers = Controllers(t.temp)
+
+	// Extract the links to other entities for later
+
+	return nil
+}
+
+// DataCenterBridging is This type shall describe the capability, status,
+// and configuration values related to Data Center Bridging (DCB) for a
+// controller.
+type DataCenterBridging struct {
+	common.Entity
+
+	// Capable is The value of this property shall be a boolean indicating
+	// whether this controller is capable of Data Center Bridging (DCB).
+	Capable bool
+}
+
+// UnmarshalJSON unmarshals a DataCenterBridging object from the raw JSON.
+func (datacenterbridging *DataCenterBridging) UnmarshalJSON(b []byte) error {
+	type temp DataCenterBridging
+	var t struct {
+		temp
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	*datacenterbridging = DataCenterBridging(t.temp)
+
+	// Extract the links to other entities for later
+
+	return nil
+}
+
+// NPIV is This type shall contain N_Port ID Virtualization (NPIV)
+// capabilties for a controller.
+type NPIV struct {
+	common.Entity
+
+	// MaxDeviceLogins is The value of this property shall be the maximum
+	// number of N_Port ID Virtualization (NPIV) logins allowed
+	// simultaneously from all ports on this controller.
+	MaxDeviceLogins int
+	// MaxPortLogins is The value of this property shall be the maximum
+	// number of N_Port ID Virtualization (NPIV) logins allowed per physical
+	// port on this controller.
+	MaxPortLogins int
+}
+
+// UnmarshalJSON unmarshals a NPIV object from the raw JSON.
+func (npiv *NPIV) UnmarshalJSON(b []byte) error {
+	type temp NPIV
+	var t struct {
+		temp
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	*npiv = NPIV(t.temp)
+
+	// Extract the links to other entities for later
+
+	return nil
+}
+
+// NetworkAdapter is A NetworkAdapter represents the physical network
+// adapter capable of connecting to a computer network.  Examples include
+// but are not limited to Ethernet, Fibre Channel, and converged network
+// adapters.
+type NetworkAdapter struct {
+	common.Entity
+
+	//// ODataContext is the odata context.
+	//ODataContext string `json:"@odata.context"`
+	//// ODataEtag is the odata etag.
+	//ODataEtag string `json:"@odata.etag"`
+	//// ODataID is the odata identifier.
+	//ODataId string `json:"@odata.id"`
+	//// ODataType is the odata type.
+	//ODataType string `json:"@odata.type"`
+	// Actions is The Actions property shall contain the available actions
+	// for this resource.
+	Actions string
+	// Assembly is The value of this property shall be a link to a resource
+	// of type Assembly.
+	assembly string
+	// Controllers is The value of this property shall contain the set of
+	// network controllers ASICs that make up this NetworkAdapter.
+	controllers []string
+	// Description provides a description of this resource.
+	Description string
+	// Manufacturer is The value of this property shall contain a value that
+	// represents the manufacturer of the network adapter.
+	Manufacturer string
+	// Model is The value of this property shall contain the information
+	// about how the manufacturer references this network adapter.
+	Model string
+	// NetworkDeviceFunctions is The value of this property shall be a link
+	// to a collection of type NetworkDeviceFunctionCollection.
+	networkDeviceFunctions string
+	// NetworkPorts is The value of this property shall be a link to a
+	// collection of type NetworkPortCollection.
+	networkPorts string
+	// Oem is The value of this string shall be of the format for the
+	// reserved word *Oem*.
+	OEM string `json:"Oem"`
+	// PartNumber is The value of this property shall contain the part number
+	// for the network adapter as defined by the manufacturer.
+	PartNumber string
+	// SKU is The value of this property shall contain the Stock Keeping Unit
+	// (SKU) for the network adapter.
+	SKU string
+	// SerialNumber is The value of this property shall contain the serial
+	// number for the network adapter.
+	SerialNumber string
+	// Status is This property shall contain any status or health properties
+	// of the resource.
+	Status common.Status
+}
+
+// UnmarshalJSON unmarshals a NetworkAdapter object from the raw JSON.
+func (networkadapter *NetworkAdapter) UnmarshalJSON(b []byte) error {
+	type temp NetworkAdapter
+	type linkReference struct {
+		Controllers common.Links
+	}
+	var t struct {
+		temp
+		Assembly               common.Link
+		NetworkDeviceFunctions common.Link
+		NetworkPorts           common.Link
+		Links                  linkReference
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	// Extract the links to other entities for later
+	*networkadapter = NetworkAdapter(t.temp)
+	networkadapter.controllers = t.Links.Controllers.ToStrings()
+	networkadapter.assembly = string(t.Assembly)
+	networkadapter.networkDeviceFunctions = string(t.NetworkDeviceFunctions)
+	networkadapter.networkPorts = string(t.NetworkPorts)
+
+	return nil
+}
+
+// GetNetworkAdapter will get a NetworkAdapter instance from the Redfish service.
+func GetNetworkAdapter(c common.Client, uri string) (*NetworkAdapter, error) {
+	resp, err := c.Get(uri)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var networkAdapter NetworkAdapter
+	err = json.NewDecoder(resp.Body).Decode(&networkAdapter)
+	if err != nil {
+		return nil, err
+	}
+
+	networkAdapter.SetClient(c)
+	return &networkAdapter, nil
+}
+
+// ListReferencedNetworkAdapter gets the collection of Chassis from a provided reference.
+func ListReferencedNetworkAdapter(c common.Client, link string) ([]*NetworkAdapter, error) {
+	var result []*NetworkAdapter
+	links, err := common.GetCollection(c, link)
+	if err != nil {
+		return result, err
+	}
+
+	for _, networkAdapterLink := range links.ItemLinks {
+		networkAdapter, err := GetNetworkAdapter(c, networkAdapterLink)
+		if err != nil {
+			return result, err
+		}
+		result = append(result, networkAdapter)
+	}
+
+	return result, nil
+}
+
+// NicPartitioning is This type shall contain the capability, status, and
+// configuration values for a controller.
+type NicPartitioning struct {
+	common.Entity
+
+	// NparCapable is This property shall indicate the ability of a
+	// controller to support NIC function partitioning.
+	NparCapable bool
+	// NparEnabled is This property shall indicate whether or not NIC
+	// function partitioning is active on this controller.
+	NparEnabled bool
+}
+
+// UnmarshalJSON unmarshals a NicPartitioning object from the raw JSON.
+func (nicpartitioning *NicPartitioning) UnmarshalJSON(b []byte) error {
+	type temp NicPartitioning
+	var t struct {
+		temp
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	*nicpartitioning = NicPartitioning(t.temp)
+
+	// Extract the links to other entities for later
+
+	return nil
+}
+
+// SRIOV is This type shall contain Single-Root Input/Output
+// Virtualization (SR-IOV) capabilities.
+type SRIOV struct {
+	common.Entity
+
+	// SRIOVVEPACapable is The value of this property shall be a boolean
+	// indicating whether this controller supports Single Root Input/Output
+	// Virtualization (SR-IOV) in Virtual Ethernet Port Aggregator (VEPA)
+	// mode.
+	SRIOVVEPACapable bool
+}
+
+// UnmarshalJSON unmarshals a SRIOV object from the raw JSON.
+func (sriov *SRIOV) UnmarshalJSON(b []byte) error {
+	type temp SRIOV
+	var t struct {
+		temp
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	*sriov = SRIOV(t.temp)
+
+	// Extract the links to other entities for later
+
+	return nil
+}
+
+// VirtualFunction is This type shall describe the capability, status,
+// and configuration values related to a virtual function for a
+// controller.
+type VirtualFunction struct {
+	common.Entity
+
+	// DeviceMaxCount is The value of this property shall be the maximum
+	// number of Virtual Functions (VFs) supported by this controller.
+	DeviceMaxCount int
+	// MinAssignmentGroupSize is The value of this property shall be the
+	// minimum number of Virtual Functions (VFs) that can be allocated or
+	// moved between physical functions for this controller.
+	MinAssignmentGroupSize int
+	// NetworkPortMaxCount is The value of this property shall be the maximum
+	// number of Virtual Functions (VFs) supported per network port for this
+	// controller.
+	NetworkPortMaxCount int
+}
+
+// UnmarshalJSON unmarshals a VirtualFunction object from the raw JSON.
+func (virtualfunction *VirtualFunction) UnmarshalJSON(b []byte) error {
+	type temp VirtualFunction
+	var t struct {
+		temp
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	*virtualfunction = VirtualFunction(t.temp)
+
+	// Extract the links to other entities for later
+
+	return nil
+}
+
+// VirtualizationOffload is This type shall describe the capability,
+// status, and configuration values related to a virtualization offload
+// for a controller.
+type VirtualizationOffload struct {
+	common.Entity
+
+	// SRIOV is This object shall contain Single-Root Input/Output
+	// Virtualization (SR-IOV) capabilities.
+	SRIOV string
+	// VirtualFunction is This property shall describe the capability,
+	// status, and configuration values related to the virtual function for
+	// this controller.
+	VirtualFunction string
+}
+
+// UnmarshalJSON unmarshals a VirtualizationOffload object from the raw JSON.
+func (virtualizationoffload *VirtualizationOffload) UnmarshalJSON(b []byte) error {
+	type temp VirtualizationOffload
+	var t struct {
+		temp
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	*virtualizationoffload = VirtualizationOffload(t.temp)
+
+	// Extract the links to other entities for later
+
+	return nil
+}

--- a/school/redfish/networkport.go
+++ b/school/redfish/networkport.go
@@ -1,0 +1,318 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redfish
+
+import (
+	"encoding/json"
+
+	"github.com/stmcginnis/gofish/school/common"
+)
+
+// FlowControl is
+type FlowControl string
+
+const (
+	// NoneFlowControl No IEEE 802.3x flow control is enabled on this port.
+	NoneFlowControl FlowControl = "None"
+	// TXFlowControl IEEE 802.3x flow control may be initiated by this
+	// station.
+	TXFlowControl FlowControl = "TX"
+	// RXFlowControl IEEE 802.3x flow control may be initiated by the link
+	// partner.
+	RXFlowControl FlowControl = "RX"
+	// TX_RXFlowControl IEEE 802.3x flow control may be initiated by this
+	// station or the link partner.
+	TX_RXFlowControl FlowControl = "TX_RX"
+)
+
+// LinkNetworkTechnology is
+type LinkNetworkTechnology string
+
+const (
+	// EthernetLinkNetworkTechnology The port is capable of connecting to an
+	// Ethernet network.
+	EthernetLinkNetworkTechnology LinkNetworkTechnology = "Ethernet"
+	// InfiniBandLinkNetworkTechnology The port is capable of connecting to
+	// an InfiniBand network.
+	InfiniBandLinkNetworkTechnology LinkNetworkTechnology = "InfiniBand"
+	// FibreChannelLinkNetworkTechnology The port is capable of connecting to
+	// a Fibre Channel network.
+	FibreChannelLinkNetworkTechnology LinkNetworkTechnology = "FibreChannel"
+)
+
+// PortConnectionType is
+type PortConnectionType string
+
+const (
+	// NotConnectedPortConnectionType This port is not connected.
+	NotConnectedPortConnectionType PortConnectionType = "NotConnected"
+	// NPortPortConnectionType This port connects via an N-Port to a switch.
+	NPortPortConnectionType PortConnectionType = "NPort"
+	// PointToPointPortConnectionType This port connects in a Point-to-point
+	// configuration.
+	PointToPointPortConnectionType PortConnectionType = "PointToPoint"
+	// PrivateLoopPortConnectionType This port connects in a private loop
+	// configuration.
+	PrivateLoopPortConnectionType PortConnectionType = "PrivateLoop"
+	// PublicLoopPortConnectionType This port connects in a public
+	// configuration.
+	PublicLoopPortConnectionType PortConnectionType = "PublicLoop"
+	// GenericPortConnectionType This port connection type is a generic
+	// fabric port.
+	GenericPortConnectionType PortConnectionType = "Generic"
+	// ExtenderFabricPortConnectionType This port connection type is an
+	// extender fabric port.
+	ExtenderFabricPortConnectionType PortConnectionType = "ExtenderFabric"
+)
+
+// SupportedEthernetCapabilities is
+type SupportedEthernetCapabilities string
+
+const (
+	// WakeOnLANSupportedEthernetCapabilities Wake on LAN (WoL) is supported
+	// on this port.
+	WakeOnLANSupportedEthernetCapabilities SupportedEthernetCapabilities = "WakeOnLAN"
+	// EEESupportedEthernetCapabilities IEEE 802.3az Energy Efficient
+	// Ethernet (EEE) is supported on this port.
+	EEESupportedEthernetCapabilities SupportedEthernetCapabilities = "EEE"
+)
+
+// NetDevFuncMaxBWAlloc is This type shall describe a maximum bandwidth
+// percentage allocation for a network device function associated with a
+// port.
+type NetDevFuncMaxBWAlloc struct {
+	common.Entity
+
+	// MaxBWAllocPercent is The value of this property shall be the maximum
+	// bandwidth percentage allocation for the associated network device
+	// function.
+	MaxBWAllocPercent int
+	// NetworkDeviceFunction is The value of this property shall be a
+	// reference of type NetworkDeviceFunction that represents the Network
+	// Device Function associated with this bandwidth setting of this Network
+	// Port.
+	NetworkDeviceFunction string
+}
+
+// UnmarshalJSON unmarshals a NetDevFuncMaxBWAlloc object from the raw JSON.
+func (netdevfuncmaxbwalloc *NetDevFuncMaxBWAlloc) UnmarshalJSON(b []byte) error {
+	type temp NetDevFuncMaxBWAlloc
+	var t struct {
+		temp
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	*netdevfuncmaxbwalloc = NetDevFuncMaxBWAlloc(t.temp)
+
+	// Extract the links to other entities for later
+
+	return nil
+}
+
+// NetDevFuncMinBWAlloc is This type shall describe a minimum bandwidth
+// percentage allocation for a network device function associated with a
+// port.
+type NetDevFuncMinBWAlloc struct {
+	common.Entity
+
+	// MinBWAllocPercent is The value of this property shall be the minimum
+	// bandwidth percentage allocation for the associated network device
+	// function.  The sum total of all minimum percentages shall not exceed
+	// 100.
+	MinBWAllocPercent int
+	// NetworkDeviceFunction is The value of this property shall be a
+	// reference of type NetworkDeviceFunction that represents the Network
+	// Device Function associated with this bandwidth setting of this Network
+	// Port.
+	NetworkDeviceFunction string
+}
+
+// UnmarshalJSON unmarshals a NetDevFuncMinBWAlloc object from the raw JSON.
+func (netdevfuncminbwalloc *NetDevFuncMinBWAlloc) UnmarshalJSON(b []byte) error {
+	type temp NetDevFuncMinBWAlloc
+	var t struct {
+		temp
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	*netdevfuncminbwalloc = NetDevFuncMinBWAlloc(t.temp)
+
+	// Extract the links to other entities for later
+
+	return nil
+}
+
+// NetworkPort is A Network Port represents a discrete physical port
+// capable of connecting to a network.
+type NetworkPort struct {
+	common.Entity
+
+	// ODataContext is the odata context.
+	ODataContext string `json:"@odata.context"`
+	// ODataEtag is the odata etag.
+	ODataEtag string `json:"@odata.etag"`
+	// ODataID is the odata identifier.
+	ODataId string `json:"@odata.id"`
+	// ODataType is the odata type.
+	ODataType string `json:"@odata.type"`
+	// Actions is The Actions property shall contain the available actions
+	// for this resource.
+	Actions string
+	// ActiveLinkTechnology is The value of this property shall be the
+	// configured link technology of this port.
+	ActiveLinkTechnology LinkNetworkTechnology
+	// AssociatedNetworkAddresses is The value of this property shall be an
+	// array of configured network addresses that are associated with this
+	// network port, including the programmed address of the lowest numbered
+	// network device function, the configured but not active address if
+	// applicable, the address for hardware port teaming, or other network
+	// addresses.
+	AssociatedNetworkAddresses []string
+	// CurrentLinkSpeedMbps is The value of this property shall be the
+	// current configured link speed of this port.
+	CurrentLinkSpeedMbps int
+	// Description provides a description of this resource.
+	Description string
+	// EEEEnabled is The value of this property shall be a boolean indicating
+	// whether IEEE 802.3az Energy Efficient Ethernet (EEE) is enabled for
+	// this network port.
+	EEEEnabled bool
+	// FCFabricName is This property shall indicate the FC Fabric Name
+	// provided by the switch.
+	FCFabricName string
+	// FCPortConnectionType is The value of this property shall be the
+	// connection type for this port.
+	FCPortConnectionType PortConnectionType
+	// FlowControlConfiguration is The value of this property shall be the
+	// locally configured 802.3x flow control setting for this network port.
+	FlowControlConfiguration FlowControl
+	// FlowControlStatus is The value of this property shall be the 802.3x
+	// flow control behavior negotiated with the link partner for this
+	// network port (Ethernet-only).
+	FlowControlStatus FlowControl
+	// LinkStatus is The value of this property shall be the link status
+	// between this port and its link partner.
+	LinkStatus LinkStatus
+	// MaxFrameSize is The value of this property shall be the maximum frame
+	// size supported by the port.
+	MaxFrameSize int
+	// NetDevFuncMaxBWAlloc is The value of this property shall be an array
+	// of maximum bandwidth allocation percentages for the Network Device
+	// Functions associated with this port.
+	NetDevFuncMaxBWAlloc []NetDevFuncMaxBWAlloc
+	// NetDevFuncMinBWAlloc is The value of this property shall be an array
+	// of minimum bandwidth percentage allocations for each of the network
+	// device functions associated with this port.
+	NetDevFuncMinBWAlloc []NetDevFuncMinBWAlloc
+	// NumberDiscoveredRemotePorts is The value of this property shall be the
+	// number of ports not on this adapter that this port has discovered.
+	NumberDiscoveredRemotePorts int
+	// Oem is The value of this string shall be of the format for the
+	// reserved word *Oem*.
+	OEM string `json:"Oem"`
+	// PhysicalPortNumber is The value of this property shall be the physical
+	// port number on the network adapter hardware that this Network Port
+	// corresponds to.  This value should match a value visible on the
+	// hardware.  When HostPortEnabled and ManagementPortEnabled are both
+	// "false", the port shall not establish physical link.
+	PhysicalPortNumber string
+	// PortMaximumMTU is The value of this property shall be the largest
+	// maximum transmission unit (MTU) that can be configured for this
+	// network port.
+	PortMaximumMTU int
+	// SignalDetected is The value of this property shall be a boolean
+	// indicating whether the port has detected enough signal on enough lanes
+	// to establish link.
+	SignalDetected bool
+	// Status is This property shall contain any status or health properties
+	// of the resource.
+	Status common.Status
+	// SupportedEthernetCapabilities is The value of this property shall be
+	// an array of zero or more Ethernet capabilities supported by this port.
+	SupportedEthernetCapabilities []SupportedEthernetCapabilities
+	// SupportedLinkCapabilities is This object shall describe the static
+	// capabilities of the port, irrespective of transient conditions such as
+	// cabling, interface module presence, or remote link parter status or
+	// configuration.
+	SupportedLinkCapabilities []SupportedLinkCapabilities
+	// VendorId is This property shall indicate the Vendor Identification
+	// string information as provided by the manufacturer of this port.
+	VendorId string
+	// WakeOnLANEnabled is The value of this property shall be a boolean
+	// indicating whether Wake on LAN (WoL) is enabled for this network port.
+	WakeOnLANEnabled bool
+}
+
+// UnmarshalJSON unmarshals a NetworkPort object from the raw JSON.
+func (networkport *NetworkPort) UnmarshalJSON(b []byte) error {
+	type temp NetworkPort
+	var t struct {
+		temp
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	*networkport = NetworkPort(t.temp)
+
+	// Extract the links to other entities for later
+
+	return nil
+}
+
+// SupportedLinkCapabilities is This type shall describe the static
+// capabilities of an associated port, irrespective of transient
+// conditions such as cabling, interface module presence, or remote link
+// parter status or configuration.
+type SupportedLinkCapabilities struct {
+	common.Entity
+
+	// AutoSpeedNegotiation is The value of this property shall be indicate
+	// whether the port is capable of auto-negotiating speed.
+	AutoSpeedNegotiation bool
+	// CapableLinkSpeedMbps is The value of this property shall be all of the
+	// possible network link speed capabilities of this port.
+	CapableLinkSpeedMbps []string
+	// LinkNetworkTechnology is The value of this property shall be a network
+	// technology capability of this port.
+	LinkNetworkTechnology LinkNetworkTechnology
+}
+
+// UnmarshalJSON unmarshals a SupportedLinkCapabilities object from the raw JSON.
+func (supportedlinkcapabilities *SupportedLinkCapabilities) UnmarshalJSON(b []byte) error {
+	type temp SupportedLinkCapabilities
+	var t struct {
+		temp
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	*supportedlinkcapabilities = SupportedLinkCapabilities(t.temp)
+
+	// Extract the links to other entities for later
+
+	return nil
+}

--- a/school/redfish/processor.go
+++ b/school/redfish/processor.go
@@ -1,0 +1,640 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redfish
+
+import (
+	"encoding/json"
+
+	"github.com/stmcginnis/gofish/school/common"
+)
+
+// FpgaInterfaceType is
+type FpgaInterfaceType string
+
+const (
+
+	// QPIFpgaInterfaceType The Intel QuickPath Interconnect.
+	QPIFpgaInterfaceType FpgaInterfaceType = "QPI"
+	// UPIFpgaInterfaceType The Intel UltraPath Interconnect.
+	UPIFpgaInterfaceType FpgaInterfaceType = "UPI"
+	// PCIeFpgaInterfaceType A PCI Express interface.
+	PCIeFpgaInterfaceType FpgaInterfaceType = "PCIe"
+	// EthernetFpgaInterfaceType An Ethernet interface.
+	EthernetFpgaInterfaceType FpgaInterfaceType = "Ethernet"
+	// OEMFpgaInterfaceType An OEM defined interface.
+	OEMFpgaInterfaceType FpgaInterfaceType = "OEM"
+)
+
+// FpgaType is
+type FpgaType string
+
+const (
+
+	// IntegratedFpgaType The FPGA device integrasted with other porcessor in
+	// the single chip.
+	IntegratedFpgaType FpgaType = "Integrated"
+	// DiscreteFpgaType The discrete FPGA device.
+	DiscreteFpgaType FpgaType = "Discrete"
+)
+
+// InstructionSet is
+type InstructionSet string
+
+const (
+
+	// x86InstructionSet x86 32-bit.
+	x86InstructionSet InstructionSet = "x86"
+	// x86_64InstructionSet x86 64-bit.
+	x86_64InstructionSet InstructionSet = "x86-64"
+	// IA_64InstructionSet Intel IA-64.
+	IA_64InstructionSet InstructionSet = "IA-64"
+	// ARM_A32InstructionSet ARM 32-bit.
+	ARM_A32InstructionSet InstructionSet = "ARM-A32"
+	// ARM_A64InstructionSet ARM 64-bit.
+	ARM_A64InstructionSet InstructionSet = "ARM-A64"
+	// MIPS32InstructionSet MIPS 32-bit.
+	MIPS32InstructionSet InstructionSet = "MIPS32"
+	// MIPS64InstructionSet MIPS 64-bit.
+	MIPS64InstructionSet InstructionSet = "MIPS64"
+	// PowerISAInstructionSet PowerISA-64 or PowerISA-32.
+	PowerISAInstructionSet InstructionSet = "PowerISA"
+	// OEMInstructionSet OEM-defined.
+	OEMInstructionSet InstructionSet = "OEM"
+)
+
+// ProcessorArchitecture is
+type ProcessorArchitecture string
+
+const (
+
+	// x86ProcessorArchitecture x86 or x86-64.
+	x86ProcessorArchitecture ProcessorArchitecture = "x86"
+	// IA_64ProcessorArchitecture Intel Itanium.
+	IA_64ProcessorArchitecture ProcessorArchitecture = "IA-64"
+	// ARMProcessorArchitecture ARM.
+	ARMProcessorArchitecture ProcessorArchitecture = "ARM"
+	// MIPSProcessorArchitecture MIPS.
+	MIPSProcessorArchitecture ProcessorArchitecture = "MIPS"
+	// PowerProcessorArchitecture Power.
+	PowerProcessorArchitecture ProcessorArchitecture = "Power"
+	// OEMProcessorArchitecture OEM-defined.
+	OEMProcessorArchitecture ProcessorArchitecture = "OEM"
+)
+
+// ProcessorMemoryType is
+type ProcessorMemoryType string
+
+const (
+
+	// L1CacheProcessorMemoryType L1 cache.
+	L1CacheProcessorMemoryType ProcessorMemoryType = "L1Cache"
+	// L2CacheProcessorMemoryType L2 cache.
+	L2CacheProcessorMemoryType ProcessorMemoryType = "L2Cache"
+	// L3CacheProcessorMemoryType L3 cache.
+	L3CacheProcessorMemoryType ProcessorMemoryType = "L3Cache"
+	// L4CacheProcessorMemoryType L4 cache.
+	L4CacheProcessorMemoryType ProcessorMemoryType = "L4Cache"
+	// L5CacheProcessorMemoryType L5 cache.
+	L5CacheProcessorMemoryType ProcessorMemoryType = "L5Cache"
+	// L6CacheProcessorMemoryType L6 cache.
+	L6CacheProcessorMemoryType ProcessorMemoryType = "L6Cache"
+	// L7CacheProcessorMemoryType L7 cache.
+	L7CacheProcessorMemoryType ProcessorMemoryType = "L7Cache"
+	// HBM1ProcessorMemoryType High Bandwidth Memory.
+	HBM1ProcessorMemoryType ProcessorMemoryType = "HBM1"
+	// HBM2ProcessorMemoryType The second generation of High Bandwidth
+	// Memory.
+	HBM2ProcessorMemoryType ProcessorMemoryType = "HBM2"
+	// HBM3ProcessorMemoryType The third generation of High Bandwidth Memory.
+	HBM3ProcessorMemoryType ProcessorMemoryType = "HBM3"
+	// SGRAMProcessorMemoryType Synchronous graphics RAM.
+	SGRAMProcessorMemoryType ProcessorMemoryType = "SGRAM"
+	// GDDRProcessorMemoryType Synchronous graphics random-access memory.
+	GDDRProcessorMemoryType ProcessorMemoryType = "GDDR"
+	// GDDR2ProcessorMemoryType Double data rate type two synchronous
+	// graphics random-access memory.
+	GDDR2ProcessorMemoryType ProcessorMemoryType = "GDDR2"
+	// GDDR3ProcessorMemoryType Double data rate type three synchronous
+	// graphics random-access memory.
+	GDDR3ProcessorMemoryType ProcessorMemoryType = "GDDR3"
+	// GDDR4ProcessorMemoryType Double data rate type four synchronous
+	// graphics random-access memory.
+	GDDR4ProcessorMemoryType ProcessorMemoryType = "GDDR4"
+	// GDDR5ProcessorMemoryType Double data rate type five synchronous
+	// graphics random-access memory.
+	GDDR5ProcessorMemoryType ProcessorMemoryType = "GDDR5"
+	// GDDR5XProcessorMemoryType Double data rate type five synchronous
+	// graphics random-access memory.
+	GDDR5XProcessorMemoryType ProcessorMemoryType = "GDDR5X"
+	// GDDR6ProcessorMemoryType Double data rate type five synchronous
+	// graphics random-access memory.
+	GDDR6ProcessorMemoryType ProcessorMemoryType = "GDDR6"
+	// DDRProcessorMemoryType Double data rate synchronous dynamic random-
+	// access memory.
+	DDRProcessorMemoryType ProcessorMemoryType = "DDR"
+	// DDR2ProcessorMemoryType Double data rate type two synchronous dynamic
+	// random-access memory.
+	DDR2ProcessorMemoryType ProcessorMemoryType = "DDR2"
+	// DDR3ProcessorMemoryType Double data rate type three synchronous
+	// dynamic random-access memory.
+	DDR3ProcessorMemoryType ProcessorMemoryType = "DDR3"
+	// DDR4ProcessorMemoryType Double data rate type four synchronous dynamic
+	// random-access memory.
+	DDR4ProcessorMemoryType ProcessorMemoryType = "DDR4"
+	// DDR5ProcessorMemoryType Double data rate type five synchronous dynamic
+	// random-access memory.
+	DDR5ProcessorMemoryType ProcessorMemoryType = "DDR5"
+	// SDRAMProcessorMemoryType Synchronous dynamic random-access memory.
+	SDRAMProcessorMemoryType ProcessorMemoryType = "SDRAM"
+	// SRAMProcessorMemoryType Static random-access memory.
+	SRAMProcessorMemoryType ProcessorMemoryType = "SRAM"
+	// FlashProcessorMemoryType Flash memory.
+	FlashProcessorMemoryType ProcessorMemoryType = "Flash"
+	// OEMProcessorMemoryType OEM-defined.
+	OEMProcessorMemoryType ProcessorMemoryType = "OEM"
+)
+
+// ProcessorType is
+type ProcessorType string
+
+const (
+
+	// CPUProcessorType A Central Processing Unit.
+	CPUProcessorType ProcessorType = "CPU"
+	// GPUProcessorType A Graphics Processing Unit.
+	GPUProcessorType ProcessorType = "GPU"
+	// FPGAProcessorType A Field Programmable Gate Array.
+	FPGAProcessorType ProcessorType = "FPGA"
+	// DSPProcessorType A Digital Signal Processor.
+	DSPProcessorType ProcessorType = "DSP"
+	// AcceleratorProcessorType An Accelerator.
+	AcceleratorProcessorType ProcessorType = "Accelerator"
+	// CoreProcessorType A Core in a Processor.
+	CoreProcessorType ProcessorType = "Core"
+	// ThreadProcessorType A Thread in a Processor.
+	ThreadProcessorType ProcessorType = "Thread"
+	// OEMProcessorType An OEM-defined Processing Unit.
+	OEMProcessorType ProcessorType = "OEM"
+)
+
+// FPGA is This object shall contain the properties of the FPGA device
+// represented by a Processor.
+type FPGA struct {
+	common.Entity
+
+	// ExternalInterfaces is The value of this property shall be an array of
+	// objects that describe the external connectivity of the FPGA.
+	ExternalInterfaces []FpgaInterface
+	// FirmwareId is The value of this property shall contain a string
+	// decsribing the FPGA firmware identifier.
+	FirmwareId string
+	// FirmwareManufacturer is The value of this property shall contain a
+	// string decsribing the FPGA firmware manufacturer.
+	FirmwareManufacturer string
+	// FirmwareVersion is The value of this property shall contain a string
+	// decsribing the FPGA firmware version.
+	FirmwareVersion string
+	// FpgaType is The value of this property shall be a type of the FPGA
+	// device.
+	FpgaType string
+	// HostInterface is The value of this property shall be an object that
+	// describes the connectivity to the host for system software to use.
+	HostInterface string
+	// Model is The value of this property shall be a model of the FPGA
+	// device.
+	Model string
+	// Oem is This object represents the Oem property.  All values for
+	// resources described by this schema shall comply to the requirements as
+	// described in the Redfish specification.
+	OEM string `json:"Oem"`
+	// PCIeVirtualFunctions is The value of this property shall be an integer
+	// that describes the number of PCIe Virtual Functions configured within
+	// the FPGA.
+	PCIeVirtualFunctions string
+	// ProgrammableFromHost is The value of this property shall indicate
+	// whether the FPGA firmware can be reprogrammed from the host using
+	// system software.  If set to false, system software shall not be able
+	// to program the FPGA firmware from the host interface.  In either
+	// state, a management controller may be able to program the FPGA
+	// firmware using the sideband interface.
+	ProgrammableFromHost bool
+	// ReconfigurationSlots is The value of this property shall be an array
+	// of the structures describing the FPGA reconfiguration slots that can
+	// be programmed with the acceleration functions.
+	ReconfigurationSlots []FpgaReconfigurationSlot
+}
+
+// UnmarshalJSON unmarshals a FPGA object from the raw JSON.
+func (fpga *FPGA) UnmarshalJSON(b []byte) error {
+	type temp FPGA
+	var t struct {
+		temp
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	*fpga = FPGA(t.temp)
+
+	// Extract the links to other entities for later
+
+	return nil
+}
+
+// FpgaInterface is This type shall contain information about the
+// interface to the FPGA.
+type FpgaInterface struct {
+	common.Entity
+
+	// Ethernet is The value of this property shall be an object the
+	// describes the Ethernet related information about this FPGA interface.
+	Ethernet string
+	// InterfaceType is The value of this property shall be an enum that
+	// describes the type of interface to the FPGA.
+	InterfaceType FpgaInterfaceType
+	// PCIe is The value of this property shall be an object the describes
+	// the PCI-e related information about this FPGA interface.
+	PCIe string
+}
+
+// UnmarshalJSON unmarshals a FpgaInterface object from the raw JSON.
+func (fpgainterface *FpgaInterface) UnmarshalJSON(b []byte) error {
+	type temp FpgaInterface
+	var t struct {
+		temp
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	*fpgainterface = FpgaInterface(t.temp)
+
+	// Extract the links to other entities for later
+
+	return nil
+}
+
+// FpgaReconfigurationSlot is This type shall contain information about
+// the FPGA reconfiguration slot.
+type FpgaReconfigurationSlot struct {
+	common.Entity
+
+	// AccelerationFunction is The value of this property shall be a
+	// reference to the acceleration function resources provided by the code
+	// programmed into a reconfiguration slot and shall reference a resource
+	// of type AccelerationFunction.
+	AccelerationFunction string
+	// ProgrammableFromHost is The value of this property shall indicate
+	// whether the reconfiguration slot can be reprogrammed from the host
+	// using system software.  If set to false, system software shall not be
+	// able to program the reconfiguration slot from the host interface.  In
+	// either state, a management controller may be able to program the
+	// reconfiguration slot using the sideband interface.
+	ProgrammableFromHost bool
+	// SlotId is The value of this property shall be the FPGA reconfiguration
+	// slot identifier.
+	SlotId string
+	// UUID is used to contain a universal unique identifier number for the
+	// reconfiguration slot.
+	UUID string
+}
+
+// UnmarshalJSON unmarshals a FpgaReconfigurationSlot object from the raw JSON.
+func (fpgareconfigurationslot *FpgaReconfigurationSlot) UnmarshalJSON(b []byte) error {
+	type temp FpgaReconfigurationSlot
+	var t struct {
+		temp
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	*fpgareconfigurationslot = FpgaReconfigurationSlot(t.temp)
+
+	// Extract the links to other entities for later
+
+	return nil
+}
+
+// OemActions is This type shall contain any additional OEM actions for
+// this resource.
+type OemActions struct {
+	common.Entity
+}
+
+// UnmarshalJSON unmarshals a OemActions object from the raw JSON.
+func (oemactions *OemActions) UnmarshalJSON(b []byte) error {
+	type temp OemActions
+	var t struct {
+		temp
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	*oemactions = OemActions(t.temp)
+
+	// Extract the links to other entities for later
+
+	return nil
+}
+
+// Processor is used to represent a single processor contained within a
+// system.
+type Processor struct {
+	common.Entity
+
+	// ODataContext is the odata context.
+	ODataContext string `json:"@odata.context"`
+	// ODataEtag is the odata etag.
+	ODataEtag string `json:"@odata.etag"`
+	// ODataID is the odata identifier.
+	ODataId string `json:"@odata.id"`
+	// ODataType is the odata type.
+	ODataType string `json:"@odata.type"`
+	// AccelerationFunctions is The value of this property shall be a link to
+	// a collection of type AccelerationFunctionCollection.
+	AccelerationFunctions string
+	// Actions is The Actions property shall contain the available actions
+	// for this resource.
+	Actions string
+	// Assembly is The value of this property shall be a link to a resource
+	// of type Assembly.
+	assembly string
+	// Description provides a description of this resource.
+	Description string
+	// FPGA is The value of this property shall be an object containing
+	// properties specific for Processors of type FPGA.
+	FPGA string
+	// InstructionSet is This property shall contain the string which
+	// identifies the instruction set of the processor contained in this
+	// socket.
+	InstructionSet InstructionSet
+	// Links is The Links property, as described by the Redfish
+	// Specification, shall contain references to resources that are related
+	// to, but not contained by (subordinate to), this resource.
+	Links string
+	// Location is This property shall contain location information of the
+	// associated processor.
+	Location string
+	// Manufacturer is This property shall contain a string which identifies
+	// the manufacturer of the processor.
+	Manufacturer string
+	// MaxSpeedMHz is This property shall indicate the maximum rated clock
+	// speed of the processor in MHz.
+	MaxSpeedMHz int
+	// MaxTDPWatts is The value of this property shall be the maximum Thermal
+	// Design Power (TDP) in watts.
+	MaxTDPWatts int
+	// Metrics is This property shall be a reference to the Metrics
+	// associated with this Processor.
+	Metrics string
+	// Model is This property shall indicate the model information as
+	// provided by the manufacturer of this processor.
+	Model string
+	// ProcessorArchitecture is This property shall contain the string which
+	// identifies the architecture of the processor contained in this Socket.
+	ProcessorArchitecture ProcessorArchitecture
+	// ProcessorId is This object shall contain identification information
+	// for this processor.
+	ProcessorId ProcessorId
+	// ProcessorMemory is The value of this property shall be the memory
+	// directly attached or integrated witin this Processor.
+	processorMemory []string
+	// ProcessorType is This property shall contain the string which
+	// identifies the type of processor contained in this Socket.
+	ProcessorType ProcessorType
+	// Socket is This property shall contain the string which identifies the
+	// physical location or socket of the processor.
+	Socket string
+	// Status is This property shall contain any status or health properties
+	// of the resource.
+	Status common.Status
+	// SubProcessors is The value of this property shall be a link to a
+	// collection of type ProcessorCollection.
+	SubProcessors string
+	// TDPWatts is The value of this property shall be the nominal Thermal
+	// Design Power (TDP) in watts.
+	TDPWatts int
+	// TotalCores is This property shall indicate the total count of
+	// independent processor cores contained within this processor.
+	TotalCores int
+	// TotalEnabledCores is This property shall indicate the total count of
+	// enabled independent processor cores contained within this processor.
+	TotalEnabledCores int
+	// TotalThreads is This property shall indicate the total count of
+	// independent execution threads supported by this processor.
+	TotalThreads int
+	// UUID is used to contain a universal unique identifier number for the
+	// processor.  RFC4122 describes methods that can be used to create the
+	// value.  The value should be considered to be opaque.  Client software
+	// should only treat the overall value as a universally unique identifier
+	// and should not interpret any sub-fields within the UUID.
+	UUID string
+
+	// Chassis is The value of this property shall be a reference to a
+	// resource of type Chassis that represent the physical container
+	// associated with this Processor.
+	chassis string
+	// ConnectedProcessors is The value of this property shall be an array of
+	// references of type Processor that are directly connected to this
+	// Processor.
+	connectedProcessors []string
+	// ConnectedProcessors@odata.count is
+	ConnectedProcessorsCount int
+	// Endpoints is The value of this property shall be an array of
+	// references of type Endpoint that represent Endpoints accociated with
+	// this Processor.
+	endpoints []string
+	// Endpoints@odata.count is
+	EndpointsCount int
+	// PCIeDevice is The value of this property shall be a reference of type
+	// PCIeDevice that represents the PCI-e Device associated with this
+	// Processor.
+	pcieDevice string
+	// PCIeFunctions is The value of this property shall be an array of
+	// references of type PCIeFunction that represent the PCI-e Functions
+	// associated with this Processor.
+	pcieFunctions []string
+	// PCIeFunctions@odata.count is
+	PCIeFunctionsCount int
+}
+
+// UnmarshalJSON unmarshals a Processor object from the raw JSON.
+func (processor *Processor) UnmarshalJSON(b []byte) error {
+	type temp Processor
+	var t struct {
+		temp
+		Assembly        common.Link
+		ProcessorMemory common.Links
+		Links           struct {
+			Chassis                  common.Link
+			ConnectedProcessors      common.Links
+			ConnectedProcessorsCount int `json:"ConnectedProcessors@odata.count"`
+			Endpoints                common.Links
+			EndpointsCount           int `json:"Endpoints@odata.count"`
+			PCIeDevice               common.Link
+			PCIeFunctions            common.Links
+			PCIeFunctionsCount       int `json:"PCIeFunctions@odata.count"`
+		}
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	*processor = Processor(t.temp)
+
+	// Extract the links to other entities for later
+	processor.assembly = string(t.Assembly)
+	processor.chassis = string(t.Links.Chassis)
+	processor.processorMemory = t.ProcessorMemory.ToStrings()
+	processor.connectedProcessors = t.Links.ConnectedProcessors.ToStrings()
+	processor.ConnectedProcessorsCount = t.Links.ConnectedProcessorsCount
+	processor.endpoints = t.Links.Endpoints.ToStrings()
+	processor.EndpointsCount = t.Links.EndpointsCount
+	processor.pcieDevice = string(t.Links.PCIeDevice)
+	processor.pcieFunctions = t.Links.PCIeFunctions.ToStrings()
+	processor.PCIeFunctionsCount = t.Links.PCIeFunctionsCount
+
+	return nil
+}
+
+// GetProcessor will get a Processor instance from the system
+func GetProcessor(c common.Client, uri string) (*Processor, error) {
+	resp, err := c.Get(uri)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var processor Processor
+	err = json.NewDecoder(resp.Body).Decode(&processor)
+	if err != nil {
+		return nil, err
+	}
+
+	processor.SetClient(c)
+	return &processor, nil
+}
+
+// ListReferencedProcessors gets the collection of Processor from a provided reference.
+func ListReferencedProcessors(c common.Client, link string) ([]*Processor, error) {
+	var result []*Processor
+	links, err := common.GetCollection(c, link)
+	if err != nil {
+		return result, err
+	}
+
+	for _, processorLink := range links.ItemLinks {
+		processor, err := GetProcessor(c, processorLink)
+		if err != nil {
+			return result, err
+		}
+		result = append(result, processor)
+	}
+
+	return result, nil
+}
+
+// ProcessorId is This type shall contain identification information for
+// a processor.
+type ProcessorId struct {
+	common.Entity
+
+	// EffectiveFamily is This property shall indicate the effective Family
+	// information as provided by the manufacturer of this processor.
+	EffectiveFamily string
+	// EffectiveModel is This property shall indicate the effective Model
+	// information as provided by the manufacturer of this processor.
+	EffectiveModel string
+	// IdentificationRegisters is This property shall include the raw CPUID
+	// instruction output as provided by the manufacturer of this processor.
+	IdentificationRegisters string
+	// MicrocodeInfo is This property shall indicate the Microcode
+	// Information as provided by the manufacturer of this processor.
+	MicrocodeInfo string
+	// Step is This property shall indicate the Step or revision string
+	// information as provided by the manufacturer of this processor.
+	Step string
+	// VendorId is This property shall indicate the Vendor Identification
+	// string information as provided by the manufacturer of this processor.
+	VendorId string
+}
+
+// UnmarshalJSON unmarshals a ProcessorId object from the raw JSON.
+func (processorid *ProcessorId) UnmarshalJSON(b []byte) error {
+	type temp ProcessorId
+	var t struct {
+		temp
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	*processorid = ProcessorId(t.temp)
+
+	// Extract the links to other entities for later
+
+	return nil
+}
+
+// ProcessorMemory is This type shall contain information about memory
+// directly attached or integratied within a processor.
+type ProcessorMemory struct {
+	common.Entity
+
+	// CapacityMiB is The value of this property shall be the memory capacity
+	// in MiB.
+	CapacityMiB int
+	// IntegratedMemory is The value of this property shall be a boolean
+	// indicating whether this memory is integrated within the Porcessor.
+	// Otherwise it is discrete memory attached to the Processor.
+	IntegratedMemory bool
+	// MemoryType is The value of this property shall be a type of the
+	// processor memory type.
+	MemoryType ProcessorMemoryType
+	// SpeedMHz is The value of this property shall be the operating speed of
+	// the memory in MHz.
+	SpeedMHz int
+}
+
+// UnmarshalJSON unmarshals a ProcessorMemory object from the raw JSON.
+func (processormemory *ProcessorMemory) UnmarshalJSON(b []byte) error {
+	type temp ProcessorMemory
+	var t struct {
+		temp
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	*processormemory = ProcessorMemory(t.temp)
+
+	// Extract the links to other entities for later
+
+	return nil
+}

--- a/tools/generate_from_schema.py
+++ b/tools/generate_from_schema.py
@@ -22,9 +22,8 @@ import requests
 
 LOG = logging.getLogger(__name__)
 
-# SCHEMA_BASE = 'http://redfish.dmtf.org/schemas/'
-SCHEMA_BASE = 'http://redfish.dmtf.org/schemas/swordfish/v1/'
-
+REDFISH_SCHEMA_BASE = 'http://redfish.dmtf.org/schemas/v1/'
+SWORDFISH_SCHEMA_BASE = 'http://redfish.dmtf.org/schemas/swordfish/v1/'
 
 COMMON_NAME_CHANGES = {
     'Oem': 'OEM',
@@ -156,7 +155,15 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         'object',
-        help='The Swordfish schema object to process.')
+        help='The Swordfish/Redfish schema object to process.')
+    parser.add_argument(
+        '-t',
+        '--type',
+        default='swordfish',
+        const='swordfish',
+        nargs='?',
+        choices=['redfish', 'swordfish'],
+        help='Define the object type and go package')
     parser.add_argument(
         '-o',
         '--output-file',
@@ -167,7 +174,13 @@ def main():
 
     args = parser.parse_args()
 
-    url = '%s%s.json' % (SCHEMA_BASE, args.object)
+    if args.type == 'redfish':
+        url = '%s%s.json' % (REDFISH_SCHEMA_BASE, args.object)
+    elif args.type == 'swordfish':
+        url = '%s%s.json' % (SWORDFISH_SCHEMA_BASE, args.object)
+    else:
+        raise NameError("Unknown schema type")
+
     LOG.debug(url)
 
     data = requests.get(url)
@@ -190,7 +203,7 @@ def main():
             break
 
     object_data = requests.get(url).json()
-    params = {'object_name': args.object, 'classes': [], 'enums': []}
+    params = {'object_name': args.object, 'classes': [], 'enums': [], 'package': args.type}
 
     for name in object_data['definitions']:
         if name == 'Actions':

--- a/tools/source.go
+++ b/tools/source.go
@@ -10,7 +10,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package swordfish
+package {{ package }}
 
 import (
 	"encoding/json"


### PR DESCRIPTION
Update the ResetType to match the standard for the library
Move some int to float32 to properly load some responses
Add NetworkAdapters and Networkport
Add extra flag to generate_from_schema.py allowing to switch between swordfish and redfish 
Adds processor.go and make possible to return Processors from ComputerSystem

These changes have been tested against:
// HP Gen10
// Supermicro X10
// Dell M630
// Intel S2600WF0
// Dell M640
// Quanta QuantaGrid D52BM-2U