### PR TITLE
Fix various type errors with Thermal, Redundancy, and Power

### DIFF
--- a/school/redfish/power.go
+++ b/school/redfish/power.go
@@ -92,19 +92,19 @@ type InputRange struct {
 	InputType InputType
 	// MaximumFrequencyHz shall contain the value in Hertz of the maximum line
 	// input frequency which the power supply is capable of consuming for this range.
-	MaximumFrequencyHz int
+	MaximumFrequencyHz float32
 	// MaximumVoltage shall contain the value in Volts of the maximum line input
 	// voltage which the power supply is capable of consuming for this range.
-	MaximumVoltage int
+	MaximumVoltage float32
 	// MinimumFrequencyHz shall contain the value in Hertz of the minimum line
 	// input frequency which the power supply is capable of consuming for this range.
-	MinimumFrequencyHz int
+	MinimumFrequencyHz float32
 	// MinimumVoltage shall contain the value in Volts of the minimum line input
 	// voltage which the power supply is capable of consuming for this range.
-	MinimumVoltage int
+	MinimumVoltage float32
 	// OutputWattage shall contiain the maximum amount of power, in Watts, that
 	// the associated power supply is rated to deliver while operating in this input range.
-	OutputWattage int
+	OutputWattage float32
 }
 
 // Power is used to represent a power metrics resource for a Redfish
