### PR TITLE
modify poweredBy and CooledBy to common.link, as they are both links

### DIFF
--- a/school/redfish/computersystem.go
+++ b/school/redfish/computersystem.go
@@ -584,7 +584,7 @@ type CSLinks struct {
 	// CooledBy shall be an array of IDs
 	// containing pointers consistent with JSON pointer syntax to the
 	// resource that powers this computer system.
-	CooledBy []string
+	CooledBy common.Links
 	// CooledByCount is
 	CooledByCount int `json:"CooledBy@odata.count"`
 	// Endpoints shall be a reference to the
@@ -602,7 +602,7 @@ type CSLinks struct {
 	// PoweredBy shall be an array of IDs
 	// containing pointers consistent with JSON pointer syntax to the
 	// resource that powers this computer system.
-	PoweredBy []string
+	PoweredBy common.Links
 	// PoweredByCount is the number of PoweredBy objects.
 	PoweredByCount int `json:"PoweredBy@odata.count"`
 	// ResourceBlocks is used in this Computer System.


### PR DESCRIPTION
to fix the error

```
FATA[0122] Errors Getting systems from service : json: cannot unmarshal object into Go struct field CSLinks.CooledBy of type string 
FATA[0122] Errors Getting systems from service : json: cannot unmarshal object into Go struct field CSLinks.PoweredBy of type string 
```