### PR TITLE
Avoid nil pointer dereference with errors on Delete

### DIFF
--- a/client.go
+++ b/client.go
@@ -163,7 +163,7 @@ func (c *APIClient) Delete(url string) error {
 	if err != nil {
 		return err
 	}
-	if resp.Body != nil {
+	if resp != nil && resp.Body != nil {
 		resp.Body.Close()
 	}
 	return nil

--- a/client.go
+++ b/client.go
@@ -160,9 +160,11 @@ func (c *APIClient) Patch(url string, payload interface{}) (*http.Response, erro
 // Delete performs a Delete request against the Redfish service.
 func (c *APIClient) Delete(url string) error {
 	resp, err := c.runRequest("DELETE", url, nil)
-	resp.Body.Close()
 	if err != nil {
 		return err
+	}
+	if resp.Body != nil {
+		resp.Body.Close()
 	}
 	return nil
 }


### PR DESCRIPTION
Full trace below. The exporter function that triggered was `Logout()`.
```
Jan 29 11:22:10 prometheus01 redfish_exporter: panic: runtime error: invalid memory address or nil pointer dereference
Jan 29 11:22:10 prometheus01 redfish_exporter: [signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x844128]
Jan 29 11:22:10 prometheus01 redfish_exporter: goroutine 1570670 [running]:
Jan 29 11:22:10 prometheus01 redfish_exporter: github.com/stmcginnis/gofish.(*APIClient).Delete(0xc006823f40, 0xc00af972a0, 0x19, 0x872724, 0xc002731d78)
Jan 29 11:22:10 prometheus01 redfish_exporter: /users/sysp/tdockendorf/go/pkg/mod/github.com/treydock/gofish@v0.2.1-0.20200129132656-cfef2fbfcc83/client.go:171 +0x68
Jan 29 11:22:10 prometheus01 redfish_exporter: github.com/stmcginnis/gofish/redfish.DeleteSession(...)
Jan 29 11:22:10 prometheus01 redfish_exporter: /users/sysp/tdockendorf/go/pkg/mod/github.com/treydock/gofish@v0.2.1-0.20200129132656-cfef2fbfcc83/redfish/session.go:103
Jan 29 11:22:10 prometheus01 redfish_exporter: github.com/stmcginnis/gofish.(*Service).DeleteSession(...)
Jan 29 11:22:10 prometheus01 redfish_exporter: /users/sysp/tdockendorf/go/pkg/mod/github.com/treydock/gofish@v0.2.1-0.20200129132656-cfef2fbfcc83/serviceroot.go:267
Jan 29 11:22:10 prometheus01 redfish_exporter: github.com/stmcginnis/gofish.(*APIClient).Logout(0xc006823f40)
Jan 29 11:22:10 prometheus01 redfish_exporter: /users/sysp/tdockendorf/go/pkg/mod/github.com/treydock/gofish@v0.2.1-0.20200129132656-cfef2fbfcc83/client.go:264 +0x62
Jan 29 11:22:10 prometheus01 redfish_exporter: github.com/jenningsloy318/redfish_exporter/collector.(*RedfishCollector).Collect(0xc00add1e60, 0xc006befbc0)
Jan 29 11:22:10 prometheus01 redfish_exporter: /users/sysp/tdockendorf/git/redfish_exporter/collector/redfish_collector.go:99 +0x365
Jan 29 11:22:10 prometheus01 redfish_exporter: github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
Jan 29 11:22:10 prometheus01 redfish_exporter: /users/sysp/tdockendorf/go/pkg/mod/github.com/prometheus/client_golang@v1.1.0/prometheus/registry.go:442 +0x19d
Jan 29 11:22:10 prometheus01 redfish_exporter: created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather
Jan 29 11:22:10 prometheus01 redfish_exporter: /users/sysp/tdockendorf/go/pkg/mod/github.com/prometheus/client_golang@v1.1.0/prometheus/registry.go:453 +0x57d
```