### PR TITLE
Ensure response body is closed to prevent fd leak

### DIFF
--- a/client.go
+++ b/client.go
@@ -159,8 +159,12 @@ func (c *APIClient) Patch(url string, payload interface{}) (*http.Response, erro
 
 // Delete performs a Delete request against the Redfish service.
 func (c *APIClient) Delete(url string) error {
-	_, err := c.runRequest("DELETE", url, nil)
-	return err
+	resp, err := c.runRequest("DELETE", url, nil)
+	resp.Body.Close()
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // runRequest actually performs the REST calls.

--- a/redfish/session.go
+++ b/redfish/session.go
@@ -89,6 +89,7 @@ func CreateSession(c common.Client, uri string, username string, password string
 	if err != nil {
 		return auth, err
 	}
+	defer resp.Body.Close()
 
 	auth = &AuthToken{}
 	auth.Token = resp.Header.Get("X-Auth-Token")


### PR DESCRIPTION
We observed socket fd leaks related with Session establishment and the Logout function. Over time, repeated session creation and teardown would hold enough fds open to hit default limits.

By ensuring the response body is fully closed we were able to eliminate this issue locally. 

```
COMMAND     PID       USER   FD      TYPE    DEVICE SIZE/OFF      NODE NAME
redfish-e 21798 prometheus  cwd       DIR     253,1      224      1024 /
redfish-e 21798 prometheus  rtd       DIR     253,1      224      1024 /
redfish-e 21798 prometheus  txt       REG     253,1 15085858 235686043 /usr/bin/redfish-exporter
redfish-e 21798 prometheus    0u      CHR       1,3      0t0      1029 /dev/null
redfish-e 21798 prometheus    1w      REG     253,1 24459994  17072230 /var/log/redfish-exporter/redfish-exporter.log
redfish-e 21798 prometheus    2w      REG     253,1 24459994  17072230 /var/log/redfish-exporter/redfish-exporter.log
redfish-e 21798 prometheus    3u     IPv4 448580889      0t0       TCP localhost:7368 (LISTEN)
redfish-e 21798 prometheus    4u  a_inode      0,13        0      8816 [eventpoll]
redfish-e 21798 prometheus    5u     sock       0,9      0t0 448580428 protocol: TCP
redfish-e 21798 prometheus    6u     sock       0,9      0t0 448580062 protocol: TCP
redfish-e 21798 prometheus    7u     sock       0,9      0t0 448580339 protocol: TCP
redfish-e 21798 prometheus    9u     sock       0,9      0t0 448581776 protocol: TCP
redfish-e 21798 prometheus   10u     sock       0,9      0t0 448583776 protocol: TCP
redfish-e 21798 prometheus   11u     sock       0,9      0t0 448583066 protocol: TCP
redfish-e 21798 prometheus   12u     sock       0,9      0t0 448584081 protocol: TCP
redfish-e 21798 prometheus   13u     sock       0,9      0t0 448584243 protocol: TCP
redfish-e 21798 prometheus   15u     sock       0,9      0t0 448585902 protocol: TCP
redfish-e 21798 prometheus   16u     sock       0,9      0t0 448583639 protocol: TCP
redfish-e 21798 prometheus   17u     sock       0,9      0t0 448585821 protocol: TCP
```