@@ -201,17 +201,17 @@ type PowerControl struct {
 	PhysicalContext common.PhysicalContext
 	// PowerAllocatedWatts shall represent the total power currently allocated
 	// to chassis resources.
-	PowerAllocatedWatts int
+	PowerAllocatedWatts float32
 	// PowerAvailableWatts shall represent the amount of power capacity (in
 	// Watts) not already allocated and shall equal PowerCapacityWatts -
 	// PowerAllocatedWatts.
-	PowerAvailableWatts int
+	PowerAvailableWatts float32
 	// PowerCapacityWatts shall represent the total power capacity that is
 	// available for allocation to the chassis resources.
-	PowerCapacityWatts int
+	PowerCapacityWatts float32
 	// PowerConsumedWatts shall represent the actual power being consumed (in
 	// Watts) by the chassis.
-	PowerConsumedWatts int
+	PowerConsumedWatts float32
 	// PowerLimit shall contain power limit status and configuration information
 	// for this chassis.
 	PowerLimit PowerLimit
@@ -221,7 +221,7 @@ type PowerControl struct {
 	// PowerRequestedWatts shall represent the
 	// amount of power (in Watts) that the chassis resource is currently
 	// requesting be budgeted to it for future use.
-	PowerRequestedWatts int
+	PowerRequestedWatts float32
 	// Status shall contain any status or health properties
 	// of the resource.
 	Status common.Status
@@ -242,7 +242,7 @@ type PowerLimit struct {
 	// LimitInWatts shall represent the power
 	// cap limit in watts for the resource. If set to null, power capping
 	// shall be disabled.
-	LimitInWatts int
+	LimitInWatts float32
 }
 
 // PowerMetric shall contain power metrics for power
@@ -252,7 +252,7 @@ type PowerMetric struct {
 	// AverageConsumedWatts shall represent the
 	// average power level that occurred averaged over the last IntervalInMin
 	// minutes.
-	AverageConsumedWatts int
+	AverageConsumedWatts float32
 	// IntervalInMin shall represent the time
 	// interval (or window), in minutes, in which the PowerMetrics properties
 	// are measured over.
@@ -260,11 +260,11 @@ type PowerMetric struct {
 	// MaxConsumedWatts shall represent the
 	// maximum power level in watts that occurred within the last
 	// IntervalInMin minutes.
-	MaxConsumedWatts int
+	MaxConsumedWatts float32
 	// MinConsumedWatts shall represent the
 	// minimum power level in watts that occurred within the last
 	// IntervalInMin minutes.
-	MinConsumedWatts int
+	MinConsumedWatts float32
 }
 
 // PowerSupply is Details of a power supplies associated with this system
@@ -296,11 +296,11 @@ type PowerSupply struct {
 	InputRanges []InputRange
 	// LastPowerOutputWatts shall contain the average power
 	// output, measured in Watts, of the associated power supply.
-	LastPowerOutputWatts int
+	LastPowerOutputWatts float32
 	// LineInputVoltage shall contain the value in Volts of
 	// the line input voltage (measured or configured for) that the power
 	// supply has been configured to operate with or is currently receiving.
-	LineInputVoltage int
+	LineInputVoltage float32
 	// LineInputVoltageType shall contain the type of input
 	// line voltage supported by the associated power supply.
 	LineInputVoltageType LineInputVoltageType
@@ -325,13 +325,13 @@ type PowerSupply struct {
 	// PowerCapacityWatts shall contiain the maximum amount
 	// of power, in Watts, that the associated power supply is rated to
 	// deliver.
-	PowerCapacityWatts int
+	PowerCapacityWatts float32
 	// PowerInputWatts shall contain the value of the
 	// measured input power, in Watts, of the associated power supply.
-	PowerInputWatts int
+	PowerInputWatts float32
 	// PowerOutputWatts shall contain the value of the
 	// measured output power, in Watts, of the associated power supply.
-	PowerOutputWatts int
+	PowerOutputWatts float32
 	// PowerSupplyType shall contain the input power type
 	// (AC or DC) of the associated power supply.
 	PowerSupplyType PowerSupplyType
@@ -380,33 +380,33 @@ type Voltage struct {
 	// LowerThresholdCritical shall indicate
 	// the present reading is below the normal range but is not yet fatal.
 	// Units shall use the same units as the related ReadingVolts propoerty.
-	LowerThresholdCritical int
+	LowerThresholdCritical float32
 	// LowerThresholdFatal shall indicate the
 	// present reading is below the normal range and is fatal. Units shall
 	// use the same units as the related ReadingVolts propoerty.
-	LowerThresholdFatal int
+	LowerThresholdFatal float32
 	// LowerThresholdNonCritical shall indicate
 	// the present reading is below the normal range but is not critical.
 	// Units shall use the same units as the related ReadingVolts propoerty.
-	LowerThresholdNonCritical int
+	LowerThresholdNonCritical float32
 	// MaxReadingRange shall indicate the
 	// highest possible value for ReadingVolts. Units shall use the same
 	// units as the related ReadingVolts propoerty.
-	MaxReadingRange int
+	MaxReadingRange float32
 	// MemberID shall uniquely identify the member within the collection. For
 	// services supporting Redfish v1.6 or higher, this value shall be the
 	// zero-based array index.
 	MemberID string `json:"MemberId"`
 	// MinReadingRange shall indicate the lowest possible value for ReadingVolts.
 	// Units shall use the same units as the related ReadingVolts property.
-	MinReadingRange int
+	MinReadingRange float32
 	// PhysicalContext shall be a description
 	// of the affected device or region within the chassis to which this
 	// voltage measurement applies.
 	PhysicalContext string
 	// ReadingVolts shall be the present
 	// reading of the voltage sensor's reading.
-	ReadingVolts int
+	ReadingVolts float32
 	// SensorNumber shall be a numerical
 	// identifier for this voltage sensor that is unique within this
 	// resource.
@@ -417,13 +417,13 @@ type Voltage struct {
 	// UpperThresholdCritical shall indicate
 	// the present reading is above the normal range but is not yet fatal.
 	// Units shall use the same units as the related ReadingVolts propoerty.
-	UpperThresholdCritical int
+	UpperThresholdCritical float32
 	// UpperThresholdFatal shall indicate the
 	// present reading is above the normal range and is fatal. Units shall
 	// use the same units as the related ReadingVolts propoerty.
-	UpperThresholdFatal int
+	UpperThresholdFatal float32
 	// UpperThresholdNonCritical shall indicate
 	// the present reading is above the normal range but is not critical.
 	// Units shall use the same units as the related ReadingVolts propoerty.
-	UpperThresholdNonCritical int
+	UpperThresholdNonCritical float32
 }

--- a/school/redfish/power_test.go
+++ b/school/redfish/power_test.go
@@ -25,22 +25,22 @@ var powerBody = strings.NewReader(
 			"MemberId": "PC1",
 			"Name": "Fred",
 			"PhysicalContext": "Upper",
-			"PowerAllocatedWatts": 100,
-			"PowerAvailableWatts": 100,
-			"PowerCapacityWatts": 100,
-			"PowerConsumedWatts": 100,
+			"PowerAllocatedWatts": 100.0,
+			"PowerAvailableWatts": 100.0,
+			"PowerCapacityWatts": 100.0,
+			"PowerConsumedWatts": 100.0,
 			"PowerLimit": {
 				"CorrectionInMs": 10000,
 				"LimitException": "HardPowerOff",
-				"LimitInWatts": 1000
+				"LimitInWatts": 1000.0
 			},
 			"PowerMetrics": {
-				"AverageConsumedWatts": 1000,
+				"AverageConsumedWatts": 1000.0,
 				"IntervalInMin": 5,
-				"MaxConsumedWatts": 1000,
-				"MinConsumedWatts": 1000
+				"MaxConsumedWatts": 1000.0,
+				"MinConsumedWatts": 1000.0
 			},
-			"PowerRequestedWatts": 1000,
+			"PowerRequestedWatts": 1000.0,
 			"RelatedItem": [],
 			"RelatedItem@odata.count": 0,
 			"Status": {
@@ -61,23 +61,23 @@ var powerBody = strings.NewReader(
 			"IndicatorLED": "Lit",
 			"InputRanges": [{
 					"InputType": "AC",
-					"MaximumFrequencyHz": 99,
-					"MaximumVoltage": 9,
-					"MinimumFrequencyHz": 10,
-					"MinimumVoltage": 1,
-					"OutputWattage": 100
+					"MaximumFrequencyHz": 99.0,
+					"MaximumVoltage": 9.0,
+					"MinimumFrequencyHz": 10.0,
+					"MinimumVoltage": 1.0,
+					"OutputWattage": 100.0
 				},
 				{
 					"InputType": "DC",
-					"MaximumFrequencyHz": 88,
-					"MaximumVoltage": 9,
-					"MinimumFrequencyHz": 8,
-					"MinimumVoltage": 1,
-					"OutputWattage": 22
+					"MaximumFrequencyHz": 88.0,
+					"MaximumVoltage": 9.0,
+					"MinimumFrequencyHz": 8.0,
+					"MinimumVoltage": 1.0,
+					"OutputWattage": 22.0
 				}
 			],
-			"LastPowerOutputWatts": 100,
-			"LineInputVoltage": 9,
+			"LastPowerOutputWatts": 100.0,
+			"LineInputVoltage": 9.0,
 			"LineInputVoltageType": "ACandDCWideRange",
 			"Location": {},
 			"Manufacturer": "Acme Inc",
@@ -104,15 +104,15 @@ var powerBody = strings.NewReader(
 		"Redundancy@odata.count": 0,
 		"Voltages": [{
 			"@odata.id": "/redfish/v1/Voltage/1",
-			"LowerThresholdCritical": 1,
-			"LowerThresholdFatal": 0,
-			"LowerThresholdNonCritical": 5,
-			"MaxReadingRange": 10,
+			"LowerThresholdCritical": 1.0,
+			"LowerThresholdFatal": 0.0,
+			"LowerThresholdNonCritical": 5.0,
+			"MaxReadingRange": 10.0,
 			"MemberId": "Voltage1",
-			"MinReadingRange": 1,
+			"MinReadingRange": 1.0,
 			"Name": "Voltage-1",
 			"PhysicalContext": "Upper",
-			"ReadingVolts": 12,
+			"ReadingVolts": 12.0,
 			"RelatedItem": [],
 			"RelatedItem@odata.count": 0,
 			"SensorNumber": 1,
@@ -120,9 +120,9 @@ var powerBody = strings.NewReader(
 				"State": "Enabled",
 				"Health": "OK"
 			},
-			"UpperThresholdCritical": 10000,
-			"UpperThreadsholdFatal": 10001,
-			"UpperThresholdNonCritical": 1000
+			"UpperThresholdCritical": 10000.0,
+			"UpperThreadsholdFatal": 10001.0,
+			"UpperThresholdNonCritical": 1000.0
 		}],
 		"Voltages@odata.count": 1
 	}`)
@@ -162,6 +162,6 @@ func TestPower(t *testing.T) {
 	}
 
 	if result.Voltages[0].MaxReadingRange != 10 {
-		t.Errorf("Invalid MaxReadingRange: %d", result.Voltages[0].MaxReadingRange)
+		t.Errorf("Invalid MaxReadingRange: %f", result.Voltages[0].MaxReadingRange)
 	}
 }

--- a/school/redfish/redundancy.go
+++ b/school/redfish/redundancy.go
@@ -43,31 +43,49 @@ type Redundancy struct {
 
 	// ODataID is the odata identifier.
 	ODataID string `json:"@odata.id"`
-	// MaxNumSupported is The value of this property shall contain the
-	// maximum number of members allowed in the redundancy group.
+	// MaxNumSupported shall contain the maximum number of members allowed in
+	// the redundancy group.
 	MaxNumSupported int
 	// MemberID ivalue of this string shall uniquely identify the member within
 	// the collection.
 	MemberID string `json:"MemberId"`
-	// MinNumNeeded is The value of this property shall contain the minimum
+	// MinNumNeeded shall contain the minimum
 	// number of members allowed in the redundancy group for the current
 	// redundancy mode to still be fault tolerant.
 	MinNumNeeded int
-	// Mode is The value of this property shall contain the information about
-	// the redundancy mode of this subsystem.
+	// Mode shall contain the information about the redundancy mode of this
+	// subsystem.
 	Mode RedundancyMode
-	// RedundancyEnabled is The value of this property shall be a boolean
-	// indicating whether the redundancy is enabled.
+	// RedundancyEnabled shall be a boolean indicating whether the redundancy is
+	// enabled.
 	RedundancyEnabled bool
-	// RedundancySet is The value of this property shall contain the ids of
-	// components that are part of this redundancy set. The id values may or
-	// may not be dereferenceable.
-	RedundancySet []string
-	// RedundancySetCount is
+	// RedundancySet shall contain the ids of components that are part of this
+	// redundancy set. The id values may or may not be dereferenceable.
+	redundancySet []string
+	// RedundancySetCount is the number of RedundancySets.
 	RedundancySetCount int `json:"RedundancySet@odata.count"`
-	// Status is This property shall contain any status or health properties
-	// of the resource.
+	// Status shall contain any status or health properties of the resource.
 	Status common.Status
+}
+
+// UnmarshalJSON unmarshals a Redundancy object from the raw JSON.
+func (redundancy *Redundancy) UnmarshalJSON(b []byte) error {
+	type temp Redundancy
+	var t struct {
+		temp
+		RedundancySet common.Links
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	// Extract the links to other entities for later
+	*redundancy = Redundancy(t.temp)
+	redundancy.redundancySet = t.RedundancySet.ToStrings()
+
+	return nil
 }
 
 // GetRedundancy will get a Redundancy instance from the service.

--- a/school/redfish/thermal.go
+++ b/school/redfish/thermal.go
@@ -25,6 +25,7 @@ const (
 
 // Fan is
 type Fan struct {
+	common.Entity
 	// ODataID is the odata identifier.
 	ODataID string `json:"@odata.id"`
 	// assembly shall be a link to a resource of type Assembly.
@@ -117,6 +118,7 @@ func (fan *Fan) UnmarshalJSON(b []byte) error {
 	type temp Fan
 	var t struct {
 		temp
+		FanName  string
 		Assembly common.Link
 	}
 
@@ -128,6 +130,10 @@ func (fan *Fan) UnmarshalJSON(b []byte) error {
 	// Extract the links to other entities for later
 	*fan = Fan(t.temp)
 	fan.assembly = string(t.Assembly)
+
+	if t.FanName != "" {
+		fan.Name = t.FanName
+	}
 
 	return nil
 }
@@ -156,6 +162,7 @@ func (fan *Fan) UnmarshalJSON(b []byte) error {
 
 // Temperature is
 type Temperature struct {
+	common.Entity
 	// ODataID is the odata identifier.
 	ODataID string `json:"@odata.id"`
 	// AdjustedMaxAllowableOperatingValue shall

--- a/school/redfish/thermal_test.go
+++ b/school/redfish/thermal_test.go
@@ -19,6 +19,8 @@ var thermalBody = strings.NewReader(
 		"Name": "ThermalOne",
 		"Description": "Thermal One",
 		"Fans": [{
+			"Id": "Fan1",
+			"FanName": "Fan One",
 			"Assembly": {
 				"@odata.id": "/redfish/v1/Assemblies/1"
 			},
@@ -61,6 +63,7 @@ var thermalBody = strings.NewReader(
 		},
 		"Temperatures": [{
 			"@odata.id": "/redfish/v1/Temp",
+			"Id": "Temp1",
 			"AdjustedMaxAllowableOperatingValue": 60,
 			"AdjustedMinAllowableOperatingValue": 1,
 			"DeltaPhysicalContext": "Exhaust",
@@ -105,5 +108,9 @@ func TestThermal(t *testing.T) {
 
 	if result.Name != "ThermalOne" {
 		t.Errorf("Received invalid name: %s", result.Name)
+	}
+
+	if result.Fans[0].Name != "Fan One" {
+		t.Errorf("Invalid fan name: %s", result.Fans[0].Name)
 	}
 }


### PR DESCRIPTION
This corrects a few property definitions to make them match the schema.

Closes #28 