### PR TITLE
Fix unmarshal issues from incorrectly defined fields

### DIFF
--- a/redfish/drive_test.go
+++ b/redfish/drive_test.go
@@ -67,7 +67,12 @@ var driveBody = strings.NewReader(
 		"NegotiatedSpeedGbps": 10,
 		"Operations": [],
 		"PartNumber": "12345",
-		"PhysicalLocation": {},
+		"PhysicalLocation": {
+				"PartLocation": {
+				"LocationOrdinalValue": 0,
+				"LocationType": "Slot"
+			}
+		},
 		"PredictedMediaLifeLeftPercent": 100,
 		"Protocol": "FC",
 		"Revision": "2.0",

--- a/redfish/memory.go
+++ b/redfish/memory.go
@@ -236,7 +236,7 @@ type Memory struct {
 	// IsSpareDeviceEnabled shall be true if a spare device is enabled for this Memory.
 	IsSpareDeviceEnabled bool
 	// Location shall contain location information of the associated memory.
-	Location string
+	Location common.Location
 	// LogicalSizeMiB shall be the total size of the logical memory in MiB.
 	LogicalSizeMiB int
 	// Manufacturer shall contain a string which identifies the manufacturer of the Memory.

--- a/redfish/memory_test.go
+++ b/redfish/memory_test.go
@@ -40,6 +40,13 @@ var memoryBody = strings.NewReader(
 		"FirmwareRevision": "3",
 		"IsRankSpareEnabled": false,
 		"IsSpareDeviceEnabled": false,
+		"Location": {
+			"PartLocation": {
+				"LocationType": "Slot",
+				"ServiceLabel": "DIMM 5",
+				"LocationOrdinalValue": 4
+			}
+		},
 		"LogicalSizeMiB": 2097152,
 		"Manufacturer": "Generic",
 		"MemoryDeviceType": "DDR4",

--- a/redfish/networkadapter.go
+++ b/redfish/networkadapter.go
@@ -84,8 +84,8 @@ type Controllers struct {
 	// firmware package.
 	FirmwarePackageVersion string
 	// Location shall contain location information of the associated network
-	// adapter controller. TODO: Needs to be a Location struct.
-	//Location string
+	// adapter controller.
+	Location common.Location
 	// PCIeInterface is used to connect this PCIe-based controller to its host.
 	PCIeInterface PCIeInterface
 	// NetworkDeviceFunctions shall be an array of references of type

--- a/redfish/power.go
+++ b/redfish/power.go
@@ -302,8 +302,8 @@ type PowerSupply struct {
 	// line voltage supported by the associated power supply.
 	LineInputVoltageType LineInputVoltageType
 	// Location shall contain location information of the
-	// associated power supply. TODO: Make Location object.
-	//Location string
+	// associated power supply.
+	Location common.Location
 	// Manufacturer shall be the name of the
 	// organization responsible for producing the power supply. This
 	// organization might be the entity from whom the power supply is

--- a/redfish/processor.go
+++ b/redfish/processor.go
@@ -287,7 +287,7 @@ type Processor struct {
 	Links string
 	// Location shall contain location information of the
 	// associated processor.
-	Location string
+	Location common.Location
 	// Manufacturer shall contain a string which identifies
 	// the manufacturer of the processor.
 	Manufacturer string

--- a/redfish/processor.go
+++ b/redfish/processor.go
@@ -299,7 +299,7 @@ type Processor struct {
 	MaxTDPWatts int
 	// Metrics shall be a reference to the Metrics
 	// associated with this Processor.
-	Metrics string
+	metrics string
 	// Model shall indicate the model information as
 	// provided by the manufacturer of this processor.
 	Model string
@@ -376,6 +376,7 @@ func (processor *Processor) UnmarshalJSON(b []byte) error {
 		temp
 		AccelerationFunctions common.Link
 		Assembly              common.Link
+		Metrics               common.Link
 		ProcessorMemory       common.Links
 		Links                 struct {
 			Chassis                  common.Link
@@ -408,6 +409,7 @@ func (processor *Processor) UnmarshalJSON(b []byte) error {
 	processor.pcieDevice = string(t.Links.PCIeDevice)
 	processor.pcieFunctions = t.Links.PCIeFunctions.ToStrings()
 	processor.PCIeFunctionsCount = t.Links.PCIeFunctionsCount
+	processor.metrics = string(t.Metrics)
 
 	return nil
 }

--- a/redfish/processor_test.go
+++ b/redfish/processor_test.go
@@ -12,18 +12,13 @@ import (
 
 var processorBody = strings.NewReader(
 	`{
-		"@odata.context": "/redfish/v1/$metadata#Processor.Processor",
-		"@odata.type": "#Processor.1_0_0.Processor",
-		"@odata.id": "/redfish/v1/Systems/System-1/Processors/CPU0",
-		"Name": "Processor",
-		"Id": "CPU0",
-		"AccelerationFunctions": {
-			"@odata.id": "/redfish/v1/Systems/System-1/Processors/CPU0/Functions"
+		"@odata.context":"/redfish/v1/$metadata#Processor.Processor",
+		"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.2",
+		"@odata.type":"#Processor.v1_3_1.Processor",
+		"Assembly":{
+		   "@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Assembly"
 		},
-		"Assembly": {
-			"@odata.id": "/redfish/v1/Assembly/1"
-		},
-		"Description": "Processor one",
+		"Description":"Represents the properties of a Processor attached to this System",
 		"FPGA": {
 			"ExternalInterfaces": [{
 				"Ethernet": {
@@ -67,8 +62,91 @@ var processorBody = strings.NewReader(
 					"UUID": "e703fdd1-e386-48cb-beef-097a2b35d3e1"
 				}
 			]
-		}
-	}`)
+		},
+		"Id":"CPU.Socket.2",
+		"InstructionSet":"x86-64",
+		"Links":{
+		   "Chassis":{
+			  "@odata.id":"/redfish/v1/Chassis/System.Embedded.1"
+		   }
+		},
+		"Manufacturer":"Intel",
+		"MaxSpeedMHz":4000,
+		"Metrics": {
+			"@odata.id": "/redfish/v1/Systems/1/Processors/1/ProcessorMetrics"
+		},
+		"Model":"Intel(R) Xeon(R) Gold 6136 CPU @ 3.00GHz",
+		"Name":"CPU 2",
+		"Oem":{
+		   "Dell":{
+			  "DellProcessor":{
+				 "@odata.context":"/redfish/v1/$metadata#DellProcessor.DellProcessor",
+				 "@odata.id":"/redfish/v1/Dell/Systems/System.Embedded.1/Processors/DellProcessor/CPU.Socket.2",
+				 "@odata.type":"#DellProcessor.v1_1_0.DellProcessor",
+				 "CPUFamily":"Intel(R)Xeon(TM)",
+				 "CPUStatus":"CPUEnabled",
+				 "Cache1Associativity":"8-WaySet-Associative",
+				 "Cache1ErrorMethodology":"Parity",
+				 "Cache1InstalledSizeKB":768,
+				 "Cache1Level":"L1",
+				 "Cache1Location":"Internal",
+				 "Cache1PrimaryStatus":"OK",
+				 "Cache1SRAMType":"Unknown",
+				 "Cache1SizeKB":768,
+				 "Cache1Type":"Unified",
+				 "Cache1WritePolicy":"WriteBack",
+				 "Cache2Associativity":"16-WaySet-Associative",
+				 "Cache2ErrorMethodology":"Single-bitECC",
+				 "Cache2InstalledSizeKB":12288,
+				 "Cache2Level":"L2",
+				 "Cache2Location":"Internal",
+				 "Cache2PrimaryStatus":"OK",
+				 "Cache2SRAMType":"Unknown",
+				 "Cache2SizeKB":12288,
+				 "Cache2Type":"Unified",
+				 "Cache2WritePolicy":"WriteBack",
+				 "Cache3Associativity":"FullyAssociative",
+				 "Cache3ErrorMethodology":"Single-bitECC",
+				 "Cache3InstalledSizeKB":25344,
+				 "Cache3Level":"L3",
+				 "Cache3Location":"Internal",
+				 "Cache3PrimaryStatus":"OK",
+				 "Cache3SRAMType":"Unknown",
+				 "Cache3SizeKB":25344,
+				 "Cache3Type":"Unified",
+				 "Cache3WritePolicy":"WriteBack",
+				 "CurrentClockSpeedMhz":3000,
+				 "ExternalBusClockSpeedMhz":10400,
+				 "HyperThreadingCapable":"Yes",
+				 "HyperThreadingEnabled":"Yes",
+				 "LastSystemInventoryTime":"2020-01-07T00:53:28+00:00",
+				 "LastUpdateTime":"2019-08-27T14:52:23+00:00",
+				 "TurboModeCapable":"Yes",
+				 "TurboModeEnabled":"Yes",
+				 "VirtualizationTechnologyCapable":"Yes",
+				 "VirtualizationTechnologyEnabled":"Yes",
+				 "Volts":"1.8"
+			  }
+		   }
+		},
+		"ProcessorArchitecture":"x86",
+		"ProcessorId":{
+		   "EffectiveFamily":"179",
+		   "EffectiveModel":"85",
+		   "IdentificationRegisters":"0x00050654",
+		   "MicrocodeInfo":null,
+		   "Step":"4",
+		   "VendorId":"GenuineIntel"
+		},
+		"ProcessorType":"CPU",
+		"Socket":"CPU.Socket.2",
+		"Status":{
+		   "Health":"OK",
+		   "State":"Enabled"
+		},
+		"TotalCores":12,
+		"TotalThreads":24
+	 }`)
 
 // TestProcessor tests the parsing of Processor objects.
 func TestProcessor(t *testing.T) {
@@ -79,15 +157,15 @@ func TestProcessor(t *testing.T) {
 		t.Errorf("Error decoding JSON: %s", err)
 	}
 
-	if result.ID != "CPU0" {
+	if result.ID != "CPU.Socket.2" {
 		t.Errorf("Received invalid ID: %s", result.ID)
 	}
 
-	if result.Name != "Processor" {
+	if result.Name != "CPU 2" {
 		t.Errorf("Received invalid name: %s", result.Name)
 	}
 
-	if result.assembly != "/redfish/v1/Assembly/1" {
+	if result.assembly != "/redfish/v1/Chassis/System.Embedded.1/Assembly" {
 		t.Errorf("Invalid assembly link: %s", result.assembly)
 	}
 


### PR DESCRIPTION
This fixes an issue with Location and ProcessMetrics fields that were incorrectly defined as strings.

Closes #61 