### PR TITLE
Flesh out ComputerSystem properties and linked objects

### DIFF
--- a/school/redfish/bios.go
+++ b/school/redfish/bios.go
@@ -1,0 +1,82 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redfish
+
+import (
+	"encoding/json"
+
+	"github.com/stmcginnis/gofish/school/common"
+)
+
+// Bios is used to represent BIOS attributes.
+type Bios struct {
+	common.Entity
+
+	// ODataContext is the odata context.
+	ODataContext string `json:"@odata.context"`
+	// ODataEtag is the odata etag.
+	ODataEtag string `json:"@odata.etag"`
+	// ODataID is the odata identifier.
+	ODataID string `json:"@odata.id"`
+	// ODataType is the odata type.
+	ODataType string `json:"@odata.type"`
+	// AttributeRegistry is the Resource ID of the Attribute Registry that has
+	// the system-specific information about a BIOS resource.
+	AttributeRegistry string
+	// Attributes are additional properties in this object, and can be looked up
+	// in the Attribute Registry by their AttributeName.
+	// Attributes string
+	// Description provides a description of this resource.
+	Description string
+}
+
+// GetBios will get a Bios instance from the service.
+func GetBios(c common.Client, uri string) (*Bios, error) {
+	resp, err := c.Get(uri)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var bios Bios
+	err = json.NewDecoder(resp.Body).Decode(&bios)
+	if err != nil {
+		return nil, err
+	}
+
+	bios.SetClient(c)
+	return &bios, nil
+}
+
+// ListReferencedBioss gets the collection of Bios from a provided reference.
+func ListReferencedBioss(c common.Client, link string) ([]*Bios, error) {
+	var result []*Bios
+	if link == "" {
+		return result, nil
+	}
+
+	links, err := common.GetCollection(c, link)
+	if err != nil {
+		return result, err
+	}
+
+	for _, biosLink := range links.ItemLinks {
+		bios, err := GetBios(c, biosLink)
+		if err != nil {
+			return result, err
+		}
+		result = append(result, bios)
+	}
+
+	return result, nil
+}

--- a/school/redfish/computersystem.go
+++ b/school/redfish/computersystem.go
@@ -333,8 +333,8 @@ const (
 	NmiResetType ResetType = "Nmi"
 )
 
