### PR TITLE
Add unit testing of Update() calls

### DIFF
--- a/common/testclient.go
+++ b/common/testclient.go
@@ -1,0 +1,78 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package common
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// TestAPICall captures the arguments to one of the API calls.
+type TestAPICall struct {
+	// Action is the REST action (GET, PUT, etc) of the call
+	Action string
+	// URL is the URL to send to
+	URL string
+	// Payload is the string representation of the payload
+	Payload string
+}
+
+// TestClient is a mock client to use for unit testing some of the
+// function calls and actions that would normally need to connect
+// with a host.
+type TestClient struct {
+	// calls collects any API calls made through the client
+	calls []TestAPICall
+}
+
+// CapturedCalls gets all calls that were made through this instance
+func (c *TestClient) CapturedCalls() []TestAPICall {
+	return c.calls
+}
+
+// Reset resets the captured information for this mock client.
+func (c *TestClient) Reset() {
+	c.calls = []TestAPICall{}
+}
+
+// recordCall is a helper to record any API calls made through this client
+func (c *TestClient) recordCall(action string, url string, payload interface{}) {
+	call := TestAPICall{
+		Action:  action,
+		URL:     url,
+		Payload: fmt.Sprintf("%v", payload),
+	}
+	c.calls = append(c.calls, call)
+}
+
+// Get performs a GET request against the Redfish service.
+func (c *TestClient) Get(url string) (*http.Response, error) {
+	c.recordCall("GET", url, nil)
+	return nil, nil
+}
+
+// Post performs a Post request against the Redfish service.
+func (c *TestClient) Post(url string, payload interface{}) (*http.Response, error) {
+	c.recordCall("POST", url, payload)
+	return nil, nil
+}
+
+// Put performs a Put request against the Redfish service.
+func (c *TestClient) Put(url string, payload interface{}) (*http.Response, error) {
+	c.recordCall("PUT", url, payload)
+	return nil, nil
+}
+
+// Patch performs a Patch request against the Redfish service.
+func (c *TestClient) Patch(url string, payload interface{}) (*http.Response, error) {
+	c.recordCall("PATH", url, payload)
+	return nil, nil
+}
+
+// Delete performs a Delete request against the Redfish service.
+func (c *TestClient) Delete(url string) error {
+	c.recordCall("DELETE", url, nil)
+	return nil
+}

--- a/common/types.go
+++ b/common/types.go
@@ -81,9 +81,6 @@ func (e *Entity) Update(originalEntity reflect.Value, currentEntity reflect.Valu
 		}
 	}
 
