### PR TITLE
Remove etag properties

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -519,8 +519,6 @@ type Resource struct {
 	Entity
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// Description provides a description of this resource.
@@ -531,8 +529,6 @@ type Resource struct {
 type ResourceCollection struct {
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataID is the odata identifier.
 	ODataID string `json:"@odata.id"`
 	// ODataType is the odata type.

--- a/redfish/accountservice.go
+++ b/redfish/accountservice.go
@@ -158,8 +158,6 @@ type AccountService struct {
 	common.Entity
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// AccountLockoutCounterResetAfter shall contain the

--- a/redfish/assembly.go
+++ b/redfish/assembly.go
@@ -18,8 +18,6 @@ type Assembly struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// Assemblies shall be the definition for assembly records for a Redfish

--- a/redfish/bios.go
+++ b/redfish/bios.go
@@ -57,8 +57,6 @@ type Bios struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// AttributeRegistry is the Resource ID of the Attribute Registry that has

--- a/redfish/chassis.go
+++ b/redfish/chassis.go
@@ -152,8 +152,6 @@ type Chassis struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// AssetTag shall contain an identifying string that

--- a/redfish/compositionservice.go
+++ b/redfish/compositionservice.go
@@ -18,8 +18,6 @@ type CompositionService struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// AllowOverprovisioning shall be a boolean indicating whether this service

--- a/redfish/computersystem.go
+++ b/redfish/computersystem.go
@@ -376,8 +376,6 @@ type ComputerSystem struct {
 
 	// ODataContext is the @odata.context
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the @odata.etag
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the @odata.type
 	ODataType string `json:"@odata.type"`
 

--- a/redfish/drive.go
+++ b/redfish/drive.go
@@ -123,8 +123,6 @@ type Drive struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// assembly shall be a link to a resource of type Assembly.

--- a/redfish/endpoint.go
+++ b/redfish/endpoint.go
@@ -102,8 +102,6 @@ type Endpoint struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// ConnectedEntities shall contain all the entities which this endpoint

--- a/redfish/ethernetinterface.go
+++ b/redfish/ethernetinterface.go
@@ -105,8 +105,6 @@ type EthernetInterface struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// AutoNeg shall be true if auto negotiation of speed and duplex is enabled

--- a/redfish/eventdestination.go
+++ b/redfish/eventdestination.go
@@ -116,8 +116,6 @@ type EventDestination struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// Context shall contain a client supplied context that will remain with the

--- a/redfish/eventservice.go
+++ b/redfish/eventservice.go
@@ -73,8 +73,6 @@ type EventService struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// DeliveryRetryAttempts shall be the

--- a/redfish/hostinterface.go
+++ b/redfish/hostinterface.go
@@ -47,8 +47,6 @@ type HostInterface struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// AuthNoneRoleID is used when no authentication on this interface is

--- a/redfish/logentry.go
+++ b/redfish/logentry.go
@@ -311,8 +311,6 @@ type LogEntry struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// Created shall be the time at which the log entry was created.

--- a/redfish/logservice.go
+++ b/redfish/logservice.go
@@ -48,8 +48,6 @@ type LogService struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// DateTime shall represent the current DateTime value that the log service

--- a/redfish/manager.go
+++ b/redfish/manager.go
@@ -168,8 +168,6 @@ type Manager struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// AutoDSTEnabled shall contain the enabled status of the automatic Daylight

--- a/redfish/manageraccount.go
+++ b/redfish/manageraccount.go
@@ -31,8 +31,6 @@ type ManagerAccount struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// AccountTypes shall contain an array of the various

--- a/redfish/memory.go
+++ b/redfish/memory.go
@@ -191,8 +191,6 @@ type Memory struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// AllocationAlignmentMiB shall be the alignment boundary on which memory

--- a/redfish/memorydomain.go
+++ b/redfish/memorydomain.go
@@ -16,8 +16,6 @@ type MemoryDomain struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// AllowsBlockProvisioning shall indicate if this Memory Domain supports the

--- a/redfish/memorymetrics.go
+++ b/redfish/memorymetrics.go
@@ -76,8 +76,6 @@ type MemoryMetrics struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// BandwidthPercent shall contain memory bandwidth utilization as a

--- a/redfish/networkadapter.go
+++ b/redfish/networkadapter.go
@@ -172,8 +172,6 @@ type NetworkAdapter struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// Assembly shall be a link to a resource of type Assembly.

--- a/redfish/networkdevicefunction.go
+++ b/redfish/networkdevicefunction.go
@@ -234,8 +234,6 @@ type NetworkDeviceFunction struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// AssignablePhysicalPorts shall be an array of physical port references

--- a/redfish/networkinterface.go
+++ b/redfish/networkinterface.go
@@ -27,8 +27,6 @@ type NetworkInterface struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// Description provides a description of this resource.

--- a/redfish/networkport.go
+++ b/redfish/networkport.go
@@ -122,8 +122,6 @@ type NetworkPort struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// Actions shall contain the available actions for this resource.

--- a/redfish/pciedevice.go
+++ b/redfish/pciedevice.go
@@ -46,8 +46,6 @@ type PCIeDevice struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// Assembly shall be a link to a resource of type Assembly.

--- a/redfish/pciefunction.go
+++ b/redfish/pciefunction.go
@@ -81,8 +81,6 @@ type PCIeFunction struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// ClassCode shall be the PCI Class Code of the PCIe device function.

--- a/redfish/power.go
+++ b/redfish/power.go
@@ -115,8 +115,6 @@ type Power struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// Description provides a description of this resource.

--- a/redfish/processor.go
+++ b/redfish/processor.go
@@ -259,8 +259,6 @@ type Processor struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// accelerationFunctions shall be a link to

--- a/redfish/role.go
+++ b/redfish/role.go
@@ -40,8 +40,6 @@ type Role struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// AssignedPrivileges shall contain the Redfish

--- a/redfish/secureboot.go
+++ b/redfish/secureboot.go
@@ -59,8 +59,6 @@ type SecureBoot struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// Description provides a description of this resource.

--- a/redfish/session.go
+++ b/redfish/session.go
@@ -44,8 +44,6 @@ type Session struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// Description provides a description of this resource.

--- a/redfish/simplestorage.go
+++ b/redfish/simplestorage.go
@@ -31,8 +31,6 @@ type SimpleStorage struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// Actions is The Actions property shall contain the available actions

--- a/redfish/storage.go
+++ b/redfish/storage.go
@@ -33,8 +33,6 @@ type Storage struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// Description provides a description of this resource.

--- a/redfish/task.go
+++ b/redfish/task.go
@@ -75,8 +75,6 @@ type Task struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// Description provides a description of this resource.

--- a/redfish/thermal.go
+++ b/redfish/thermal.go
@@ -260,8 +260,6 @@ type Thermal struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// Description provides a description of this resource.

--- a/redfish/vlannetworkinterface.go
+++ b/redfish/vlannetworkinterface.go
@@ -26,8 +26,6 @@ type VLanNetworkInterface struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// Description provides a description of this resource.

--- a/serviceroot.go
+++ b/serviceroot.go
@@ -67,8 +67,6 @@ type Service struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataID is the odata identifier.
 	ODataID string `json:"@odata.id"`
 	// ODataType is the odata type.

--- a/swordfish/capacity.go
+++ b/swordfish/capacity.go
@@ -58,8 +58,6 @@ type CapacitySource struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// Description provides a description of this resource.

--- a/swordfish/classofservice.go
+++ b/swordfish/classofservice.go
@@ -18,8 +18,6 @@ type ClassOfService struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// ClassOfServiceVersion is the version describing the creation or last

--- a/swordfish/dataprotectionlineofservice.go
+++ b/swordfish/dataprotectionlineofservice.go
@@ -18,8 +18,6 @@ type DataProtectionLineOfService struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// Description provides a description of this resource.

--- a/swordfish/dataprotectionloscapabilities.go
+++ b/swordfish/dataprotectionloscapabilities.go
@@ -72,8 +72,6 @@ type DataProtectionLoSCapabilities struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// Description provides a description of this resource.

--- a/swordfish/datasecuritylineofservice.go
+++ b/swordfish/datasecuritylineofservice.go
@@ -17,8 +17,6 @@ type DataSecurityLineOfService struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// AntivirusEngineProvider shall specify an AntiVirus provider.

--- a/swordfish/datasecurityloscapabilities.go
+++ b/swordfish/datasecurityloscapabilities.go
@@ -114,8 +114,6 @@ type DataSecurityLoSCapabilities struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// Description provides a description of this resource.

--- a/swordfish/datastoragelineofservice.go
+++ b/swordfish/datastoragelineofservice.go
@@ -17,8 +17,6 @@ type DataStorageLineOfService struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// AccessCapabilities is Each entry specifies a required storage access

--- a/swordfish/datastorageloscapabilities.go
+++ b/swordfish/datastorageloscapabilities.go
@@ -53,8 +53,6 @@ type DataStorageLoSCapabilities struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// Description provides a description of this resource.

--- a/swordfish/endpointgroup.go
+++ b/swordfish/endpointgroup.go
@@ -45,8 +45,6 @@ type EndpointGroup struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// AccessState is used for associated resources through all

--- a/swordfish/fileshare.go
+++ b/swordfish/fileshare.go
@@ -32,8 +32,6 @@ type FileShare struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// CASupported shall indicate that Continuous Availability is supported.

--- a/swordfish/filesystem.go
+++ b/swordfish/filesystem.go
@@ -98,8 +98,6 @@ type FileSystem struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// AccessCapabilities shall be an array containing entries for the supported

--- a/swordfish/ioconnectivitylineofservice.go
+++ b/swordfish/ioconnectivitylineofservice.go
@@ -17,8 +17,6 @@ type IOConnectivityLineOfService struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// AccessProtocols shall specify the Access protocol for this service

--- a/swordfish/ioconnectivityloscapabilities.go
+++ b/swordfish/ioconnectivityloscapabilities.go
@@ -18,8 +18,6 @@ type IOConnectivityLoSCapabilities struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// Description provides a description of this resource.

--- a/swordfish/ioperformancelineofservice.go
+++ b/swordfish/ioperformancelineofservice.go
@@ -17,8 +17,6 @@ type IOPerformanceLineOfService struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// AverageIOOperationLatencyMicroseconds shall be the expected average IO

--- a/swordfish/ioperformanceloscapabilities.go
+++ b/swordfish/ioperformanceloscapabilities.go
@@ -39,8 +39,6 @@ type IOPerformanceLoSCapabilities struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// Description provides a description of this resource.

--- a/swordfish/spareresourceset.go
+++ b/swordfish/spareresourceset.go
@@ -17,8 +17,6 @@ type SpareResourceSet struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// Description provides a description of this resource.

--- a/swordfish/storagegroup.go
+++ b/swordfish/storagegroup.go
@@ -57,8 +57,6 @@ type StorageGroup struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// AccessState shall describe the access

--- a/swordfish/storagepool.go
+++ b/swordfish/storagepool.go
@@ -21,8 +21,6 @@ type StoragePool struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// AllocatedPools shall contain a reference

--- a/swordfish/storagereplicainfo.go
+++ b/swordfish/storagereplicainfo.go
@@ -437,8 +437,6 @@ type StorageReplicaInfo struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// Description provides a description of this resource.

--- a/swordfish/storageservice.go
+++ b/swordfish/storageservice.go
@@ -22,7 +22,6 @@ type StorageService struct {
 	// ODataContext is
 	ODataContext string `json:"@odata.context"`
 	// ODataEtag is
-	ODataEtag string `json:"@odata.etag"`
 	// ODataId is
 	// ODataType is
 	ODataType string `json:"@odata.type"`

--- a/swordfish/volume.go
+++ b/swordfish/volume.go
@@ -241,8 +241,6 @@ type Volume struct {
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
-	// ODataEtag is the odata etag.
-	ODataEtag string `json:"@odata.etag"`
 	// ODataType is the odata type.
 	ODataType string `json:"@odata.type"`
 	// AccessCapabilities shall specify a current storage access capability.


### PR DESCRIPTION
ETags are defined as strings, but some vendor implementations return this as a numeric value, causing problems in the JSON unmarshalling from the API response. Since these are not used anywhere in the library, and since it is mostly an internal protocol detail, this just removes the field for now until we know we actually need it.