### PR TITLE
Handle HREF in links but prefer @odata.id

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -100,6 +100,7 @@ type Link string
 func (l *Link) UnmarshalJSON(b []byte) error {
 	var t struct {
 		ODataID string `json:"@odata.id"`
+		Href    string `json:"href"`
 	}
 
 	err := json.Unmarshal(b, &t)
@@ -108,6 +109,9 @@ func (l *Link) UnmarshalJSON(b []byte) error {
 	}
 
 	*l = Link(t.ODataID)
+	if *l == "" {
+		*l = Link(t.Href)
+	}
 	return nil
 }
 


### PR DESCRIPTION
For really old HP/HPE systems, they do not use @odata.id, but use href instead.  This allows the system to continue to limp along and work better.  At least get past session creation.

You may not want this, but it seems to work on my old HP system and continues working with my dell system.

Clicked too quickly on some things.  Edited to add more information.