### PR TITLE
Added support of basic authentication

### DIFF
--- a/redfish/session.go
+++ b/redfish/session.go
@@ -69,8 +69,11 @@ type Session struct {
 
 // AuthToken contains the authentication and session information.
 type AuthToken struct {
-	Token   string
-	Session string
+	Token     string
+	Session   string
+	Username  string
+	Password  string
+	BasicAuth bool
 }
 
 type authPayload struct {


### PR DESCRIPTION
Hello Sean,

I've added the possibility of basic authentication against the redfish API. This might be interesting in different scenarios (like the ones for some reason you don't want to have a token).

To the gofish.ClientConfig struct I've added a field called BasicAuth. If not set, it will use the token authentication as before. If set explicitly to true, it will use basic auth. 

To allow this to happen, I've also modified the struct redfish.AuthToken, adding Username, Password and a BasicAuth fields. This will make us be aware if we want to use token auth or basic auth while building the APIClient.

When creating the request for HTTP methods, we will check this struct and we will include the needed headers, either for token auth or basic auth.

Best regards.
/Miguel