### PR TITLE
Fix Logout fail

### DIFF
--- a/redfish/session.go
+++ b/redfish/session.go
@@ -6,6 +6,7 @@ package redfish
 
 import (
 	"encoding/json"
+	"net/url"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -93,6 +94,10 @@ func CreateSession(c common.Client, uri string, username string, password string
 	auth = &AuthToken{}
 	auth.Token = resp.Header.Get("X-Auth-Token")
 	auth.Session = resp.Header.Get("Location")
+
+	if urlParser, err := url.ParseRequestURI(auth.Session); err == nil {
+		auth.Session = urlParser.RequestURI()
+	}
 
 	return auth, err
 }


### PR DESCRIPTION
I propose this PR to fix Logout() fail on some vendor and have a question.

According to Redfish specification, client must get the URI of Session Resource from the Location header. But some vendor implementation returns the full URI path like `https://blahblah.blah/redfish/v1/SessionService/Sessions/{session id}`. This URI will generate the invalid session address and fail the logout from BMC, because last runRequest() from the call-path of Logout() combines that full URI path with the endpoint URL. If a user run this as a client tool many times, it makes session overflow.

From that reason I modified the CreateSession, but I didn't put any code to return an error from Logout() on failure.

Is it necessary to return an error when a logout fails?