### PR TITLE
add features for the LogService

### DIFF
--- a/redfish/logservice.go
+++ b/redfish/logservice.go
@@ -165,6 +165,13 @@ func (logservice *LogService) Entries() ([]*LogEntry, error) {
 // ClearLog shall delete all entries found in the Entries collection for this
 // Log Service.
 func (logservice *LogService) ClearLog() error {
-	_, err := logservice.Client.Post(logservice.clearLogTarget, nil)
+	type temp struct {
+		Action string
+	}
+	t := temp{
+		Action: "LogService.ClearLog",
+	}
+
+	_, err := logservice.Client.Post(logservice.clearLogTarget, t)
 	return err
 }

--- a/redfish/manager.go
+++ b/redfish/manager.go
@@ -399,3 +399,8 @@ func (manager *Manager) Reset(resetType ResetType) error {
 func (manager *Manager) EthernetInterfaces() ([]*EthernetInterface, error) {
 	return ListReferencedEthernetInterfaces(manager.Client, manager.ethernetInterfaces)
 }
+
+// LogServices get this manager's log services on this system.
+func (manager *Manager) LogServices()([]*LogService, error) {
+	return ListReferencedLogServices(manager.Client, manager.logServices)
+}


### PR DESCRIPTION
I propose this PR to fix following 2 features.

- Some BMC serve the SEL logs through `Managers/{id}/LogServices`. 
- Posting ClearLog with empty payload occur 'Invalid JSON Format' error.