### PR TITLE
Add client connection settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,12 @@ import (
 )
 
 func main() {
-    c, err := gofish.APIClient("http://localhost:5000", nil)
+    c, err := gofish.ConnectDefault("http://localhost:5000")
     if err != nil {
         panic(err)
     }
 
-    service, err := gofish.ServiceRoot(c)
-    if err != nil {
-        panic(err)
-    }
-
+    service := c.Service
     chassis, err := service.Chassis()
     if err != nil {
         panic(err)

--- a/examples/query_chassis.go
+++ b/examples/query_chassis.go
@@ -6,55 +6,25 @@ package main
 import (
 	"fmt"
 
-	"crypto/tls"
-	"net/http"
-
 	"github.com/stmcginnis/gofish"
 )
 
-func httpclientForSelfSigned() (client *http.Client, err error) {
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-
-	client = &http.Client{
-		Transport: tr,
-	}
-
-	return client, err
-}
-
 func main() {
-	// Build a httpclient for bmcs with self signed certs
-	httpclient, err := httpclientForSelfSigned()
+	// Create a new instance of gofish client, ignoring self-signed certs
+	config := gofish.ClientConfig{
+		Endpoint: "https://bmc-ip",
+		Username: "my-username",
+		Password: "my-password",
+		Insecure: true,
+	}
+	c, err := gofish.Connect(config)
 	if err != nil {
 		panic(err)
 	}
+	defer c.Logout()
 
-	// Create a new instance of gofish client
-	c, err := gofish.APIClient("https://bmc-ip", httpclient)
-	if err != nil {
-		panic(err)
-	}
-
-	// Attached the client to service root
-	service, err := gofish.ServiceRoot(c)
-	if err != nil {
-		panic(err)
-	}
-
-	// Generates a authenticated session
-	auth, err := service.CreateSession("my-username", "my-password")
-	if err != nil {
-		panic(err)
-	}
-	fmt.Printf("%+v\n", auth)
-
-	// Make sure to delete the session and logout
-	defer service.DeleteSession(auth.Session)
-
-	// Assign the token back to our gofish client
-	c.Token = auth.Token
+	// Retrieve the service root
+	service := c.Service
 
 	// Query the chassis data using the session token
 	chassis, err := service.Chassis()

--- a/examples/query_sessions.go
+++ b/examples/query_sessions.go
@@ -6,55 +6,25 @@ package main
 import (
 	"fmt"
 
-	"crypto/tls"
-	"net/http"
-
 	"github.com/stmcginnis/gofish"
 )
 
-func httpclientForSelfSigned() (client *http.Client, err error) {
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-
-	client = &http.Client{
-		Transport: tr,
-	}
-
-	return client, err
-}
-
 func main() {
-	// Build a httpclient for bmcs with self signed certs
-	httpclient, err := httpclientForSelfSigned()
+	// Create a new instance of gofish client, ignoring self-signed certs
+	config := gofish.ClientConfig{
+		Endpoint: "https://bmc-ip",
+		Username: "my-username",
+		Password: "my-password",
+		Insecure: true,
+	}
+	c, err := gofish.Connect(config)
 	if err != nil {
 		panic(err)
 	}
+	defer c.Logout()
 
-	// Create a new instance of gofish client
-	c, err := gofish.APIClient("https://bmc-ip", httpclient)
-	if err != nil {
-		panic(err)
-	}
-
-	// Attached the client to service root
-	service, err := gofish.ServiceRoot(c)
-	if err != nil {
-		panic(err)
-	}
-
-	// Generates a authenticated session
-	auth, err := service.CreateSession("my-username", "my-password")
-	if err != nil {
-		panic(err)
-	}
-	fmt.Printf("%+v\n", auth)
-
-	// Make sure to delete the session and logout
-	service.DeleteSession(auth.Session)
-
-	// Assign the token back to our gofish client
-	c.Token = auth.Token
+	// Retrieve the service root
+	service := c.Service
 
 	// Query the active sessions using the session token
 	sessions, err := service.Sessions()


### PR DESCRIPTION
This changes the way you connect to a redfish service. ConnectDefault
will use default values to create an unauthenticated connection to the
service (typically useful for testing against the simulator), otherwise
you create a ClientConfig variable that contains all of your connection
settings and pass that in to a Connect call.

Closes: #33