### PR TITLE
Add chassis test for redfish_exporter failure

### DIFF
--- a/redfish/chassis_test.go
+++ b/redfish/chassis_test.go
@@ -60,6 +60,44 @@ var chassisBody = `{
 		}
 	}`
 
+var supermicroRAIDChassisBody = `{
+    "@odata.type": "#Chassis.v1_9_1.Chassis",
+    "@odata.id": "/redfish/v1/Chassis/HA-RAID.0.StorageEnclosure.0",
+    "Id": "HA-RAID.0.StorageEnclosure.0",
+    "Name": "Internal Enclosure 0",
+    "ChassisType": "Enclosure",
+    "Model": "Internal Enclosure",
+    "SerialNumber": "",
+    "PartNumber": "",
+    "Links": {
+        "ManagedBy": [
+            {
+                "@odata.id": "/redfish/v1/Managers/1"
+            }
+        ],
+        "Storage": [
+            {
+                "@odata.id": "/redfish/v1/Systems/1/Storage/HA-RAID"
+            }
+        ],
+        "Drives": [
+            {
+                "@odata.id": "/redfish/v1/Chassis/HA-RAID.0.StorageEnclosure.0/Drives/Disk.Bay.0"
+            },
+            {
+                "@odata.id": "/redfish/v1/Chassis/HA-RAID.0.StorageEnclosure.0/Drives/Disk.Bay.1"
+            },
+            {
+                "@odata.id": "/redfish/v1/Chassis/HA-RAID.0.StorageEnclosure.0/Drives/Disk.Bay.2"
+            },
+            {
+                "@odata.id": "/redfish/v1/Chassis/HA-RAID.0.StorageEnclosure.0/Drives/Disk.Bay.3"
+            }
+        ]
+    },
+    "Oem": {}
+}`
+
 // TestChassis tests the parsing of Chassis objects.
 func TestChassis(t *testing.T) {
 	var result Chassis
@@ -124,6 +162,37 @@ func TestChassis(t *testing.T) {
 	if len(result.SupportedResetTypes) != 2 {
 		t.Errorf("Invalid allowable reset actions, expected 2, got %d",
 			len(result.SupportedResetTypes))
+	}
+}
+
+// TestMinimumChassis tests a failure we had from how SM returns a RAID
+// controller chassis.
+//
+// The required properties according to the spec are:
+// "required": [
+//	"ChassisType",
+//	"@odata.id",
+//	"@odata.type",
+//	"Id",
+//	"Name"]
+func TestMinimumChassis(t *testing.T) {
+	var result Chassis
+	err := json.NewDecoder(strings.NewReader(supermicroRAIDChassisBody)).Decode(&result)
+
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+
+	if result.ID != "HA-RAID.0.StorageEnclosure.0" {
+		t.Errorf("Received invalid ID: %s", result.ID)
+	}
+
+	if result.Name != "Internal Enclosure 0" {
+		t.Errorf("Received invalid name: %s", result.Name)
+	}
+
+	if result.ChassisType != EnclosureChassisType {
+		t.Errorf("Received invalid chassis type: %s", result.ChassisType)
 	}
 }
 


### PR DESCRIPTION
A user of redfish_exporter is getting a failure with one of their
Supermicro servers, but not all. Looking at the raw json returned from
these machines, the failure happens on a host that has a RAID chassis in
addition to the normal system chassis.

The results from getting the RAID chassis don't have as many values as
the full chassis, but according to the required properties defined in
the spec, it does return everything that is required.

To test to see if this was an issue in gofish, added a unit test that
would use the response from this system's RAID chassis and a new test
that validates only the spec-required minimum values. It appears gofish
handles this appropriately, but adding this test just in case. We may
want to add minimum required value tests for more objects, but this is a
start.

This is to help debug:
https://github.com/jenningsloy318/redfish_exporter/issues/15