### PR TITLE
Etag changed from string to json.Number

### DIFF
--- a/redfish/accountservice.go
+++ b/redfish/accountservice.go
@@ -159,7 +159,7 @@ type AccountService struct {
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
 	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
+	ODataEtag json.Number `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// AccountLockoutCounterResetAfter shall contain the


### PR DESCRIPTION
Hello Sean,

Looks like the *ODataEtag* field from *AccountService* struct was set to **string**. Apparently this is what Redfish spec says.
However, I was testing this against my infra (Dell R7415 with iDRAC9 version 4.00.00) and the body from the response was:

~~~
{
	"@odata.context": "/redfish/v1/$metadata#AccountService.AccountService",
	"@odata.type": "#AccountService.v1_3_1.AccountService",
	"@odata.id": "/redfish/v1/AccountService",
	"@odata.etag": 77968587947,
	"AccountLockoutCounterResetAfter": 0,
	"AccountLockoutDuration": 0,
	"AccountLockoutThreshold": 0,
	"Accounts": {
		"@odata.id": "/redfish/v1/AccountService/Accounts"
	},
...
}
~~~

As you can see, in this case (for some reason I truly unknown) the returned JSON comes with that field set to an **int**. 
I set that field to json.Number to avoid that situation, since it supports froat64, int64 and string. That solves the issue.

At the same time I will try to contact PG from PowerEdge to see what's going on in there.

This issue might affect other parts of the code when dealing with PowerEdge probably... If I find more stuff, I will report it in the future :)