### PR TITLE
Fixed AccountService Links field

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -23,6 +23,8 @@ type Client interface {
 
 // Entity provides the common basis for all Redfish and Swordfish objects.
 type Entity struct {
+	// ODataID is the location of the resource.
+	ODataID string `json:"@odata.id"`
 	// ID uniquely identifies the resource.
 	ID string `json:"Id"`
 	// Name is the name of the resource or array element.

--- a/examples/change_login.go
+++ b/examples/change_login.go
@@ -1,0 +1,52 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+package main
+
+import (
+	"fmt"
+
+	"github.com/stmcginnis/gofish"
+)
+
+func main() {
+	// Create a new instance of gofish client, ignoring self-signed certs
+	username := "my-username"
+	config := gofish.ClientConfig{
+		Endpoint: "https://bmc-ip",
+		Username: username,
+		Password: "my-password",
+		Insecure: true,
+	}
+	c, err := gofish.Connect(config)
+	if err != nil {
+		panic(err)
+	}
+	defer c.Logout()
+
+	// Retrieve the service root
+	service := c.Service
+
+	// Query the chassis data using the session token
+	accts, err := service.AccountService()
+	if err != nil {
+		panic(err)
+	}
+	accs, err := accts.Accounts()
+	if err != nil {
+		panic(err)
+	}
+
+	for _, acc := range accs {
+		if acc.UserName == username {
+			urlE := "/redfish/v1/AccountService/Accounts/"+acc.ID
+			payload := make(map[string]string)
+			payload["UserName"] = "new-username"
+			payload["Password"] = "new-password"
+			res, err := c.Patch(urlE, payload)
+			if err == nil {
+				fmt.Printf("%#v\n\n", res)
+			}
+		}
+	}
+}

--- a/examples/change_login.go
+++ b/examples/change_login.go
@@ -44,9 +44,10 @@ func main() {
 			payload["UserName"] = "new-username"
 			payload["Password"] = "new-password"
 			res, err := c.Patch(urlE, payload)
-			if err == nil {
-				fmt.Printf("%#v\n\n", res)
+			if err != nil {
+				panic(err)
 			}
+			fmt.Printf("%#v\n", res)
 		}
 	}
 }

--- a/examples/change_login.go
+++ b/examples/change_login.go
@@ -27,27 +27,29 @@ func main() {
 	// Retrieve the service root
 	service := c.Service
 
-	// Query the chassis data using the session token
-	accts, err := service.AccountService()
+	// Query the AccountService using the session token
+	accountService, err := service.AccountService()
 	if err != nil {
 		panic(err)
 	}
-	accs, err := accts.Accounts()
+	// Get list of accounts
+	accounts, err := accountService.Accounts()
 	if err != nil {
 		panic(err)
 	}
-
-	for _, acc := range accs {
-		if acc.UserName == username {
-			urlE := "/redfish/v1/AccountService/Accounts/"+acc.ID
+	// Iterate over accounts to find the current user
+	for _, account := range accounts {
+		if account.UserName == username {
 			payload := make(map[string]string)
 			payload["UserName"] = "new-username"
+			// New password must follow the rules set in AccountService : 
+			// MinPasswordLength and MaxPasswordLength
 			payload["Password"] = "new-password"
-			res, err := c.Patch(urlE, payload)
+			res, err := c.Patch(account.ODataID, payload)
 			if err != nil {
 				panic(err)
 			}
-			fmt.Printf("%#v\n", res)
+			fmt.Printf("%+v\n", res)
 		}
 	}
 }

--- a/redfish/accounts.go
+++ b/redfish/accounts.go
@@ -40,6 +40,10 @@ func (as *AccountService) UnmarshalJSON(b []byte) error {
 	if err != nil {
 		return err
 	}
+	err = json.Unmarshal(b, &t.Links)
+	if err != nil {
+		return err
+	}
 
 	*as = AccountService(t.temp)
 


### PR DESCRIPTION
Redfish AccountService output does not have Links field. Both Accounts and Roles are contained in the main body.
Would you prefer to keep it this way to prevent confusion with the Accounts() and Roles() methods?