### PR TITLE
Adds NewAPIClient method

### DIFF
--- a/client.go
+++ b/client.go
@@ -33,7 +33,7 @@ type APIClient struct {
 	Service *Service
 
 	// Auth information saved for later to be able to log out
-	auth *redfish.AuthToken
+	Auth *redfish.AuthToken
 }
 
 // ClientConfig holds the settings for establishing a connection.
@@ -161,8 +161,8 @@ func (c *APIClient) Get(url string) (*http.Response, error) {
 
 	req.Header.Set("User-Agent", userAgent)
 	req.Header.Set("Accept", applicationJSON)
-	if c.auth != nil && c.auth.Token != "" {
-		req.Header.Set("X-Auth-Token", c.auth.Token)
+	if c.Auth != nil && c.Auth.Token != "" {
+		req.Header.Set("X-Auth-Token", c.Auth.Token)
 	}
 	req.Close = true
 
@@ -199,8 +199,8 @@ func (c *APIClient) Post(url string, payload []byte) (*http.Response, error) {
 	req.Header.Set("User-Agent", userAgent)
 	req.Header.Set("Content-Type", applicationJSON)
 	req.Header.Set("Accept", applicationJSON)
-	if c.auth != nil && c.auth.Token != "" {
-		req.Header.Set("X-Auth-Token", c.auth.Token)
+	if c.Auth != nil && c.Auth.Token != "" {
+		req.Header.Set("X-Auth-Token", c.Auth.Token)
 	}
 	req.Close = true
 
@@ -246,8 +246,8 @@ func (c *APIClient) Delete(url string) error {
 
 	req.Header.Set("User-Agent", "gofish/1.0.0")
 	req.Header.Set("Accept", "application/json")
-	if c.auth != nil && c.auth.Token != "" {
-		req.Header.Set("X-Auth-Token", c.auth.Token)
+	if c.Auth != nil && c.Auth.Token != "" {
+		req.Header.Set("X-Auth-Token", c.Auth.Token)
 	}
 	req.Close = true
 
@@ -271,7 +271,7 @@ func (c *APIClient) Delete(url string) error {
 // Logout will delete any active session. Useful to defer logout when creating
 // a new connection.
 func (c *APIClient) Logout() {
-	if c.Service != nil && c.auth != nil {
-		c.Service.DeleteSession(c.auth.Session)
+	if c.Service != nil && c.Auth != nil {
+		c.Service.DeleteSession(c.Auth.Session)
 	}
 }


### PR DESCRIPTION
The change merged in 33f8f279b8ddcac08b02472235aed76d56d3267e removes the `gofish.APIClient` method which would allow a user to pass in his own `net/http.Client`                                                                                                 
                                                                                                                                                                                                                                                                               
This change prevents the user from being able to tune the transport parameters - something we've seen as necessary in [bmclib](https://github.com/bmc-toolbox/bmclib/blob/master/internal/httpclient/httpclient.go#L15)                                                        
                                                                                                                                                                                                                                                                               
I would like to propose this change, that add the `NewAPIClient` method which gives the user of this library a bit more flexibility in the connection setup.                                                                                                               

Do suggest alternatives if this does not seem ideal :)