### PR TITLE
export symbol client.Auth

### DIFF
--- a/client.go
+++ b/client.go
@@ -38,7 +38,7 @@ type APIClient struct {
 	Service *Service
 
 	// Auth information saved for later to be able to log out
-	auth *redfish.AuthToken
+	Auth *redfish.AuthToken
 
 	// dumpWriter will receive HTTP dumps if non-nil.
 	dumpWriter io.Writer
@@ -128,7 +128,7 @@ func Connect(config ClientConfig) (c *APIClient, err error) {
 		}
 
 		client.Service = service
-		client.auth = auth
+		client.Auth = auth
 	}
 
 	return client, err
@@ -221,12 +221,12 @@ func (c *APIClient) runRequest(method string, url string, payload interface{}) (
 	}
 
 	// Add auth info if authenticated
-	if c.auth != nil {
-		if c.auth.Token != "" {
-			req.Header.Set("X-Auth-Token", c.auth.Token)
+	if c.Auth != nil {
+		if c.Auth.Token != "" {
+			req.Header.Set("X-Auth-Token", c.Auth.Token)
 		} else {
-			if c.auth.BasicAuth == true && c.auth.Username != "" && c.auth.Password != "" {
-				encodedAuth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%v:%v", c.auth.Username, c.auth.Password)))
+			if c.Auth.BasicAuth == true && c.Auth.Username != "" && c.Auth.Password != "" {
+				encodedAuth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%v:%v", c.Auth.Username, c.Auth.Password)))
 				req.Header.Set("Authorization", fmt.Sprintf("Basic %v", encodedAuth))
 			}
 		}
@@ -282,7 +282,7 @@ func (c *APIClient) runRequest(method string, url string, payload interface{}) (
 // Logout will delete any active session. Useful to defer logout when creating
 // a new connection.
 func (c *APIClient) Logout() {
-	if c.Service != nil && c.auth != nil {
-		_ = c.Service.DeleteSession(c.auth.Session)
+	if c.Service != nil && c.Auth != nil {
+		_ = c.Service.DeleteSession(c.Auth.Session)
 	}
 }


### PR DESCRIPTION
This is the hack I mentioned in #79. It works fine but required a bit of code duplication regarding session initialization. I use it like this (slightly simplified):
```golang
// This initializes a new client with either an existing or a new session
func client(endpoint, user, pass string) (client *gofish.APIClient, err error) {
        client, err = oldSession(endpoint, "mysessionfile")
        if err != nil {
                return newSession(endpoint, sessionfile, user, pass)
        }
        return client, nil
}

func oldSession(endpoint, sessionfile string) (client *gofish.APIClient, err error) {
        tok, err := readSession(sessionfile) // returns a redfish.AuthToken
        if err != nil {
                return
        }
        client, err = connect(endpoint, "", "")
        if err != nil {
                return
        }
        service, err := gofish.ServiceRoot(client)
        if err != nil {
                return
        }

        client.Service = service
        client.Auth = tok
        _, err = service.Chassis()
        // Tried a query; if it errors out, this session has probably expired
        if err != nil {
                return
        }
        return client, nil
}

func newSession(endpoint, sessionfile, user, pass string) (client *gofish.APIClient, err error) {
        client, err = connect(endpoint, user, pass)
        if err != nil {
                return
        }
        err = writeSession(sessionfile, client.Auth)
        return
}

func connect(endpoint, user, pass string) (c *gofish.APIClient, err error) {
        return gofish.Connect(
                gofish.ClientConfig{
                        Endpoint:   endpoint,
                        Username:   user,
                        Password:   pass,
                        Insecure:   true,
                })
}
```
I'll just open another PR with an idea how to avoid this.