### PR TITLE
send reset action if server return empty supported reset type

### DIFF
--- a/redfish/manager.go
+++ b/redfish/manager.go
@@ -358,18 +358,25 @@ func ListReferencedManagers(c common.Client, link string) ([]*Manager, error) {
 
 // Reset shall perform a reset of the manager.
 func (manager *Manager) Reset(resetType ResetType) error {
+	if len(manager.SupportedResetTypes) == 0 {
+		// reset directly without reset type. HPE server has the behavior
+		type temp struct {
+			Action string
+		}
+		t := temp{
+			Action: "Manager.Reset",
+		}
+
+		_, err := manager.Client.Post(manager.resetTarget, t)
+		return err
+	}
 	// Make sure the requested reset type is supported by the manager.
 	valid := false
-	if len(manager.SupportedResetTypes) > 0 {
-		for _, allowed := range manager.SupportedResetTypes {
-			if resetType == allowed {
-				valid = true
-				break
-			}
+	for _, allowed := range manager.SupportedResetTypes {
+		if resetType == allowed {
+			valid = true
+			break
 		}
-	} else {
-		// No allowed values supplied, assume we are OK
-		valid = true
 	}
 
 	if !valid {


### PR DESCRIPTION
If server returns empty supported reset type, it should be reset without any reset type. Seems like this is the behavior of hpe server

Signed-off-by: Leslie Qi Wang <leslie.qiwa@gmail.com>