-// Actions shall contain the available actions for this resource
-type Actions struct {
+// CSActions shall contain the available actions for this resource
+type CSActions struct {
 	// ComputerSystemReset shall perform a reset of the ComputerSystem. For
 	// systems which implement ACPI Power Button functionality, the
 	// PushPowerButton value shall perform or emulate an ACPI Power Button push.
@@ -363,7 +363,7 @@ type ComputerSystem struct {
 	ODataType string `json:"@odata.type"`
 
 	// Actions type shall contain the available actions for this resource.
-	Actions Actions
+	Actions CSActions
 	// AssetTag shall contain the value of the asset tag of the system.
 	AssetTag string
 	// bios shall be a link to a resource of
@@ -398,8 +398,7 @@ type ComputerSystem struct {
 	// IndicatorLED shall contain the indicator
 	// light state for the indicator light associated with this system.
 	IndicatorLED common.IndicatorLED
-	// logServices shall be a link to a
-	// collection of type LogServiceCollection.
+	// logServices shall be a link to a collection of type LogServiceCollection.
 	logServices string
 	// Manufacturer shall contain a value that represents the manufacturer of the system.
 	Manufacturer string
@@ -416,8 +415,8 @@ type ComputerSystem struct {
 	Model string
 	// Name is the resource name.
 	Name string
-	// networkInterfaces shall be a link to a
-	// collection of type NetworkInterfaceCollection.
+	// networkInterfaces shall be a link to a collection of type
+	// NetworkInterfaceCollection.
 	networkInterfaces string
 	// PCIeDevices shall be an array of references of type PCIeDevice.
 	pcieDevices []string
@@ -529,22 +528,6 @@ func (computersystem *ComputerSystem) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// Processors return a collection of processors from this system
-func (computersystem *ComputerSystem) Processors() ([]*Processor, error) {
-	return ListReferencedProcessors(computersystem.Client, computersystem.processors)
-	//var result []*Processor
-	//for _, uri := range computersystem.processors {
-	//	cs, err := GetProcessor(computersystem.Client, uri)
-	//	if err != nil {
-	//		return nil, err
-	//	}
-	//
-	//	result = append(result, cs)
-	//}
-	//
-	//return result, nil
-}
-
 // GetComputerSystem will get a ComputerSystem instance from the service.
 func GetComputerSystem(c common.Client, uri string) (*ComputerSystem, error) {
 	resp, err := c.Get(uri)
@@ -581,6 +564,90 @@ func ListReferencedComputerSystems(c common.Client, link string) ([]*ComputerSys
 	}
 
 	return result, nil
+}
+
+// Bios gets the Bios information for this ComputerSystem.
+func (computersystem *ComputerSystem) Bios() (*Bios, error) {
+	if computersystem.bios == "" {
+		return nil, nil
+	}
+
+	return GetBios(computersystem.Client, computersystem.bios)
+}
+
+// EthernetInterfaces get this system's ethernet interfaces.
+func (computersystem *ComputerSystem) EthernetInterfaces() ([]*EthernetInterface, error) {
+	return ListReferencedEthernetInterfaces(computersystem.Client, computersystem.ethernetInterfaces)
+}
+
+// LogServices get this system's log services.
+func (computersystem *ComputerSystem) LogServices() ([]*LogService, error) {
+	return ListReferencedLogServices(computersystem.Client, computersystem.logServices)
+}
+
+// Memory gets this system's memory.
+func (computersystem *ComputerSystem) Memory() ([]*Memory, error) {
+	return ListReferencedMemorys(computersystem.Client, computersystem.memory)
+}
+
+// MemoryDomains gets this system's memory domains.
+func (computersystem *ComputerSystem) MemoryDomains() ([]*MemoryDomain, error) {
+	return ListReferencedMemoryDomains(computersystem.Client, computersystem.memoryDomains)
+}
+
+// NetworkInterfaces returns a collection of network interfaces in this system.
+func (computersystem *ComputerSystem) NetworkInterfaces() ([]*NetworkInterface, error) {
+	return ListReferencedNetworkInterfaces(computersystem.Client, computersystem.networkInterfaces)
+}
+
+// PCIeDevices gets all PCIeDevices for this system.
+func (computersystem *ComputerSystem) PCIeDevices() ([]*PCIeDevice, error) {
+	var result []*PCIeDevice
+	for _, pciedeviceLink := range computersystem.pcieDevices {
+		pciedevice, err := GetPCIeDevice(computersystem.Client, pciedeviceLink)
+		if err != nil {
+			return result, err
+		}
+		result = append(result, pciedevice)
+	}
+	return result, nil
+}
+
+// PCIeFunctions gets all PCIeFunctions for this system.
+func (computersystem *ComputerSystem) PCIeFunctions() ([]*PCIeFunction, error) {
+	var result []*PCIeFunction
+	for _, pciefunctionLink := range computersystem.pcieFunctions {
+		pciefunction, err := GetPCIeFunction(computersystem.Client, pciefunctionLink)
+		if err != nil {
+			return result, err
+		}
+		result = append(result, pciefunction)
+	}
+	return result, nil
+}
+
+// Processors returns a collection of processors from this system
+func (computersystem *ComputerSystem) Processors() ([]*Processor, error) {
+	return ListReferencedProcessors(computersystem.Client, computersystem.processors)
+}
+
+// SecureBoot gets the secure boot information for the system.
+func (computersystem *ComputerSystem) SecureBoot() (*SecureBoot, error) {
+	if computersystem.secureBoot == "" {
+		return nil, nil
+	}
+
+	return GetSecureBoot(computersystem.Client, computersystem.secureBoot)
+}
+
+// SimpleStorages gets all simple storage services of this system.
+func (computersystem *ComputerSystem) SimpleStorages() ([]*SimpleStorage, error) {
+	return ListReferencedSimpleStorages(computersystem.Client, computersystem.simpleStorage)
+}
+
+// Storage gets the storage associated with this system.
+func (computersystem *ComputerSystem) Storage() ([]*Storage, error) {
+	return ListReferencedStorages(computersystem.Client, computersystem.storage)
 }
 
 // CSLinks are references to resources that are related to, but not contained
@@ -634,8 +701,7 @@ type CSLinks struct {
 	SupplyingComputerSystemsCount int `json:"SupplyingComputerSystems@odata.count"`
 }
 
-// MemorySummary contains properties which describe the
-// central memory for a system.
+// MemorySummary contains properties which describe the central memory for a system.
 type MemorySummary struct {
 	// MemoryMirroring is the ability and type of memory mirring supported by this system.
 	MemoryMirroring MemoryMirroring
@@ -646,7 +712,7 @@ type MemorySummary struct {
 	TotalSystemMemoryGiB float32
 	// TotalSystemPersistentMemoryGiB is the total amount of configured
 	// persistent memory available to the system as measured in gibibytes.
-	TotalSystemPersistentMemoryGiB int
+	TotalSystemPersistentMemoryGiB float32
 }
 
 // ProcessorSummary is This type shall contain properties which describe
@@ -673,13 +739,12 @@ type TrustedModules struct {
 	// version, if applicable, as defined by the manufacturer for the Trusted
 	// Module.
 	FirmwareVersion2 string
-	// InterfaceType is the interface type of the
-	// installed Trusted Module.
-	InterfaceType string
+	// InterfaceType is the interface type of the installed Trusted Module.
+	InterfaceType InterfaceType
 	// InterfaceTypeSelection is the Interface
 	// Type Selection method (for example to switch between TPM1_2 and
 	// TPM2_0) that is supported by this TrustedModule.
-	InterfaceTypeSelection string
+	InterfaceTypeSelection InterfaceTypeSelection
 	// Status is any status or health properties
 	// of the resource.
 	Status common.Status
@@ -694,8 +759,7 @@ type WatchdogTimer struct {
 	// by the user, and updates to this property shall not initiate a
 	// watchdog timer countdown.
 	FunctionEnabled bool
-	// Status is any status or health properties
-	// of the resource.
+	// Status is any status or health properties of the resource.
 	Status struct {
 		State common.State
 	}

--- a/school/redfish/logentry.go
+++ b/school/redfish/logentry.go
@@ -1,0 +1,463 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redfish
+
+import (
+	"encoding/json"
+
+	"github.com/stmcginnis/gofish/school/common"
+)
+
+// EventSeverity is
+type EventSeverity string
+
+const (
+
+	// OKEventSeverity Informational or operating normally.
+	OKEventSeverity EventSeverity = "OK"
+	// WarningEventSeverity A condition requiring attention.
+	WarningEventSeverity EventSeverity = "Warning"
+	// CriticalEventSeverity A critical condition requiring immediate
+	// attention.
+	CriticalEventSeverity EventSeverity = "Critical"
+)
+
+// LogEntryCode is
+type LogEntryCode string
+
+const (
+
+	// AssertLogEntryCode The condition has been asserted.
+	AssertLogEntryCode LogEntryCode = "Assert"
+	// DeassertLogEntryCode The condition has been deasserted.
+	DeassertLogEntryCode LogEntryCode = "Deassert"
+	// LowerNonCriticalGoingLowLogEntryCode The reading crossed the
+	// Lower Non-critical threshold while going low.
+	LowerNonCriticalGoingLowLogEntryCode LogEntryCode = "Lower Non-critical - going low"
+	// LowerNonCriticalGoingHighLogEntryCode The reading crossed the
+	// Lower Non-critical threshold while going high.
+	LowerNonCriticalGoingHighLogEntryCode LogEntryCode = "Lower Non-critical - going high"
+	// LowerCriticalGoingLowLogEntryCode The reading crossed the Lower
+	// Critical threshold while going low.
+	LowerCriticalGoingLowLogEntryCode LogEntryCode = "Lower Critical - going low"
+	// LowerCriticalGoingHighLogEntryCode The reading crossed the Lower
+	// Critical threshold while going high.
+	LowerCriticalGoingHighLogEntryCode LogEntryCode = "Lower Critical - going high"
+	// LowerNonRecoverableGoingLowLogEntryCode The reading crossed the
+	// Lower Non-recoverable threshold while going low.
+	LowerNonRecoverableGoingLowLogEntryCode LogEntryCode = "Lower Non-recoverable - going low"
+	// LowerNonRecoverableGoingHighLogEntryCode The reading crossed the
+	// Lower Non-recoverable threshold while going high.
+	LowerNonRecoverableGoingHighLogEntryCode LogEntryCode = "Lower Non-recoverable - going high"
+	// UpperNonCriticalGoingLowLogEntryCode The reading crossed the
+	// Upper Non-critical threshold while going low.
+	UpperNonCriticalGoingLowLogEntryCode LogEntryCode = "Upper Non-critical - going low"
+	// UpperNonCriticalGoingHighLogEntryCode The reading crossed the
+	// Upper Non-critical threshold while going high.
+	UpperNonCriticalGoingHighLogEntryCode LogEntryCode = "Upper Non-critical - going high"
+	// UpperCriticalGoingLowLogEntryCode The reading crossed the Upper
+	// Critical threshold while going low.
+	UpperCriticalGoingLowLogEntryCode LogEntryCode = "Upper Critical - going low"
+	// UpperCriticalGoingHighLogEntryCode The reading crossed the Upper
+	// Critical threshold while going high.
+	UpperCriticalGoingHighLogEntryCode LogEntryCode = "Upper Critical - going high"
+	// UpperNonRecoverableGoingLowLogEntryCode The reading crossed the
+	// Upper Non-recoverable threshold while going low.
+	UpperNonRecoverableGoingLowLogEntryCode LogEntryCode = "Upper Non-recoverable - going low"
+	// UpperNonRecoverableGoingHighLogEntryCode The reading crossed the
+	// Upper Non-recoverable threshold while going high.
+	UpperNonRecoverableGoingHighLogEntryCode LogEntryCode = "Upper Non-recoverable - going high"
+	// TransitionToIdleLogEntryCode The state transitioned to idle.
+	TransitionToIdleLogEntryCode LogEntryCode = "Transition to Idle"
+	// TransitionToActiveLogEntryCode The state transitioned to active.
+	TransitionToActiveLogEntryCode LogEntryCode = "Transition to Active"
+	// TransitionToBusyLogEntryCode The state transitioned to busy.
+	TransitionToBusyLogEntryCode LogEntryCode = "Transition to Busy"
+	// StateDeassertedLogEntryCode The state has been deasserted.
+	StateDeassertedLogEntryCode LogEntryCode = "State Deasserted"
+	// StateAssertedLogEntryCode The state has been asserted.
+	StateAssertedLogEntryCode LogEntryCode = "State Asserted"
+	// PredictiveFailureDeassertedLogEntryCode A Predictive Failure is no
+	// longer present.
+	PredictiveFailureDeassertedLogEntryCode LogEntryCode = "Predictive Failure deasserted"
+	// PredictiveFailureAssertedLogEntryCode A Predictive Failure has been
+	// detected.
+	PredictiveFailureAssertedLogEntryCode LogEntryCode = "Predictive Failure asserted"
+	// LimitNotExceededLogEntryCode A limit has not been exceeded.
+	LimitNotExceededLogEntryCode LogEntryCode = "Limit Not Exceeded"
+	// LimitExceededLogEntryCode A limit has been exceeded.
+	LimitExceededLogEntryCode LogEntryCode = "Limit Exceeded"
+	// PerformanceMetLogEntryCode Performance meets expectations.
+	PerformanceMetLogEntryCode LogEntryCode = "Performance Met"
+	// PerformanceLagsLogEntryCode Performance does not meet expectations.
+	PerformanceLagsLogEntryCode LogEntryCode = "Performance Lags"
+	// TransitionToOKLogEntryCode A state has changed to OK.
+	TransitionToOKLogEntryCode LogEntryCode = "Transition to OK"
+	// TransitionToNonCriticalFromOKLogEntryCode A state has changed to
+	// Non-Critical from OK.
+	TransitionToNonCriticalFromOKLogEntryCode LogEntryCode = "Transition to Non-Critical from OK"
+	// TransitionToCriticalFromLessSevereLogEntryCode A state has
+	// changed to Critical from less severe.
+	TransitionToCriticalFromLessSevereLogEntryCode LogEntryCode = "Transition to Critical from less severe"
+	// TransitionToNonrecoverableFromLessSevereLogEntryCode A state has
+	// changed to Non-recoverable from less severe.
+	TransitionToNonrecoverableFromLessSevereLogEntryCode LogEntryCode = "Transition to Non-recoverable from less severe"
+	// TransitionToNonCriticalFromMoreSevereLogEntryCode A state has
+	// changed to Non-Critical from more severe.
+	TransitionToNonCriticalFromMoreSevereLogEntryCode LogEntryCode = "Transition to Non-Critical from more severe"
+	// TransitionToCriticalFromNonrecoverableLogEntryCode A state has
+	// changed to Critical from Non-recoverable.
+	TransitionToCriticalFromNonrecoverableLogEntryCode LogEntryCode = "Transition to Critical from Non-recoverable"
+	// TransitionToNonrecoverableLogEntryCode A state has changed to Non-
+	// recoverable.
+	TransitionToNonrecoverableLogEntryCode LogEntryCode = "Transition to Non-recoverable"
+	// MonitorLogEntryCode A Monitor event.
+	MonitorLogEntryCode LogEntryCode = "Monitor"
+	// InformationalLogEntryCode An Informational event.
+	InformationalLogEntryCode LogEntryCode = "Informational"
+	// DeviceRemovedDeviceAbsentLogEntryCode A device has been removed
+	// or is now absent.
+	DeviceRemovedDeviceAbsentLogEntryCode LogEntryCode = "Device Removed / Device Absent"
+	// DeviceInsertedDevicePresentLogEntryCode A device has been
+	// inserted or is now present.
+	DeviceInsertedDevicePresentLogEntryCode LogEntryCode = "Device Inserted / Device Present"
+	// DeviceDisabledLogEntryCode A device has been disabled.
+	DeviceDisabledLogEntryCode LogEntryCode = "Device Disabled"
+	// DeviceEnabledLogEntryCode A device has been enabled.
+	DeviceEnabledLogEntryCode LogEntryCode = "Device Enabled"
+	// TransitionToRunningLogEntryCode A state has transitioned to Running.
+	TransitionToRunningLogEntryCode LogEntryCode = "Transition to Running"
+	// TransitionToInTestLogEntryCode A state has transitioned to In Test.
+	TransitionToInTestLogEntryCode LogEntryCode = "Transition to In Test"
+	// TransitionToPowerOffLogEntryCode A state has transitioned to Power
+	// Off.
+	TransitionToPowerOffLogEntryCode LogEntryCode = "Transition to Power Off"
+	// TransitionToOnLineLogEntryCode A state has transitioned to On Line.
+	TransitionToOnLineLogEntryCode LogEntryCode = "Transition to On Line"
+	// TransitionToOffLineLogEntryCode A state has transitioned to Off
+	// Line.
+	TransitionToOffLineLogEntryCode LogEntryCode = "Transition to Off Line"
+	// TransitionToOffDutyLogEntryCode A state has transitioned to Off
+	// Duty.
+	TransitionToOffDutyLogEntryCode LogEntryCode = "Transition to Off Duty"
+	// TransitionToDegradedLogEntryCode A state has transitioned to
+	// Degraded.
+	TransitionToDegradedLogEntryCode LogEntryCode = "Transition to Degraded"
+	// TransitionToPowerSaveLogEntryCode A state has transitioned to Power
+	// Save.
+	TransitionToPowerSaveLogEntryCode LogEntryCode = "Transition to Power Save"
+	// InstallErrorLogEntryCode An Install Error has been detected.
+	InstallErrorLogEntryCode LogEntryCode = "Install Error"
+	// FullyRedundantLogEntryCode Indicates that full redundancy has been
+	// regained.
+	FullyRedundantLogEntryCode LogEntryCode = "Fully Redundant"
+	// RedundancyLostLogEntryCode Entered any non-redundant state, including
+	// Non-redundant: Insufficient Resources.
+	RedundancyLostLogEntryCode LogEntryCode = "Redundancy Lost"
+	// RedundancyDegradedLogEntryCode Redundancy still exists, but at less
+	// than full level.
+	RedundancyDegradedLogEntryCode LogEntryCode = "Redundancy Degraded"
+	// NonredundantSufficientResourcesFromRedundantLogEntryCode Redundancy has
+	// been lost but unit is functioning with minimum resources needed for
+	// normal operation.
+	NonredundantSufficientResourcesFromRedundantLogEntryCode LogEntryCode = "Non-redundant:Sufficient Resources from Redundant"
+	// NonredundantSufficientResourcesFromInsufficientResourcesLogEntryCode Unit has regained minimum resources needed for
+	// normal operation.
+	NonredundantSufficientResourcesFromInsufficientResourcesLogEntryCode LogEntryCode = "Non-redundant:Sufficient Resources from Insufficient Resources"
+	// NonredundantInsufficientResourcesLogEntryCode Unit is non-redundant
+	// and has insufficient resource to maintain normal operation.
+	NonredundantInsufficientResourcesLogEntryCode LogEntryCode = "Non-redundant:Insufficient Resources"
+	// RedundancyDegradedFromFullyRedundantLogEntryCode Unit has lost
+	// some redundant resource(s) but is still in a redundant state.
+	RedundancyDegradedFromFullyRedundantLogEntryCode LogEntryCode = "Redundancy Degraded from Fully Redundant"
+	// RedundancyDegradedFromNonredundantLogEntryCode Unit has regained
+	// some resource(s) and is redundant but not fully redundant.
+	RedundancyDegradedFromNonredundantLogEntryCode LogEntryCode = "Redundancy Degraded from Non-redundant"
+	// D0PowerStateLogEntryCode The ACPI defined D0 Power State.
+	D0PowerStateLogEntryCode LogEntryCode = "D0 Power State"
+	// D1PowerStateLogEntryCode The ACPI defined D1 Power State.
+	D1PowerStateLogEntryCode LogEntryCode = "D1 Power State"
+	// D2PowerStateLogEntryCode The ACPI defined D2 Power State.
+	D2PowerStateLogEntryCode LogEntryCode = "D2 Power State"
+	// D3PowerStateLogEntryCode The ACPI defined D3 Power State.
+	D3PowerStateLogEntryCode LogEntryCode = "D3 Power State"
+	// OEMLogEntryCode An OEM defined event.
+	OEMLogEntryCode LogEntryCode = "OEM"
+)
+
+// LogEntryType is
+type LogEntryType string
+
+const (
+
+	// EventLogEntryType Contains a Redfish-defined message (event).
+	EventLogEntryType LogEntryType = "Event"
+	// SELLogEntryType Contains a legacy IPMI System Event Log (SEL) entry.
+	SELLogEntryType LogEntryType = "SEL"
+	// OemLogEntryType Contains an entry in an OEM-defined format.
+	OemLogEntryType LogEntryType = "Oem"
+)
+
+// SensorType is
+type SensorType string
+
+const (
+
+	// PlatformSecurityViolationAttemptSensorType A platform security
+	// sensor.
+	PlatformSecurityViolationAttemptSensorType SensorType = "Platform Security Violation Attempt"
+	// TemperatureSensorType A temperature sensor.
+	TemperatureSensorType SensorType = "Temperature"
+	// VoltageSensorType A voltage sensor.
+	VoltageSensorType SensorType = "Voltage"
+	// CurrentSensorType A current sensor.
+	CurrentSensorType SensorType = "Current"
+	// FanSensorType A fan sensor.
+	FanSensorType SensorType = "Fan"
+	// PhysicalChassisSecuritySensorType A physical security sensor.
+	PhysicalChassisSecuritySensorType SensorType = "Physical Chassis Security"
+	// ProcessorSensorType A sensor for a processor.
+	ProcessorSensorType SensorType = "Processor"
+	// PowerSupplyConverterSensorType A sensor for a power supply or DC-
+	// to-DC converter.
+	PowerSupplyConverterSensorType SensorType = "Power Supply / Converter"
+	// PowerUnitSensorType A sensor for a power unit.
+	PowerUnitSensorType SensorType = "PowerUnit"
+	// CoolingDeviceSensorType A sensor for a cooling device.
+	CoolingDeviceSensorType SensorType = "CoolingDevice"
+	// OtherUnitsBasedSensorSensorType A sensor for a miscellaneous analog
+	// sensor.
+	OtherUnitsBasedSensorSensorType SensorType = "Other Units-based Sensor"
+	// MemorySensorType A sensor for a memory device.
+	MemorySensorType SensorType = "Memory"
+	// DriveSlotBaySensorType A sensor for a drive slot or bay.
+	DriveSlotBaySensorType SensorType = "Drive Slot/Bay"
+	// POSTMemoryResizeSensorType A sensor for a POST memory resize event.
+	POSTMemoryResizeSensorType SensorType = "POST Memory Resize"
+	// SystemFirmwareProgressSensorType A sensor for a system firmware
+	// progress event.
+	SystemFirmwareProgressSensorType SensorType = "System Firmware Progress"
+	// EventLoggingDisabledSensorType A sensor for the event log.
+	EventLoggingDisabledSensorType SensorType = "Event Logging Disabled"
+	// SystemEventSensorType A sensor for a system event.
+	SystemEventSensorType SensorType = "System Event"
+	// CriticalInterruptSensorType A sensor for a critical interrupt event.
+	CriticalInterruptSensorType SensorType = "Critical Interrupt"
+	// ButtonSwitchSensorType A sensor for a button or switch.
+	ButtonSwitchSensorType SensorType = "Button/Switch"
+	// ModuleBoardSensorType A sensor for a module or board.
+	ModuleBoardSensorType SensorType = "Module/Board"
+	// MicrocontrollerCoprocessorSensorType A sensor for a microcontroller
+	// or coprocessor.
+	MicrocontrollerCoprocessorSensorType SensorType = "Microcontroller/Coprocessor"
+	// AddinCardSensorType A sensor for an add-in card.
+	AddinCardSensorType SensorType = "Add-in Card"
+	// ChassisSensorType A sensor for a chassis.
+	ChassisSensorType SensorType = "Chassis"
+	// ChipSetSensorType A sensor for a chipset.
+	ChipSetSensorType SensorType = "ChipSet"
+	// OtherFRUSensorType A sensor for an other type of FRU.
+	OtherFRUSensorType SensorType = "Other FRU"
+	// CableInterconnectSensorType A sensor for a cable or interconnect type
+	// of device.
+	CableInterconnectSensorType SensorType = "Cable/Interconnect"
+	// TerminatorSensorType A sensor for a terminator.
+	TerminatorSensorType SensorType = "Terminator"
+	// SystemBootRestartSensorType A sensor for a system boot or restart
+	// event.
+	SystemBootRestartSensorType SensorType = "SystemBoot/Restart"
+	// BootErrorSensorType A sensor for a boot error event.
+	BootErrorSensorType SensorType = "Boot Error"
+	// BaseOSBootInstallationStatusSensorType A sensor for a base OS boot or
+	// installation status event.
+	BaseOSBootInstallationStatusSensorType SensorType = "BaseOSBoot/InstallationStatus"
+	// OSStopShutdownSensorType A sensor for an OS stop or shutdown event
+	OSStopShutdownSensorType SensorType = "OS Stop/Shutdown"
+	// SlotConnectorSensorType A sensor for a slot or connector.
+	SlotConnectorSensorType SensorType = "Slot/Connector"
+	// SystemACPIPowerStateSensorType A sensor for an ACPI power state
+	// event.
+	SystemACPIPowerStateSensorType SensorType = "System ACPI PowerState"
+	// WatchdogSensorType A sensor for a watchdog event.
+	WatchdogSensorType SensorType = "Watchdog"
+	// PlatformAlertSensorType A sensor for a platform alert event.
+	PlatformAlertSensorType SensorType = "Platform Alert"
+	// EntityPresenceSensorType A sensor for an entity presence event.
+	EntityPresenceSensorType SensorType = "Entity Presence"
+	// MonitorASICICSensorType A sensor for a monitor ASIC or IC.
+	MonitorASICICSensorType SensorType = "Monitor ASIC/IC"
+	// LANSensorType A sensor for a LAN device.
+	LANSensorType SensorType = "LAN"
+	// ManagementSubsystemHealthSensorType A sensor for a management
+	// subsystem health event.
+	ManagementSubsystemHealthSensorType SensorType = "Management Subsystem Health"
+	// BatterySensorType A sensor for a battery.
+	BatterySensorType SensorType = "Battery"
+	// SessionAuditSensorType A sensor for a session audit event.
+	SessionAuditSensorType SensorType = "Session Audit"
+	// VersionChangeSensorType A sensor for a version change event.
+	VersionChangeSensorType SensorType = "Version Change"
+	// FRUStateSensorType A sensor for a FRU state event.
+	FRUStateSensorType SensorType = "FRUState"
+	// OEMSensorType An OEM defined sensor.
+	OEMSensorType SensorType = "OEM"
+)
+
+// LogEntry shall represent the log format for log services.
+type LogEntry struct {
+	common.Entity
+
+	// ODataContext is the odata context.
+	ODataContext string `json:"@odata.context"`
+	// ODataEtag is the odata etag.
+	ODataEtag string `json:"@odata.etag"`
+	// ODataID is the odata identifier.
+	ODataID string `json:"@odata.id"`
+	// ODataType is the odata type.
+	ODataType string `json:"@odata.type"`
+	// Created shall be the time at which the log entry was created.
+	Created string
+	// Description provides a description of this resource.
+	Description string
+	// EntryCode shall be present if the EntryType value is
+	// SEL. These enumerations are the values from tables 42-1 and 42-2 of
+	// the IPMI specification.
+	EntryCode LogEntryCode
+	// EntryType shall represent the type of LogEntry. If
+	// the resource represents an IPMI SEL log entry, the value shall be SEL.
+	// If the resource represents an Event log, the value shall be Event. If
+	// the resource represents an OEM log format, the value shall be Oem.
+	EntryType LogEntryType
+	// EventGroupID shall indicate that events are related and shall have the
+	// same value in the case where multiple Event messages are produced by the
+	// same root cause. Implementations shall use separate values for events
+	// with separate root cause. There shall not be ordering of events implied
+	// by the value of this property.
+	EventGroupID int `json:"EventGroupId"`
+	// EventID records an Event and the value shall indicate a unique identifier
+	// for the event, the format of which is implementation dependent.
+	EventID string `json:"EventId"`
+	// EventTimestamp records an Event and the value shall be the time the event
+	// occurred.
+	EventTimestamp string
+	// Message shall be the Message property of
+	// the event if the EntryType is Event, the Description if the EntryType
+	// is SEL, and OEM Specific if the EntryType is Oem.
+	Message string
+	// MessageArgs contains message arguments to be substituted into
+	// the message included or in the message looked up via a registry.
+	MessageArgs []string
+	// MessageId shall the MessageId property
+	// of the event if the EntryType is Event, the three IPMI Event Data
+	// bytes if the EntryType is SEL, and OEM Specific if the EntryType is
+	// Oem. The format of this property shall be as defined in the Redfish
+	// specification. If representing the three IPMI Event Data bytes, the
+	// format should follow the pattern '^0[xX](([a-fA-F]|[0-9]){2}){3}$',
+	// where Event Data 1 is the first byte in the string, Event Data 2 is
+	// the second byte in the string, and Event Data 3 is the third byte in
+	// the string.
+	MessageID string `json:"MessageId"`
+	// OemLogEntryCode shall represent the OEM
+	// specific Log Entry Code type of the Entry. This property shall only
+	// be present if the value of EntryType is SEL and the value of
+	// LogEntryCode is OEM.
+	OemLogEntryCode string
+	// OemRecordFormat shall represent the OEM
+	// specific format of the Entry. This property shall be required if the
+	// value of EntryType is Oem.
+	OemRecordFormat string
+	// OemSensorType is used if the value of EntryType is SEL and the value
+	// of SensorType is OEM.
+	OemSensorType string
+	// SensorNumber shall be the IPMI sensor
+	// number if the EntryType is SEL, the count of events if the EntryType
+	// is Event, and OEM Specific if EntryType is Oem.
+	SensorNumber int
+	// SensorType shall be present if the EntryType value is
+	// SEL. These enumerations are the values from table 42-3 of the IPMI
+	// specification.
+	SensorType SensorType
+	// Severity shall be the severity of the
+	// condition resulting in the log entry, as defined in the Status section
+	// of the Redfish specificaiton.
+	Severity EventSeverity
+	// originOfCondition shall be an href that
+	// references the resource for which the log is associated.
+	originOfCondition string
+}
+
+// UnmarshalJSON unmarshals a LogEntry object from the raw JSON.
+func (logentry *LogEntry) UnmarshalJSON(b []byte) error {
+	type temp LogEntry
+	var t struct {
+		temp
+		Links struct {
+			// OriginOfCondition shall be an href that
+			// references the resource for which the log is associated.
+			OriginOfCondition common.Link
+		}
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	// Extract the links to other entities for later
+	*logentry = LogEntry(t.temp)
+	logentry.originOfCondition = string(t.Links.OriginOfCondition)
+
+	return nil
+}
+
+// GetLogEntry will get a LogEntry instance from the service.
+func GetLogEntry(c common.Client, uri string) (*LogEntry, error) {
+	resp, err := c.Get(uri)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var logentry LogEntry
+	err = json.NewDecoder(resp.Body).Decode(&logentry)
+	if err != nil {
+		return nil, err
+	}
+
+	logentry.SetClient(c)
+	return &logentry, nil
+}
+
+// ListReferencedLogEntrys gets the collection of LogEntry from
+// a provided reference.
+func ListReferencedLogEntrys(c common.Client, link string) ([]*LogEntry, error) {
+	var result []*LogEntry
+	if link == "" {
+		return result, nil
+	}
+
+	links, err := common.GetCollection(c, link)
+	if err != nil {
+		return result, err
+	}
+
+	for _, logentryLink := range links.ItemLinks {
+		logentry, err := GetLogEntry(c, logentryLink)
+		if err != nil {
+			return result, err
+		}
+		result = append(result, logentry)
+	}
+
+	return result, nil
+}

--- a/school/redfish/logservice.go
+++ b/school/redfish/logservice.go
@@ -1,0 +1,183 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redfish
+
+import (
+	"encoding/json"
+
+	"github.com/stmcginnis/gofish/school/common"
+)
+
+// LogEntryTypes is the type of log entry.
+type LogEntryTypes string
+
+const (
+	// EventLogEntryTypes contains Redfish-defined messages (events).
+	EventLogEntryTypes LogEntryTypes = "Event"
+	// SELLogEntryTypes contains legacy IPMI System Event Log (SEL) entries.
+	SELLogEntryTypes LogEntryTypes = "SEL"
+	// MultipleLogEntryTypes contains multiple Log Entry types or a
+	// single entry type cannot be guaranteed by the Log Service.
+	MultipleLogEntryTypes LogEntryTypes = "Multiple"
+	// OEMLogEntryTypes contains entries in an OEM-defined format.
+	OEMLogEntryTypes LogEntryTypes = "OEM"
+)
+
+// OverWritePolicy is the log overwriting policy.
+type OverWritePolicy string
+
+const (
+
+	// UnknownOverWritePolicy means the policy is not known or is undefined.
+	UnknownOverWritePolicy OverWritePolicy = "Unknown"
+	// WrapsWhenFullOverWritePolicy means when full, new entries to the Log will
+	// overwrite previous entries.
+	WrapsWhenFullOverWritePolicy OverWritePolicy = "WrapsWhenFull"
+	// NeverOverWritesOverWritePolicy means when full, new entries to the Log will
+	// be discarded.
+	NeverOverWritesOverWritePolicy OverWritePolicy = "NeverOverWrites"
+)
+
+// LogService is used to represent a log service for a Redfish
+// implementation.
+type LogService struct {
+	common.Entity
+
+	// ODataContext is the odata context.
+	ODataContext string `json:"@odata.context"`
+	// ODataEtag is the odata etag.
+	ODataEtag string `json:"@odata.etag"`
+	// ODataID is the odata identifier.
+	ODataID string `json:"@odata.id"`
+	// ODataType is the odata type.
+	ODataType string `json:"@odata.type"`
+	// DateTime shall represent the current DateTime value that the log service
+	// is using, with offset from UTC, in Redfish Timestamp format.
+	DateTime string
+	// DateTimeLocalOffset shall represent the offset from UTC time that the
+	// current value of DataTime property contains.
+	DateTimeLocalOffset string
+	// Description provides a description of this resource.
+	Description string
+	// Entries shall reference a collection of resources of type LogEntry.
+	Entries string
+	// LogEntryType shall represent the
+	// EntryType of all LogEntry resources contained in the Entries
+	// collection. If a single EntryType for all LogEntry resources cannot
+	// be determined or guaranteed by the Service, the value of this property
+	// shall be 'Multiple'.
+	LogEntryType LogEntryTypes
+	// MaxNumberOfRecords shall be the maximum
+	// numbers of LogEntry resources in the Entries collection for this
+	// service.
+	MaxNumberOfRecords string
+	// OverWritePolicy shall indicate the
+	// policy of the log service when the MaxNumberOfRecords has been
+	// reached. Unknown indicates the log overwrite policy is unknown.
+	// WrapsWhenFull indicates that the log overwrites its entries with new
+	// entries when the log has reached its maximum capacity. NeverOverwrites
+	// indicates that the log never overwrites its entries by the new entries
+	// and ceases logging when the limit has been reached.
+	OverWritePolicy OverWritePolicy
+	// ServiceEnabled shall be a boolean
+	// indicating whether this service is enabled.
+	ServiceEnabled bool
+	// Status shall contain any status or health properties of the resource.
+	Status common.Status
+}
+
+// UnmarshalJSON unmarshals a LogService object from the raw JSON.
+func (logservice *LogService) UnmarshalJSON(b []byte) error {
+	type temp LogService
+	var t struct {
+		temp
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	*logservice = LogService(t.temp)
+
+	// Extract the links to other entities for later
+
+	return nil
+}
+
+// GetLogService will get a LogService instance from the service.
+func GetLogService(c common.Client, uri string) (*LogService, error) {
+	resp, err := c.Get(uri)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var logservice LogService
+	err = json.NewDecoder(resp.Body).Decode(&logservice)
+	if err != nil {
+		return nil, err
+	}
+
+	logservice.SetClient(c)
+	return &logservice, nil
+}
+
+// ListReferencedLogServices gets the collection of LogService from
+// a provided reference.
+func ListReferencedLogServices(c common.Client, link string) ([]*LogService, error) {
+	var result []*LogService
+	if link == "" {
+		return result, nil
+	}
+
+	links, err := common.GetCollection(c, link)
+	if err != nil {
+		return result, err
+	}
+
+	for _, logserviceLink := range links.ItemLinks {
+		logservice, err := GetLogService(c, logserviceLink)
+		if err != nil {
+			return result, err
+		}
+		result = append(result, logservice)
+	}
+
+	return result, nil
+}
+
+// OemActions is This type shall contain any additional OEM actions for
+// this resource.
+type OemActions struct {
+	common.Entity
+}
+
+// UnmarshalJSON unmarshals a OemActions object from the raw JSON.
+func (oemactions *OemActions) UnmarshalJSON(b []byte) error {
+	type temp OemActions
+	var t struct {
+		temp
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	*oemactions = OemActions(t.temp)
+
+	// Extract the links to other entities for later
+
+	return nil
+}

--- a/school/redfish/memorydomain.go
+++ b/school/redfish/memorydomain.go
@@ -1,0 +1,142 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redfish
+
+import (
+	"encoding/json"
+
+	"github.com/stmcginnis/gofish/school/common"
+)
+
+// MemoryDomain is used to represent Memory Domains.
+type MemoryDomain struct {
+	common.Entity
+
+	// ODataContext is the odata context.
+	ODataContext string `json:"@odata.context"`
+	// ODataEtag is the odata etag.
+	ODataEtag string `json:"@odata.etag"`
+	// ODataID is the odata identifier.
+	ODataID string `json:"@odata.id"`
+	// ODataType is the odata type.
+	ODataType string `json:"@odata.type"`
+	// AllowsBlockProvisioning shall indicate if this Memory Domain supports the
+	// creation of Blocks of memory.
+	AllowsBlockProvisioning bool
+	// AllowsMemoryChunkCreation shall indicate if this Memory Domain supports
+	// the creation of Memory Chunks.
+	AllowsMemoryChunkCreation bool
+	// AllowsMirroring shall indicate if this Memory Domain supports the
+	// creation of Memory Chunks with mirroring enabled.
+	AllowsMirroring bool
+	// AllowsSparing shall indicate if this Memory Domain supports the creation
+	// of Memory Chunks with sparing enabled.
+	AllowsSparing bool
+	// Description provides a description of this resource.
+	Description string
+	// InterleavableMemorySets shall represent the interleave sets for the
+	// memory chunk.
+	InterleavableMemorySets []MemorySet
+	// memoryChunks shall be a link to a collection of type MemoryChunkCollection.
+	memoryChunks string
+}
+
+// UnmarshalJSON unmarshals a MemoryDomain object from the raw JSON.
+func (memorydomain *MemoryDomain) UnmarshalJSON(b []byte) error {
+	type temp MemoryDomain
+	var t struct {
+		temp
+		MemoryChunks common.Link
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	// Extract the links to other entities for later
+	*memorydomain = MemoryDomain(t.temp)
+	memorydomain.memoryChunks = string(t.MemoryChunks)
+
+	return nil
+}
+
+// GetMemoryDomain will get a MemoryDomain instance from the service.
+func GetMemoryDomain(c common.Client, uri string) (*MemoryDomain, error) {
+	resp, err := c.Get(uri)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var memorydomain MemoryDomain
+	err = json.NewDecoder(resp.Body).Decode(&memorydomain)
+	if err != nil {
+		return nil, err
+	}
+
+	memorydomain.SetClient(c)
+	return &memorydomain, nil
+}
+
+// ListReferencedMemoryDomains gets the collection of MemoryDomain from
+// a provided reference.
+func ListReferencedMemoryDomains(c common.Client, link string) ([]*MemoryDomain, error) {
+	var result []*MemoryDomain
+	if link == "" {
+		return result, nil
+	}
+
+	links, err := common.GetCollection(c, link)
+	if err != nil {
+		return result, err
+	}
+
+	for _, memorydomainLink := range links.ItemLinks {
+		memorydomain, err := GetMemoryDomain(c, memorydomainLink)
+		if err != nil {
+			return result, err
+		}
+		result = append(result, memorydomain)
+	}
+
+	return result, nil
+}
+
+// MemorySet shall represent the interleave sets for a memory chunk.
+type MemorySet struct {
+	// MemorySet shall be links to objects of type Memory.
+	memorySet []string
+	// MemorySetCount is the number of memory sets.
+	MemorySetCount int `json:"MemorySet@odata.count"`
+}
+
+// UnmarshalJSON unmarshals a MemorySet object from the raw JSON.
+func (memoryset *MemorySet) UnmarshalJSON(b []byte) error {
+	type temp MemorySet
+	var t struct {
+		temp
+		MemorySet common.Links
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	// Extract the links to other entities for later
+	*memoryset = MemorySet(t.temp)
+	memoryset.memorySet = t.MemorySet.ToStrings()
+
+	return nil
+}

--- a/school/redfish/networkadapter.go
+++ b/school/redfish/networkadapter.go
@@ -18,134 +18,105 @@ import (
 	"github.com/stmcginnis/gofish/school/common"
 )
 
-// ControllerCapabilities is This type shall describe the capabilities of
-// a controller.
+// ControllerCapabilities shall describe the capabilities of a controller.
 type ControllerCapabilities struct {
-	// DataCenterBridging is This object shall contain capability, status,
+	// DataCenterBridging shall contain capability, status,
 	// and configuration values related to Data Center Bridging (DCB) for
 	// this controller.
 	DataCenterBridging struct {
 		Capable bool
 	}
-	// NPAR is This object shall contain capability, status, and
+	// NPAR shall contain capability, status, and
 	// configuration values related to NIC partitioning for this controller.
 	NPAR struct {
-		// NparCapable is This property shall indicate the ability of a
+		// NparCapable shall indicate the ability of a
 		// controller to support NIC function partitioning.
 		NparCapable bool
-		// NparEnabled is This property shall indicate whether or not NIC
+		// NparEnabled shall indicate whether or not NIC
 		// function partitioning is active on this controller.
 		NparEnabled bool
 	}
-	// NPIV is This object shall contain N_Port ID Virtualization (NPIV)
+	// NPIV shall contain N_Port ID Virtualization (NPIV)
 	// capabilties for this controller.
 	NPIV struct {
-		// MaxDeviceLogins is The value of this property shall be the maximum
+		// MaxDeviceLogins shall be the maximum
 		// number of N_Port ID Virtualization (NPIV) logins allowed
 		// simultaneously from all ports on this controller.
 		MaxDeviceLogins int
-		// MaxPortLogins is The value of this property shall be the maximum
+		// MaxPortLogins shall be the maximum
 		// number of N_Port ID Virtualization (NPIV) logins allowed per physical
 		// port on this controller.
 		MaxPortLogins int
 	}
-	// NetworkDeviceFunctionCount is The value of this property shall be the
+	// NetworkDeviceFunctionCount shall be the
 	// number of physical functions available on this controller.
 	NetworkDeviceFunctionCount int
-	// NetworkPortCount is The value of this property shall be the number of
+	// NetworkPortCount shall be the number of
 	// physical ports on this controller.
 	NetworkPortCount int
-	// VirtualizationOffload is This object shall contain capability, status,
+	// VirtualizationOffload shall contain capability, status,
 	// and configuration values related to virtualization offload for this
 	// controller.
 	VirtualizationOffload struct {
-		// SRIOV is This object shall contain Single-Root Input/Output
-		// Virtualization (SR-IOV) capabilities.
+		// SRIOV shall contain Single-Root Input/Output Virtualization (SR-IOV)
+		// capabilities.
 		SRIOV struct {
-			// SRIOVVEPACapable is The value of this property shall be a boolean
-			// indicating whether this controller supports Single Root Input/Output
-			// Virtualization (SR-IOV) in Virtual Ethernet Port Aggregator (VEPA)
-			// mode.
+			//SRIOVVEPACapable shall be a boolean indicating whether this
+			// controller supports Single Root Input/Output Virtualization
+			// (SR-IOV) in Virtual Ethernet Port Aggregator (VEPA) mode.
 			SRIOVVEPACapable bool
 		}
-		// VirtualFunction is This property shall describe the capability,
-		// status, and configuration values related to the virtual function for
-		// this controller.
+		// VirtualFunction shall describe the capability, status, and
+		// configuration values related to the virtual function for this controller.
 		VirtualFunction struct {
-			// DeviceMaxCount is The value of this property shall be the maximum
-			// number of Virtual Functions (VFs) supported by this controller.
+			// DeviceMaxCount shall be the maximum number of Virtual Functions
+			// (VFs) supported by this controller.
 			DeviceMaxCount int
-			// MinAssignmentGroupSize is The value of this property shall be the
-			// minimum number of Virtual Functions (VFs) that can be allocated or
-			// moved between physical functions for this controller.
+			// MinAssignmentGroupSize shall be the minimum number of Virtual
+			// Functions (VFs) that can be allocated or moved between physical
+			// functions for this controller.
 			MinAssignmentGroupSize int
-			// NetworkPortMaxCount is The value of this property shall be the maximum
-			// number of Virtual Functions (VFs) supported per network port for this
-			// controller.
+			// NetworkPortMaxCount shall be the maximum number of Virtual
+			// Functions (VFs) supported per network port for this controller.
 			NetworkPortMaxCount int
 		}
 	}
 }
 
-// UnmarshalJSON unmarshals a ControllerCapabilities object from the raw JSON.
-func (controllercapabilities *ControllerCapabilities) UnmarshalJSON(b []byte) error {
-	type temp ControllerCapabilities
-	var t struct {
-		temp
-	}
-
-	err := json.Unmarshal(b, &t)
-	if err != nil {
-		return err
-	}
-
-	*controllercapabilities = ControllerCapabilities(t.temp)
-
-	// Extract the links to other entities for later
-
-	return nil
-}
-
-// Controller is This type shall describe a network controller ASIC that
-// makes up part of a NetworkAdapter.
-type Controller struct {
-	common.Entity
-
-	// ControllerCapabilities is The value of this property shall contain the
-	// capabilities of this controller.
+// Controllers shall describe a network controller ASIC that makes up part of a
+// NetworkAdapter.
+type Controllers struct {
+	// ControllerCapabilities shall contain the capabilities of this controller.
 	ControllerCapabilities ControllerCapabilities
-	// FirmwarePackageVersion is The value of this property shall be the
-	// version number of the user-facing firmware package.
+	// FirmwarePackageVersion shall be the version number of the user-facing
+	// firmware package.
 	FirmwarePackageVersion string
-	// NetworkDeviceFunctions is The value of this property shall be an array
-	// of references of type NetworkDeviceFunction that represent the Network
-	// Device Functions associated with this Network Controller.
-	networkDeviceFunctions []string
-	// NetworkDeviceFunctions@odata.count is
-	NetworkDeviceFunctionsCount int
-	// NetworkPorts is The value of this property shall be an array of
-	// references of type NetworkPort that represent the Network Ports
-	// associated with this Network Controller.
-	networkPorts []string
-	// NetworkPorts@odata.count is
-	NetworkPortsCount int
-	// PCIeDevices is The value of this property shall be an array of
-	// references of type PCIeDevice that represent the PCI-e Devices
-	// associated with this Network Controller.
-	pcieDevices []string
-	// PCIeDevices@odata.count is
-	PCIeDevicesCount int
-	// Location is This property shall contain location information of the
-	// associated network adapter controller.
+	// Location shall contain location information of the associated network
+	// adapter controller.
 	Location string
-	// PCIeInterface is used to connect this PCIe-based controller to its
-	// host.
-	PCIeInterface string
+	// pcieInterface is used to connect this PCIe-based controller to its host.
+	pcieInterface string
+	// NetworkDeviceFunctions shall be an array of references of type
+	// NetworkDeviceFunction that represent the Network Device Functions
+	// associated with this Network Controller.
+	networkDeviceFunctions []string
+	// NetworkDeviceFunctionsCount is the number of network device functions.
+	NetworkDeviceFunctionsCount int
+	// NetworkPorts shall be an array of references of type NetworkPort that
+	// represent the Network Ports associated with this Network Controller.
+	networkPorts []string
+	// NetworkPortsCount is the number of network ports.
+	NetworkPortsCount int
+	// PCIeDevices shall be an array of references of type PCIeDevice that
+	// represent the PCI-e Devices associated with this Network Controller.
+	pcieDevices []string
+	// PCIeDevicesCount is the number of PCIeDevices.
+	PCIeDevicesCount int
 }
 
-// UnmarshalJSON unmarshals a Controller object from the raw JSON.
-func (controller *Controller) UnmarshalJSON(b []byte) error {
-	type temp Controller
+// UnmarshalJSON unmarshals a Controllers object from the raw JSON.
+func (controllers *Controllers) UnmarshalJSON(b []byte) error {
+	type temp Controllers
 	type links struct {
 		NetworkPorts                common.Links
 		NetworkPortsCount           int `json:"EthernetInterfaces@odata.count"`
@@ -157,7 +128,8 @@ func (controller *Controller) UnmarshalJSON(b []byte) error {
 
 	var t struct {
 		temp
-		Links links
+		PCIeInterface common.Link
+		Links         links
 	}
 
 	err := json.Unmarshal(b, &t)
@@ -165,146 +137,82 @@ func (controller *Controller) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	*controller = Controller(t.temp)
-
 	// Extract the links to other entities for later
-	controller.networkPorts = t.Links.NetworkPorts.ToStrings()
-	controller.NetworkPortsCount = t.Links.NetworkPortsCount
-	controller.networkDeviceFunctions = t.Links.NetworkDeviceFunctions.ToStrings()
-	controller.NetworkDeviceFunctionsCount = t.Links.NetworkDeviceFunctionsCount
-	controller.pcieDevices = t.Links.NetworkDeviceFunctions.ToStrings()
-	controller.PCIeDevicesCount = t.Links.NetworkDeviceFunctionsCount
+	*controllers = Controllers(t.temp)
+	controllers.pcieInterface = string(t.PCIeInterface)
+	controllers.networkPorts = t.Links.NetworkPorts.ToStrings()
+	controllers.NetworkPortsCount = t.Links.NetworkPortsCount
+	controllers.networkDeviceFunctions = t.Links.NetworkDeviceFunctions.ToStrings()
+	controllers.NetworkDeviceFunctionsCount = t.Links.NetworkDeviceFunctionsCount
+	controllers.pcieDevices = t.Links.NetworkDeviceFunctions.ToStrings()
+	controllers.PCIeDevicesCount = t.Links.NetworkDeviceFunctionsCount
 
 	return nil
 }
 
-// NetworkDeviceFunctions gets an array of logical interface exposed by the
-// network adapter.
-func (controller *Controller) NetworkDeviceFunctions() ([]*NetworkDeviceFunction, error) {
-	var result []*NetworkDeviceFunction
-	for _, uri := range controller.networkDeviceFunctions {
-		n, err := GetNetworkDeviceFunction(controller.Client, uri)
-		if err != nil {
-			return nil, err
-		}
-
-		result = append(result, n)
-	}
-
-	return result, nil
+// DataCenterBridging shall describe the capability, status,
+// and configuration values related to Data Center Bridging (DCB) for a
+// controller.
+type DataCenterBridging struct {
+	// Capable shall be a boolean indicating whether this controller is capable
+	// of Data Center Bridging (DCB).
+	Capable bool
 }
 
-// GetControllers will get a NetworkAdapter instance from the Redfish service.
-func GetControllers(c common.Client, uri string) (*Controller, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var controller Controller
-	err = json.NewDecoder(resp.Body).Decode(&controller)
-	if err != nil {
-		return nil, err
-	}
-
-	controller.SetClient(c)
-	return &controller, nil
-}
-
-// ListReferencedControllers gets the collection of controllers from a provided reference.
-func ListReferencedControllers(c common.Client, link string) ([]*Controller, error) {
-	var result []*Controller
-	links, err := common.GetCollection(c, link)
-	if err != nil {
-		return result, err
-	}
-
-	for _, controllerLink := range links.ItemLinks {
-		controller, err := GetControllers(c, controllerLink)
-		if err != nil {
-			return result, err
-		}
-		result = append(result, controller)
-	}
-
-	return result, nil
-}
-
-// NPIV is This type shall contain N_Port ID Virtualization (NPIV)
-// capabilties for a controller.
+// NPIV shall contain N_Port ID Virtualization (NPIV) capabilties for a
+// controller.
 type NPIV struct {
-	common.Entity
+
+	// MaxDeviceLogins shall be the maximum number of N_Port ID Virtualization
+	// (NPIV) logins allowed simultaneously from all ports on this controller.
+	MaxDeviceLogins int
+	// MaxPortLogins shall be the maximum number of N_Port ID Virtualization
+	// (NPIV) logins allowed per physical port on this controller.
+	MaxPortLogins int
 }
 
-// UnmarshalJSON unmarshals a NPIV object from the raw JSON.
-func (npiv *NPIV) UnmarshalJSON(b []byte) error {
-	type temp NPIV
-	var t struct {
-		temp
-	}
-
-	err := json.Unmarshal(b, &t)
-	if err != nil {
-		return err
-	}
-
-	*npiv = NPIV(t.temp)
-
-	// Extract the links to other entities for later
-
-	return nil
-}
-
-// NetworkAdapter is A NetworkAdapter represents the physical network
-// adapter capable of connecting to a computer network. Examples include
-// but are not limited to Ethernet, Fibre Channel, and converged network
-// adapters.
+// A NetworkAdapter represents the physical network adapter capable of
+// connecting to a computer network. Examples include but are not limited to
+// Ethernet, Fibre Channel, and converged network adapters.
 type NetworkAdapter struct {
 	common.Entity
 
-	//// ODataContext is the odata context.
-	//ODataContext string `json:"@odata.context"`
-	//// ODataEtag is the odata etag.
-	//ODataEtag string `json:"@odata.etag"`
-	//// ODataID is the odata identifier.
-	//ODataId string `json:"@odata.id"`
-	//// ODataType is the odata type.
-	//ODataType string `json:"@odata.type"`
-	// Actions is The Actions property shall contain the available actions
-	// for this resource.
+	// ODataContext is the odata context.
+	ODataContext string `json:"@odata.context"`
+	// ODataEtag is the odata etag.
+	ODataEtag string `json:"@odata.etag"`
+	// ODataID is the odata identifier.
+	ODataID string `json:"@odata.id"`
+	// ODataType is the odata type.
+	ODataType string `json:"@odata.type"`
+	// The Actions property shall contain the available actions for this resource.
 	Actions string
-	// Assembly is The value of this property shall be a link to a resource
-	// of type Assembly.
+	// Assembly shall be a link to a resource of type Assembly.
 	assembly string
-	// Controller is The value of this property shall contain the set of
-	// network controllers ASICs that make up this NetworkAdapter.
-	Controllers []Controller
+	// Controllers shall contain the set of network controllers ASICs that make
+	// up this NetworkAdapter.
+	Controllers []Controllers
 	// Description provides a description of this resource.
 	Description string
-	// Manufacturer is The value of this property shall contain a value that
-	// represents the manufacturer of the network adapter.
+	// Manufacturer shall contain a value that represents the manufacturer of
+	// the network adapter.
 	Manufacturer string
-	// Model is The value of this property shall contain the information
-	// about how the manufacturer references this network adapter.
+	// Model shall contain the information about how the manufacturer references
+	// this network adapter.
 	Model string
-	// NetworkDeviceFunctions is The value of this property shall be a link
-	// to a collection of type NetworkDeviceFunctionCollection.
+	// NetworkDeviceFunctions shall be a link to a collection of type
+	// NetworkDeviceFunctionCollection.
 	networkDeviceFunctions string
-	// NetworkPorts is The value of this property shall be a link to a
-	// collection of type NetworkPortCollection.
+	// NetworkPorts shall be a link to a collection of type NetworkPortCollection.
 	networkPorts string
-	// PartNumber is The value of this property shall contain the part number
-	// for the network adapter as defined by the manufacturer.
+	// PartNumber shall contain the part number for the network adapter as
+	// defined by the manufacturer.
 	PartNumber string
-	// SKU is The value of this property shall contain the Stock Keeping Unit
-	// (SKU) for the network adapter.
+	// SKU shall contain the Stock Keeping Unit (SKU) for the network adapter.
 	SKU string
-	// SerialNumber is The value of this property shall contain the serial
-	// number for the network adapter.
+	// SerialNumber shall contain the serial number for the network adapter.
 	SerialNumber string
-	// Status is This property shall contain any status or health properties
-	// of the resource.
+	// Status shall contain any status or health properties of the resource.
 	Status common.Status
 }
 
@@ -331,26 +239,6 @@ func (networkadapter *NetworkAdapter) UnmarshalJSON(b []byte) error {
 
 	return nil
 }
-
-// NetworkDeviceFunctions gets the collection of NetworkDeviceFunctions of this network adapter
-func (networkadapter *NetworkAdapter) NetworkDeviceFunctions() ([]*NetworkDeviceFunction, error) {
-	return ListReferencedNetworkDeviceFunctions(networkadapter.Client, networkadapter.networkDeviceFunctions)
-}
-
-//// Controller gets the collection of controllers of this network adapter
-//func (networkadapter *NetworkAdapter) Controller() ([]*Controller, error) {
-//	var result []*Controller
-//	for _, uri := range networkadapter.controllers {
-//		c, err := GetControllers(networkadapter.Client, uri)
-//		if err != nil {
-//			return nil, err
-//		}
-//
-//		result = append(result, c)
-//	}
-//
-//	return result, nil
-//}
 
 // GetNetworkAdapter will get a NetworkAdapter instance from the Redfish service.
 func GetNetworkAdapter(c common.Client, uri string) (*NetworkAdapter, error) {
@@ -389,27 +277,20 @@ func ListReferencedNetworkAdapter(c common.Client, link string) ([]*NetworkAdapt
 	return result, nil
 }
 
-// NicPartitioning is This type shall contain the capability, status, and
-// configuration values for a controller.
-type NicPartitioning struct {
-	common.Entity
+// Assembly gets this adapter's assembly.
+func (networkadapter *NetworkAdapter) Assembly() (*Assembly, error) {
+	if networkadapter.assembly == "" {
+		return nil, nil
+	}
+	return GetAssembly(networkadapter.Client, networkadapter.assembly)
 }
 
-// UnmarshalJSON unmarshals a NicPartitioning object from the raw JSON.
-func (nicpartitioning *NicPartitioning) UnmarshalJSON(b []byte) error {
-	type temp NicPartitioning
-	var t struct {
-		temp
-	}
+// NetworkDeviceFunctions gets the collection of NetworkDeviceFunctions of this network adapter
+func (networkadapter *NetworkAdapter) NetworkDeviceFunctions() ([]*NetworkDeviceFunction, error) {
+	return ListReferencedNetworkDeviceFunctions(networkadapter.Client, networkadapter.networkDeviceFunctions)
+}
 
-	err := json.Unmarshal(b, &t)
-	if err != nil {
-		return err
-	}
-
-	*nicpartitioning = NicPartitioning(t.temp)
-
-	// Extract the links to other entities for later
-
-	return nil
+// NetworkPorts gets the collection of NetworkPorts for this network adapter
+func (networkadapter *NetworkAdapter) NetworkPorts() ([]*NetworkPort, error) {
+	return ListReferencedNetworkPorts(networkadapter.Client, networkadapter.networkPorts)
 }

--- a/school/redfish/networkinterface.go
+++ b/school/redfish/networkinterface.go
@@ -1,0 +1,143 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redfish
+
+import (
+	"encoding/json"
+
+	"github.com/stmcginnis/gofish/school/common"
+)
+
+// NetworkInterfaceLinks references to resources that are related to, but not
+// contained by (subordinate to), this resource.
+type NetworkInterfaceLinks struct {
+	// NetworkAdapter shall be a reference to a
+	// resource of type NetworkAdapter that represents the physical container
+	// associated with this NetworkInterface.
+	NetworkAdapter common.Link
+}
+
+// A NetworkInterface contains references linking NetworkAdapter, NetworkPort,
+// and NetworkDeviceFunction resources and represents the functionality
+// available to the containing system.
+type NetworkInterface struct {
+	common.Entity
+
+	// ODataContext is the odata context.
+	ODataContext string `json:"@odata.context"`
+	// ODataEtag is the odata etag.
+	ODataEtag string `json:"@odata.etag"`
+	// ODataID is the odata identifier.
+	ODataID string `json:"@odata.id"`
+	// ODataType is the odata type.
+	ODataType string `json:"@odata.type"`
+	// Description provides a description of this resource.
+	Description string
+	// networkAdapter shall be a reference to a resource of type NetworkAdapter
+	// that represents the physical container associated with this NetworkInterface.
+	networkAdapter string
+	// networkDeviceFunctions shall be a link to a collection of type
+	// NetworkDeviceFunctionCollection.
+	networkDeviceFunctions string
+	// NetworkPorts shall be a link to a collection of type NetworkPortCollection.
+	networkPorts string
+	// Status shall contain any status or health properties of the resource.
+	Status common.Status
+}
+
+// UnmarshalJSON unmarshals a NetworkInterface object from the raw JSON.
+func (networkinterface *NetworkInterface) UnmarshalJSON(b []byte) error {
+	type temp NetworkInterface
+	var t struct {
+		temp
+		NetworkDeviceFunctions common.Link
+		NetworkPorts           common.Link
+		Links                  NetworkInterfaceLinks
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	// Extract the links to other entities for later
+	*networkinterface = NetworkInterface(t.temp)
+	networkinterface.networkAdapter = string(t.Links.NetworkAdapter)
+	networkinterface.networkDeviceFunctions = string(t.NetworkDeviceFunctions)
+	networkinterface.networkPorts = string(t.NetworkPorts)
+
+	return nil
+}
+
+// GetNetworkInterface will get a NetworkInterface instance from the service.
+func GetNetworkInterface(c common.Client, uri string) (*NetworkInterface, error) {
+	resp, err := c.Get(uri)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var networkinterface NetworkInterface
+	err = json.NewDecoder(resp.Body).Decode(&networkinterface)
+	if err != nil {
+		return nil, err
+	}
+
+	networkinterface.SetClient(c)
+	return &networkinterface, nil
+}
+
+// ListReferencedNetworkInterfaces gets the collection of NetworkInterface from
+// a provided reference.
+func ListReferencedNetworkInterfaces(c common.Client, link string) ([]*NetworkInterface, error) {
+	var result []*NetworkInterface
+	if link == "" {
+		return result, nil
+	}
+
+	links, err := common.GetCollection(c, link)
+	if err != nil {
+		return result, err
+	}
+
+	for _, networkinterfaceLink := range links.ItemLinks {
+		networkinterface, err := GetNetworkInterface(c, networkinterfaceLink)
+		if err != nil {
+			return result, err
+		}
+		result = append(result, networkinterface)
+	}
+
+	return result, nil
+}
+
+// NetworkAdapter gets the NetworkAdapter for this interface.
+func (networkinterface *NetworkInterface) NetworkAdapter() (*NetworkAdapter, error) {
+	if networkinterface.networkAdapter == "" {
+		return nil, nil
+	}
+
+	return GetNetworkAdapter(networkinterface.Client, networkinterface.networkAdapter)
+}
+
+// NetworkDeviceFunctions gets the collection of NetworkDeviceFunctions of this network interface
+func (networkinterface *NetworkInterface) NetworkDeviceFunctions() ([]*NetworkDeviceFunction, error) {
+	return ListReferencedNetworkDeviceFunctions(
+		networkinterface.Client, networkinterface.networkDeviceFunctions)
+}
+
+// NetworkPorts gets the collection of NetworkPorts of this network interface
+func (networkinterface *NetworkInterface) NetworkPorts() ([]*NetworkPort, error) {
+	return ListReferencedNetworkPorts(
+		networkinterface.Client, networkinterface.networkPorts)
+}

--- a/school/redfish/networkport.go
+++ b/school/redfish/networkport.go
@@ -39,13 +39,13 @@ const (
 type LinkNetworkTechnology string
 
 const (
-	// EthernetLinkNetworkTechnology The port is capable of connecting to an
+	// EthernetLinkNetworkTechnology means the port is capable of connecting to an
 	// Ethernet network.
 	EthernetLinkNetworkTechnology LinkNetworkTechnology = "Ethernet"
-	// InfiniBandLinkNetworkTechnology The port is capable of connecting to
+	// InfiniBandLinkNetworkTechnology means the port is capable of connecting to
 	// an InfiniBand network.
 	InfiniBandLinkNetworkTechnology LinkNetworkTechnology = "InfiniBand"
-	// FibreChannelLinkNetworkTechnology The port is capable of connecting to
+	// FibreChannelLinkNetworkTechnology means the port is capable of connecting to
 	// a Fibre Channel network.
 	FibreChannelLinkNetworkTechnology LinkNetworkTechnology = "FibreChannel"
 )
@@ -54,23 +54,23 @@ const (
 type PortConnectionType string
 
 const (
-	// NotConnectedPortConnectionType This port is not connected.
+	// NotConnectedPortConnectionType means this port is not connected.
 	NotConnectedPortConnectionType PortConnectionType = "NotConnected"
-	// NPortPortConnectionType This port connects via an N-Port to a switch.
+	// NPortPortConnectionType means this port connects via an N-Port to a switch.
 	NPortPortConnectionType PortConnectionType = "NPort"
-	// PointToPointPortConnectionType This port connects in a Point-to-point
+	// PointToPointPortConnectionType means this port connects in a Point-to-point
 	// configuration.
 	PointToPointPortConnectionType PortConnectionType = "PointToPoint"
-	// PrivateLoopPortConnectionType This port connects in a private loop
+	// PrivateLoopPortConnectionType means this port connects in a private loop
 	// configuration.
 	PrivateLoopPortConnectionType PortConnectionType = "PrivateLoop"
-	// PublicLoopPortConnectionType This port connects in a public
+	// PublicLoopPortConnectionType means this port connects in a public
 	// configuration.
 	PublicLoopPortConnectionType PortConnectionType = "PublicLoop"
-	// GenericPortConnectionType This port connection type is a generic
+	// GenericPortConnectionType means this port connection type is a generic
 	// fabric port.
 	GenericPortConnectionType PortConnectionType = "Generic"
-	// ExtenderFabricPortConnectionType This port connection type is an
+	// ExtenderFabricPortConnectionType means this port connection type is an
 	// extender fabric port.
 	ExtenderFabricPortConnectionType PortConnectionType = "ExtenderFabric"
 )
@@ -87,81 +87,39 @@ const (
 	EEESupportedEthernetCapabilities SupportedEthernetCapabilities = "EEE"
 )
 
-// NetDevFuncMaxBWAlloc is This type shall describe a maximum bandwidth
+// NetDevFuncMaxBWAlloc shall describe a maximum bandwidth
 // percentage allocation for a network device function associated with a
 // port.
 type NetDevFuncMaxBWAlloc struct {
-	common.Entity
-
-	// MaxBWAllocPercent is The value of this property shall be the maximum
+	// MaxBWAllocPercent shall be the maximum
 	// bandwidth percentage allocation for the associated network device
 	// function.
 	MaxBWAllocPercent int
-	// NetworkDeviceFunction is The value of this property shall be a
+	// NetworkDeviceFunction shall be a
 	// reference of type NetworkDeviceFunction that represents the Network
 	// Device Function associated with this bandwidth setting of this Network
 	// Port.
 	NetworkDeviceFunction string
 }
 
-// UnmarshalJSON unmarshals a NetDevFuncMaxBWAlloc object from the raw JSON.
-func (netdevfuncmaxbwalloc *NetDevFuncMaxBWAlloc) UnmarshalJSON(b []byte) error {
-	type temp NetDevFuncMaxBWAlloc
-	var t struct {
-		temp
-	}
-
-	err := json.Unmarshal(b, &t)
-	if err != nil {
-		return err
-	}
-
-	*netdevfuncmaxbwalloc = NetDevFuncMaxBWAlloc(t.temp)
-
-	// Extract the links to other entities for later
-
-	return nil
-}
-
-// NetDevFuncMinBWAlloc is This type shall describe a minimum bandwidth
+// NetDevFuncMinBWAlloc shall describe a minimum bandwidth
 // percentage allocation for a network device function associated with a
 // port.
 type NetDevFuncMinBWAlloc struct {
-	common.Entity
-
-	// MinBWAllocPercent is The value of this property shall be the minimum
+	// MinBWAllocPercent shall be the minimum
 	// bandwidth percentage allocation for the associated network device
 	// function. The sum total of all minimum percentages shall not exceed
 	// 100.
 	MinBWAllocPercent int
-	// NetworkDeviceFunction is The value of this property shall be a
+	// NetworkDeviceFunction shall be a
 	// reference of type NetworkDeviceFunction that represents the Network
 	// Device Function associated with this bandwidth setting of this Network
 	// Port.
 	NetworkDeviceFunction string
 }
 
-// UnmarshalJSON unmarshals a NetDevFuncMinBWAlloc object from the raw JSON.
-func (netdevfuncminbwalloc *NetDevFuncMinBWAlloc) UnmarshalJSON(b []byte) error {
-	type temp NetDevFuncMinBWAlloc
-	var t struct {
-		temp
-	}
-
-	err := json.Unmarshal(b, &t)
-	if err != nil {
-		return err
-	}
-
-	*netdevfuncminbwalloc = NetDevFuncMinBWAlloc(t.temp)
-
-	// Extract the links to other entities for later
-
-	return nil
-}
-
-// NetworkPort is A Network Port represents a discrete physical port
-// capable of connecting to a network.
+// NetworkPort represents a discrete physical port capable of connecting to a
+// network.
 type NetworkPort struct {
 	common.Entity
 
@@ -176,76 +134,76 @@ type NetworkPort struct {
 	// Actions is The Actions property shall contain the available actions
 	// for this resource.
 	Actions string
-	// ActiveLinkTechnology is The value of this property shall be the
+	// ActiveLinkTechnology shall be the
 	// configured link technology of this port.
 	ActiveLinkTechnology LinkNetworkTechnology
-	// AssociatedNetworkAddresses is The value of this property shall be an
+	// AssociatedNetworkAddresses shall be an
 	// array of configured network addresses that are associated with this
 	// network port, including the programmed address of the lowest numbered
 	// network device function, the configured but not active address if
 	// applicable, the address for hardware port teaming, or other network
 	// addresses.
 	AssociatedNetworkAddresses []string
-	// CurrentLinkSpeedMbps is The value of this property shall be the
+	// CurrentLinkSpeedMbps shall be the
 	// current configured link speed of this port.
 	CurrentLinkSpeedMbps int
 	// Description provides a description of this resource.
 	Description string
-	// EEEEnabled is The value of this property shall be a boolean indicating
+	// EEEEnabled shall be a boolean indicating
 	// whether IEEE 802.3az Energy Efficient Ethernet (EEE) is enabled for
 	// this network port.
 	EEEEnabled bool
-	// FCFabricName is This property shall indicate the FC Fabric Name
+	// FCFabricName shall indicate the FC Fabric Name
 	// provided by the switch.
 	FCFabricName string
-	// FCPortConnectionType is The value of this property shall be the
+	// FCPortConnectionType shall be the
 	// connection type for this port.
 	FCPortConnectionType PortConnectionType
-	// FlowControlConfiguration is The value of this property shall be the
+	// FlowControlConfiguration shall be the
 	// locally configured 802.3x flow control setting for this network port.
 	FlowControlConfiguration FlowControl
-	// FlowControlStatus is The value of this property shall be the 802.3x
+	// FlowControlStatus shall be the 802.3x
 	// flow control behavior negotiated with the link partner for this
 	// network port (Ethernet-only).
 	FlowControlStatus FlowControl
-	// LinkStatus is The value of this property shall be the link status
+	// LinkStatus shall be the link status
 	// between this port and its link partner.
 	LinkStatus LinkStatus
-	// MaxFrameSize is The value of this property shall be the maximum frame
+	// MaxFrameSize shall be the maximum frame
 	// size supported by the port.
 	MaxFrameSize int
-	// NetDevFuncMaxBWAlloc is The value of this property shall be an array
+	// NetDevFuncMaxBWAlloc shall be an array
 	// of maximum bandwidth allocation percentages for the Network Device
 	// Functions associated with this port.
 	NetDevFuncMaxBWAlloc []NetDevFuncMaxBWAlloc
-	// NetDevFuncMinBWAlloc is The value of this property shall be an array
+	// NetDevFuncMinBWAlloc shall be an array
 	// of minimum bandwidth percentage allocations for each of the network
 	// device functions associated with this port.
 	NetDevFuncMinBWAlloc []NetDevFuncMinBWAlloc
-	// NumberDiscoveredRemotePorts is The value of this property shall be the
+	// NumberDiscoveredRemotePorts shall be the
 	// number of ports not on this adapter that this port has discovered.
 	NumberDiscoveredRemotePorts int
 	// Oem is The value of this string shall be of the format for the
 	// reserved word *Oem*.
 	OEM string `json:"Oem"`
-	// PhysicalPortNumber is The value of this property shall be the physical
+	// PhysicalPortNumber shall be the physical
 	// port number on the network adapter hardware that this Network Port
 	// corresponds to. This value should match a value visible on the
 	// hardware. When HostPortEnabled and ManagementPortEnabled are both
 	// "false", the port shall not establish physical link.
 	PhysicalPortNumber string
-	// PortMaximumMTU is The value of this property shall be the largest
+	// PortMaximumMTU shall be the largest
 	// maximum transmission unit (MTU) that can be configured for this
 	// network port.
 	PortMaximumMTU int
-	// SignalDetected is The value of this property shall be a boolean
+	// SignalDetected shall be a boolean
 	// indicating whether the port has detected enough signal on enough lanes
 	// to establish link.
 	SignalDetected bool
-	// Status is This property shall contain any status or health properties
+	// Status shall contain any status or health properties
 	// of the resource.
 	Status common.Status
-	// SupportedEthernetCapabilities is The value of this property shall be
+	// SupportedEthernetCapabilities shall be
 	// an array of zero or more Ethernet capabilities supported by this port.
 	SupportedEthernetCapabilities []SupportedEthernetCapabilities
 	// SupportedLinkCapabilities is This object shall describe the static
@@ -256,7 +214,7 @@ type NetworkPort struct {
 	// VendorID shall indicate the Vendor Identification string information as
 	// provided by the manufacturer of this port.
 	VendorID string `json:"VendorId"`
-	// WakeOnLANEnabled is The value of this property shall be a boolean
+	// WakeOnLANEnabled shall be a boolean
 	// indicating whether Wake on LAN (WoL) is enabled for this network port.
 	WakeOnLANEnabled bool
 }
@@ -280,39 +238,60 @@ func (networkport *NetworkPort) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// SupportedLinkCapabilities is This type shall describe the static
+// GetNetworkPort will get a NetworkPort instance from the service.
+func GetNetworkPort(c common.Client, uri string) (*NetworkPort, error) {
+	resp, err := c.Get(uri)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var networkport NetworkPort
+	err = json.NewDecoder(resp.Body).Decode(&networkport)
+	if err != nil {
+		return nil, err
+	}
+
+	networkport.SetClient(c)
+	return &networkport, nil
+}
+
+// ListReferencedNetworkPorts gets the collection of NetworkPort from
+// a provided reference.
+func ListReferencedNetworkPorts(c common.Client, link string) ([]*NetworkPort, error) {
+	var result []*NetworkPort
+	if link == "" {
+		return result, nil
+	}
+
+	links, err := common.GetCollection(c, link)
+	if err != nil {
+		return result, err
+	}
+
+	for _, networkportLink := range links.ItemLinks {
+		networkport, err := GetNetworkPort(c, networkportLink)
+		if err != nil {
+			return result, err
+		}
+		result = append(result, networkport)
+	}
+
+	return result, nil
+}
+
+// SupportedLinkCapabilities shall describe the static
 // capabilities of an associated port, irrespective of transient
 // conditions such as cabling, interface module presence, or remote link
 // parter status or configuration.
 type SupportedLinkCapabilities struct {
-	common.Entity
-
-	// AutoSpeedNegotiation is The value of this property shall be indicate
+	// AutoSpeedNegotiation shall be indicate
 	// whether the port is capable of auto-negotiating speed.
 	AutoSpeedNegotiation bool
-	// CapableLinkSpeedMbps is The value of this property shall be all of the
+	// CapableLinkSpeedMbps shall be all of the
 	// possible network link speed capabilities of this port.
 	CapableLinkSpeedMbps []string
-	// LinkNetworkTechnology is The value of this property shall be a network
+	// LinkNetworkTechnology shall be a network
 	// technology capability of this port.
 	LinkNetworkTechnology LinkNetworkTechnology
-}
-
-// UnmarshalJSON unmarshals a SupportedLinkCapabilities object from the raw JSON.
-func (supportedlinkcapabilities *SupportedLinkCapabilities) UnmarshalJSON(b []byte) error {
-	type temp SupportedLinkCapabilities
-	var t struct {
-		temp
-	}
-
-	err := json.Unmarshal(b, &t)
-	if err != nil {
-		return err
-	}
-
-	*supportedlinkcapabilities = SupportedLinkCapabilities(t.temp)
-
-	// Extract the links to other entities for later
-
-	return nil
 }

--- a/school/redfish/secureboot.go
+++ b/school/redfish/secureboot.go
@@ -1,0 +1,128 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redfish
+
+import (
+	"encoding/json"
+
+	"github.com/stmcginnis/gofish/school/common"
+)
+
+// ResetKeysType is method for resetting keys.
+type ResetKeysType string
+
+const (
+	// ResetAllKeysToDefaultResetKeysType Reset the content of all UEFI
+	// Secure Boot key databases (PK, KEK, DB, DBX) to their default values.
+	ResetAllKeysToDefaultResetKeysType ResetKeysType = "ResetAllKeysToDefault"
+	// DeleteAllKeysResetKeysType Delete the content of all UEFI Secure Boot
+	// key databases (PK, KEK, DB, DBX). This puts the system in Setup Mode.
+	DeleteAllKeysResetKeysType ResetKeysType = "DeleteAllKeys"
+	// DeletePKResetKeysType Delete the content of the PK UEFI Secure Boot
+	// database. This puts the system in Setup Mode.
+	DeletePKResetKeysType ResetKeysType = "DeletePK"
+)
+
+// SecureBootCurrentBootType is the type of secure boot.
+type SecureBootCurrentBootType string
+
+const (
+
+	// EnabledSecureBootCurrentBootType Secure Boot is currently enabled.
+	EnabledSecureBootCurrentBootType SecureBootCurrentBootType = "Enabled"
+	// DisabledSecureBootCurrentBootType Secure Boot is currently disabled.
+	DisabledSecureBootCurrentBootType SecureBootCurrentBootType = "Disabled"
+)
+
+// SecureBootModeType is the boot mode.
+type SecureBootModeType string
+
+const (
+
+	// SetupModeSecureBootModeType Secure Boot is currently in Setup Mode.
+	SetupModeSecureBootModeType SecureBootModeType = "SetupMode"
+	// UserModeSecureBootModeType Secure Boot is currently in User Mode.
+	UserModeSecureBootModeType SecureBootModeType = "UserMode"
+	// AuditModeSecureBootModeType Secure Boot is currently in Audit Mode.
+	AuditModeSecureBootModeType SecureBootModeType = "AuditMode"
+	// DeployedModeSecureBootModeType Secure Boot is currently in Deployed
+	// Mode.
+	DeployedModeSecureBootModeType SecureBootModeType = "DeployedMode"
+)
+
+// SecureBoot is used to represent a UEFI Secure Boot resource.
+type SecureBoot struct {
+	common.Entity
+
+	// ODataContext is the odata context.
+	ODataContext string `json:"@odata.context"`
+	// ODataEtag is the odata etag.
+	ODataEtag string `json:"@odata.etag"`
+	// ODataID is the odata identifier.
+	ODataID string `json:"@odata.id"`
+	// ODataType is the odata type.
+	ODataType string `json:"@odata.type"`
+	// Description provides a description of this resource.
+	Description string
+	// SecureBootCurrentBoot shall indicate the UEFI Secure Boot state during
+	// the current boot cycle.
+	SecureBootCurrentBoot SecureBootCurrentBootType
+	// SecureBootEnable set to true enables UEFI Secure Boot, and setting it to
+	// false disables it. This property can be enabled only in UEFI boot mode.
+	SecureBootEnable bool
+	// SecureBootMode shall contain the current Secure Boot mode, as defined in
+	// the UEFI Specification.
+	SecureBootMode SecureBootModeType
+}
+
+// GetSecureBoot will get a SecureBoot instance from the service.
+func GetSecureBoot(c common.Client, uri string) (*SecureBoot, error) {
+	resp, err := c.Get(uri)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var secureboot SecureBoot
+	err = json.NewDecoder(resp.Body).Decode(&secureboot)
+	if err != nil {
+		return nil, err
+	}
+
+	secureboot.SetClient(c)
+	return &secureboot, nil
+}
+
+// ListReferencedSecureBoots gets the collection of SecureBoot from
+// a provided reference.
+func ListReferencedSecureBoots(c common.Client, link string) ([]*SecureBoot, error) {
+	var result []*SecureBoot
+	if link == "" {
+		return result, nil
+	}
+
+	links, err := common.GetCollection(c, link)
+	if err != nil {
+		return result, err
+	}
+
+	for _, securebootLink := range links.ItemLinks {
+		secureboot, err := GetSecureBoot(c, securebootLink)
+		if err != nil {
+			return result, err
+		}
+		result = append(result, secureboot)
+	}
+
+	return result, nil
+}

--- a/school/redfish/simplestorage.go
+++ b/school/redfish/simplestorage.go
@@ -1,0 +1,140 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redfish
+
+import (
+	"encoding/json"
+
+	"github.com/stmcginnis/gofish/school/common"
+)
+
+// Device shall describe a storage device visible to SimpleStorage.
+type Device struct {
+	// CapacityBytes shall represent the size (in bytes) of the Storage Device.
+	CapacityBytes int64
+	// Manufacturer shall indicate the name of the manufacturer of this storage device.
+	Manufacturer string
+	// Model shall indicate the model information as provided by the manufacturer
+	// of this storage device.
+	Model string
+	// Status shall contain any status or health properties
+	// of the resource.
+	Status common.Status
+}
+
+// SimpleStorage is used to represent a storage controller and its
+// directly-attached devices.
+type SimpleStorage struct {
+	common.Entity
+
+	// ODataContext is the odata context.
+	ODataContext string `json:"@odata.context"`
+	// ODataEtag is the odata etag.
+	ODataEtag string `json:"@odata.etag"`
+	// ODataID is the odata identifier.
+	ODataID string `json:"@odata.id"`
+	// ODataType is the odata type.
+	ODataType string `json:"@odata.type"`
+	// Actions is The Actions property shall contain the available actions
+	// for this resource.
+	Actions string
+	// Description provides a description of this resource.
+	Description string
+	// Devices shall contain a list of storage devices
+	// associated with this resource.
+	Devices []Device
+	// Status shall contain any status or health properties
+	// of the resource.
+	Status common.Status
+	// UefiDevicePath is used to identify and locate the specific storage
+	// controller.
+	UefiDevicePath string
+	// chassis shall be a reference to a resource of type Chassis that
+	// represent the physical container associated with this Simple Storage.
+	chassis string
+}
+
+// UnmarshalJSON unmarshals a SimpleStorage object from the raw JSON.
+func (simplestorage *SimpleStorage) UnmarshalJSON(b []byte) error {
+	type temp SimpleStorage
+	var t struct {
+		temp
+		Links struct {
+			// Chassis shall be a reference to a resource of type Chassis that
+			// represent the physical container associated with this Simple Storage.
+			Chassis common.Link
+		}
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	// Extract the links to other entities for later
+	*simplestorage = SimpleStorage(t.temp)
+	simplestorage.chassis = string(t.Links.Chassis)
+
+	return nil
+}
+
+// GetSimpleStorage will get a SimpleStorage instance from the service.
+func GetSimpleStorage(c common.Client, uri string) (*SimpleStorage, error) {
+	resp, err := c.Get(uri)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var simplestorage SimpleStorage
+	err = json.NewDecoder(resp.Body).Decode(&simplestorage)
+	if err != nil {
+		return nil, err
+	}
+
+	simplestorage.SetClient(c)
+	return &simplestorage, nil
+}
+
+// ListReferencedSimpleStorages gets the collection of SimpleStorage from
+// a provided reference.
+func ListReferencedSimpleStorages(c common.Client, link string) ([]*SimpleStorage, error) {
+	var result []*SimpleStorage
+	if link == "" {
+		return result, nil
+	}
+
+	links, err := common.GetCollection(c, link)
+	if err != nil {
+		return result, err
+	}
+
+	for _, simplestorageLink := range links.ItemLinks {
+		simplestorage, err := GetSimpleStorage(c, simplestorageLink)
+		if err != nil {
+			return result, err
+		}
+		result = append(result, simplestorage)
+	}
+
+	return result, nil
+}
+
+// Chassis gets the chassis containing this storage service.
+func (simplestorage *SimpleStorage) Chassis() (*Chassis, error) {
+	if simplestorage.chassis == "" {
+		return nil, nil
+	}
+
+	return GetChassis(simplestorage.Client, simplestorage.chassis)
+}


### PR DESCRIPTION
This adds the following objects:

* Bios
* LogEntry
* LogService
* MemoryDomain
* NetworkInterface
* SecureBoot
* SimpleStorage

It also adds access methods for links to these objects from the
ComputerSystem object, as well as other existing objects that did not
have an access method implemented yet.

Closes #19