-	// TODO: Remove this after done debugging
-	fmt.Printf("Updates: %v\n", payload)
-
 	// If there are any allowed updates, try to send updates to the system and
 	// return the result.
 	if len(payload) > 0 {

--- a/redfish/chassis_test.go
+++ b/redfish/chassis_test.go
@@ -12,8 +12,7 @@ import (
 	"github.com/stmcginnis/gofish/common"
 )
 
-var chassisBody = strings.NewReader(
-	`{
+var chassisBody = `{
 		"@odata.context": "/redfish/v1/$metadata#Chassis.Chassis",
 		"@odata.id": "/redfish/v1/Chassis/Chassis-1",
 		"@odata.type": "#Chassis.v1_0_0.Chassis",
@@ -59,12 +58,12 @@ var chassisBody = strings.NewReader(
 				]
 			}
 		}
-	}`)
+	}`
 
 // TestChassis tests the parsing of Chassis objects.
 func TestChassis(t *testing.T) {
 	var result Chassis
-	err := json.NewDecoder(chassisBody).Decode(&result)
+	err := json.NewDecoder(strings.NewReader(chassisBody)).Decode(&result)
 
 	if err != nil {
 		t.Errorf("Error decoding JSON: %s", err)
@@ -125,5 +124,35 @@ func TestChassis(t *testing.T) {
 	if len(result.SupportedResetTypes) != 2 {
 		t.Errorf("Invalid allowable reset actions, expected 2, got %d",
 			len(result.SupportedResetTypes))
+	}
+}
+
+// TestChassisUpdate tests the Update call.
+func TestChassisUpdate(t *testing.T) {
+	var result Chassis
+	err := json.NewDecoder(strings.NewReader(chassisBody)).Decode(&result)
+
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+
+	testClient := &common.TestClient{}
+	result.SetClient(testClient)
+
+	result.AssetTag = "TestAssetTag"
+	err = result.Update()
+
+	if err != nil {
+		t.Errorf("Error making Update call: %s", err)
+	}
+
+	calls := testClient.CapturedCalls()
+
+	if len(calls) != 1 {
+		t.Errorf("Expected one call to be made, captured: %v", calls)
+	}
+
+	if !strings.Contains(calls[0].Payload, result.AssetTag) {
+		t.Errorf("Unexpected update payload: %s", calls[0].Payload)
 	}
 }

--- a/redfish/computersystem.go
+++ b/redfish/computersystem.go
@@ -575,8 +575,6 @@ func (computersystem *ComputerSystem) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (computersystem *ComputerSystem) Update() error {
-	fmt.Println("ComputerSystem save called")
-
 	// Get a representation of the object's original state so we can find what
 	// to update.
 	cs := new(ComputerSystem)

--- a/redfish/eventdestination_test.go
+++ b/redfish/eventdestination_test.go
@@ -8,10 +8,11 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/stmcginnis/gofish/common"
 )
 
-var eventDestinationBody = strings.NewReader(
-	`{
+var eventDestinationBody = `{
 		"@odata.context": "/redfish/v1/$metadata#EventDestination.EventDestination",
 		"@odata.type": "#EventDestination.v1_0_0.EventDestination",
 		"@odata.id": "/redfish/v1/EventDestination",
@@ -28,12 +29,12 @@ var eventDestinationBody = strings.NewReader(
 		"ResourceTypes": ["one", "two"],
 		"SubordinateResources": false,
 		"SubscriptionType": "SSE"
-	}`)
+	}`
 
 // TestEventDestination tests the parsing of EventDestination objects.
 func TestEventDestination(t *testing.T) {
 	var result EventDestination
-	err := json.NewDecoder(eventDestinationBody).Decode(&result)
+	err := json.NewDecoder(strings.NewReader(eventDestinationBody)).Decode(&result)
 
 	if err != nil {
 		t.Errorf("Error decoding JSON: %s", err)
@@ -61,5 +62,31 @@ func TestEventDestination(t *testing.T) {
 
 	if result.SubordinateResources {
 		t.Error("Subordinate resources should be False")
+	}
+}
+
+// TestEventDestinationUpdate tests the Update call.
+func TestEventDestinationUpdate(t *testing.T) {
+	var result EventDestination
+	err := json.NewDecoder(strings.NewReader(eventDestinationBody)).Decode(&result)
+
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+
+	testClient := &common.TestClient{}
+	result.SetClient(testClient)
+
+	result.Context = "NewContext"
+	err = result.Update()
+
+	if err != nil {
+		t.Errorf("Error making Update call: %s", err)
+	}
+
+	calls := testClient.CapturedCalls()
+
+	if !strings.Contains(calls[0].Payload, "Context:NewContext") {
+		t.Errorf("Unexpected Context update payload: %s", calls[0].Payload)
 	}
 }

--- a/redfish/eventservice_test.go
+++ b/redfish/eventservice_test.go
@@ -8,10 +8,11 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/stmcginnis/gofish/common"
 )
 
-var eventServiceBody = strings.NewReader(
-	`{
+var eventServiceBody = `{
 		"@Redfish.Copyright": "Copyright 2014-2019 DMTF. All rights reserved.",
 		"@odata.context": "/redfish/v1/$metadata#EventService.EventService",
 		"@odata.type": "#EventService.v1_0_0.EventService",
@@ -56,12 +57,12 @@ var eventServiceBody = strings.NewReader(
 				]
 			}
 		}
-	}`)
+	}`
 
 // TestEventService tests the parsing of EventService objects.
 func TestEventService(t *testing.T) {
 	var result EventService
-	err := json.NewDecoder(eventServiceBody).Decode(&result)
+	err := json.NewDecoder(strings.NewReader(eventServiceBody)).Decode(&result)
 
 	if err != nil {
 		t.Errorf("Error decoding JSON: %s", err)
@@ -93,5 +94,41 @@ func TestEventService(t *testing.T) {
 
 	if result.submitTestEventTarget != "/redfish/v1/EventService/Actions/EventService.SubmitTestEvent" {
 		t.Errorf("Invalid SubmitTestEvent target: %s", result.submitTestEventTarget)
+	}
+}
+
+// TestEventServiceUpdate tests the Update call.
+func TestEventServiceUpdate(t *testing.T) {
+	var result EventService
+	err := json.NewDecoder(strings.NewReader(eventServiceBody)).Decode(&result)
+
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+
+	testClient := &common.TestClient{}
+	result.SetClient(testClient)
+
+	result.DeliveryRetryAttempts = 20
+	result.DeliveryRetryIntervalSeconds = 60
+	result.ServiceEnabled = true
+	err = result.Update()
+
+	if err != nil {
+		t.Errorf("Error making Update call: %s", err)
+	}
+
+	calls := testClient.CapturedCalls()
+
+	if !strings.Contains(calls[0].Payload, "DeliveryRetryAttempts:20") {
+		t.Errorf("Unexpected DeliveryRetryAttempts update payload: %s", calls[0].Payload)
+	}
+
+	if !strings.Contains(calls[0].Payload, "DeliveryRetryIntervalSeconds:60") {
+		t.Errorf("Unexpected DeliveryRetryIntervalSeconds update payload: %s", calls[0].Payload)
+	}
+
+	if strings.Contains(calls[0].Payload, "ServiceEnabled") {
+		t.Errorf("Unexpected DeliveryRetryIntervalSeconds update payload: %s", calls[0].Payload)
 	}
 }

--- a/redfish/manageraccount_test.go
+++ b/redfish/manageraccount_test.go
@@ -8,10 +8,11 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/stmcginnis/gofish/common"
 )
 
-var managerAccountBody = strings.NewReader(
-	`{
+var managerAccountBody = `{
 		"@odata.context": "/redfish/v1/$metadata#AccountService/Links/Members/Accounts/Links/Members/$entity",
 		"@odata.id": "/redfish/v1/AccountService/Accounts/1",
 		"@odata.type": "#AccountService.0.94.0.ManagerAccount",
@@ -19,7 +20,7 @@ var managerAccountBody = strings.NewReader(
 		"Name": "User Account",
 		"Modified": "2013-09-11T17:03:55+00:00",
 		"Description": "User Account",
-		"Password": "Password",
+		"Password": null,
 		"UserName": "Administrator",
 		"Locked": false,
 		"Enabled": true,
@@ -29,12 +30,12 @@ var managerAccountBody = strings.NewReader(
 				"@odata.id": "/redfish/v1/AccountService/Roles/Admin"
 			}
 		}
-	}`)
+	}`
 
 // TestAccount tests the parsing of Account objects.
 func TestManagerAccount(t *testing.T) {
 	var result ManagerAccount
-	err := json.NewDecoder(managerAccountBody).Decode(&result)
+	err := json.NewDecoder(strings.NewReader(managerAccountBody)).Decode(&result)
 
 	if err != nil {
 		t.Errorf("Error decoding JSON: %s", err)
@@ -54,5 +55,41 @@ func TestManagerAccount(t *testing.T) {
 
 	if result.role != "/redfish/v1/AccountService/Roles/Admin" {
 		t.Errorf("Received invalid Role: %s", result.role)
+	}
+}
+
+// TestAccountUpdate tests the Update call.
+func TestManagerAccountUpdate(t *testing.T) {
+	var result ManagerAccount
+	err := json.NewDecoder(strings.NewReader(managerAccountBody)).Decode(&result)
+
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+
+	testClient := &common.TestClient{}
+	result.SetClient(testClient)
+
+	result.Enabled = false
+	result.Locked = false
+	result.Password = "Test"
+	err = result.Update()
+
+	if err != nil {
+		t.Errorf("Error making Update call: %s", err)
+	}
+
+	calls := testClient.CapturedCalls()
+
+	if !strings.Contains(calls[0].Payload, "Enabled:false") {
+		t.Errorf("Unexpected Enabled update payload: %s", calls[0].Payload)
+	}
+
+	if strings.Contains(calls[0].Payload, "Locked") {
+		t.Errorf("Unexpected Locked in update payload: %s", calls[0].Payload)
+	}
+
+	if !strings.Contains(calls[0].Payload, "Password:Test") {
+		t.Errorf("Unexpected Password update payload: %s", calls[0].Payload)
 	}
 }

--- a/redfish/power.go
+++ b/redfish/power.go
@@ -121,6 +121,9 @@ type Power struct {
 	ODataType string `json:"@odata.type"`
 	// Description provides a description of this resource.
 	Description string
+	// IndicatorLED shall contain the indicator light state for the indicator
+	// light associated with this power supply.
+	IndicatorLED common.IndicatorLED
 	// PowerControl shall be the definition for power control (power reading and
 	// limiting) for a Redfish implementation.
 	PowerControl []PowerControl

--- a/redfish/thermal.go
+++ b/redfish/thermal.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -294,24 +293,24 @@ func (thermal *Thermal) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// Update commits updates to this object's properties to the running system.
-func (thermal *Thermal) Update() error {
+// // Update commits updates to this object's properties to the running system.
+// func (thermal *Thermal) Update() error {
 
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Thermal)
-	original.UnmarshalJSON(thermal.rawData)
+// 	// Get a representation of the object's original state so we can find what
+// 	// to update.
+// 	original := new(Thermal)
+// 	original.UnmarshalJSON(thermal.rawData)
 
-	readWriteFields := []string{
-		"Fans",
-		"Temperatures",
-	}
+// 	readWriteFields := []string{
+// 		"Fans",
+// 		"Temperatures",
+// 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(thermal).Elem()
+// 	originalElement := reflect.ValueOf(original).Elem()
+// 	currentElement := reflect.ValueOf(thermal).Elem()
 
-	return thermal.Entity.Update(originalElement, currentElement, readWriteFields)
-}
+// 	return thermal.Entity.Update(originalElement, currentElement, readWriteFields)
+// }
 
 // GetThermal will get a Thermal instance from the service.
 func GetThermal(c common.Client, uri string) (*Thermal, error) {

--- a/redfish/thermal_test.go
+++ b/redfish/thermal_test.go
@@ -10,8 +10,7 @@ import (
 	"testing"
 )
 
-var thermalBody = strings.NewReader(
-	`{
+var thermalBody = `{
 		"@odata.context": "/redfish/v1/$metadata#Thermal.Thermal",
 		"@odata.type": "#Thermal.v1_0_0.Thermal",
 		"@odata.id": "/redfish/v1/Thermal",
@@ -91,12 +90,12 @@ var thermalBody = strings.NewReader(
 			"UpperThresholdNonCritical": 9998
 		}],
 		"Temperatures@odata.count": 1
-	}`)
+	}`
 
 // TestThermal tests the parsing of Thermal objects.
 func TestThermal(t *testing.T) {
 	var result Thermal
-	err := json.NewDecoder(thermalBody).Decode(&result)
+	err := json.NewDecoder(strings.NewReader(thermalBody)).Decode(&result)
 
 	if err != nil {
 		t.Errorf("Error decoding JSON: %s", err)

--- a/redfish/vlannetworkinterface_test.go
+++ b/redfish/vlannetworkinterface_test.go
@@ -8,10 +8,11 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/stmcginnis/gofish/common"
 )
 
-var vlanNetworkInterfaceBody = strings.NewReader(
-	`{
+var vlanNetworkInterfaceBody = `{
 		"@odata.context": "/redfish/v1/$metadata#VlanNetworkInterface.VlanNetworkInterface",
 		"@odata.type": "#VLanNetworkInterface.v1_1_3.VLanNetworkInterface",
 		"@odata.id": "/redfish/v1/VlanNetworkInterface",
@@ -20,12 +21,12 @@ var vlanNetworkInterfaceBody = strings.NewReader(
 		"Description": "VlanNetworkInterface One",
 		"VLANEnable": true,
 		"VLANId": 200
-	}`)
+	}`
 
 // TestVlanNetworkInterface tests the parsing of VlanNetworkInterface objects.
 func TestVlanNetworkInterface(t *testing.T) {
 	var result VLanNetworkInterface
-	err := json.NewDecoder(vlanNetworkInterfaceBody).Decode(&result)
+	err := json.NewDecoder(strings.NewReader(vlanNetworkInterfaceBody)).Decode(&result)
 
 	if err != nil {
 		t.Errorf("Error decoding JSON: %s", err)
@@ -45,5 +46,31 @@ func TestVlanNetworkInterface(t *testing.T) {
 
 	if result.VLANID != 200 {
 		t.Errorf("Invalid VLAN ID: %d", result.VLANID)
+	}
+}
+
+// TestVlanNetworkInterfaceUpdate tests the Update call.
+func TestVlanNetworkInterfaceUpdate(t *testing.T) {
+	var result VLanNetworkInterface
+	err := json.NewDecoder(strings.NewReader(vlanNetworkInterfaceBody)).Decode(&result)
+
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+
+	testClient := &common.TestClient{}
+	result.SetClient(testClient)
+
+	result.VLANEnable = false
+	err = result.Update()
+
+	if err != nil {
+		t.Errorf("Error making Update call: %s", err)
+	}
+
+	calls := testClient.CapturedCalls()
+
+	if !strings.Contains(calls[0].Payload, "VLANEnable:false") {
+		t.Errorf("Unexpected VLANEnable update payload: %s", calls[0].Payload)
 	}
 }


### PR DESCRIPTION
This adds a mock Client object that can be used in unit tests to test
calls and adds unit tests to make sure the expected values are sent for
Update() calls.