### PR TITLE
Add *http.Response return to APIClient.Delete method

### DIFF
--- a/client.go
+++ b/client.go
@@ -179,15 +179,15 @@ func (c *APIClient) Patch(url string, payload interface{}) (*http.Response, erro
 }
 
 // Delete performs a Delete request against the Redfish service.
-func (c *APIClient) Delete(url string) error {
+func (c *APIClient) Delete(url string) (*http.Response, error) {
 	resp, err := c.runRequest(http.MethodDelete, url, nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if resp != nil && resp.Body != nil {
 		resp.Body.Close()
 	}
-	return nil
+	return resp, nil
 }
 
 // runRequest actually performs the REST calls.

--- a/common/testclient.go
+++ b/common/testclient.go
@@ -155,11 +155,11 @@ func (c *TestClient) Patch(url string, payload interface{}) (*http.Response, err
 }
 
 // Delete performs a Delete request against the Redfish service.
-func (c *TestClient) Delete(url string) error {
+func (c *TestClient) Delete(url string) (*http.Response, error) {
 	c.recordCall(http.MethodDelete, url, nil)
 	customReturnForAction := c.getCustomReturnForAction(http.MethodDelete)
 	if customReturnForAction == nil {
-		return nil
+		return nil, nil
 	}
-	return customReturnForAction.(error)
+	return customReturnForAction.(*http.Response), nil
 }

--- a/common/types.go
+++ b/common/types.go
@@ -20,7 +20,7 @@ type Client interface {
 	Post(url string, payload interface{}) (*http.Response, error)
 	Patch(url string, payload interface{}) (*http.Response, error)
 	Put(url string, payload interface{}) (*http.Response, error)
-	Delete(url string) error
+	Delete(url string) (*http.Response, error)
 }
 
 // Entity provides the common basis for all Redfish and Swordfish objects.

--- a/redfish/eventdestination.go
+++ b/redfish/eventdestination.go
@@ -389,8 +389,8 @@ func DeleteEventDestination(c common.Client, uri string) (err error) {
 	if len(strings.TrimSpace(uri)) == 0 {
 		return fmt.Errorf("uri should not be empty")
 	}
-	resp, err := c.Delete(uri)
-	defer resp.Body.Close()
+	_, err = c.Delete(uri)
+	//defer resp.Body.Close()
 
 	return err
 }

--- a/redfish/eventdestination.go
+++ b/redfish/eventdestination.go
@@ -389,8 +389,10 @@ func DeleteEventDestination(c common.Client, uri string) (err error) {
 	if len(strings.TrimSpace(uri)) == 0 {
 		return fmt.Errorf("uri should not be empty")
 	}
+	resp, err := c.Delete(uri)
+	defer resp.Body.Close()
 
-	return c.Delete(uri)
+	return err
 }
 
 // ListReferencedEventDestinations gets the collection of EventDestination from

--- a/redfish/session.go
+++ b/redfish/session.go
@@ -104,7 +104,7 @@ func CreateSession(c common.Client, uri string, username string, password string
 
 // DeleteSession deletes a session using the location as argument
 func DeleteSession(c common.Client, url string) (err error) {
-	resp, err := c.Delete(uri, a)
+	resp, err := c.Delete(url)
 	if err != nil {
 		return err
 	}

--- a/redfish/session.go
+++ b/redfish/session.go
@@ -104,7 +104,12 @@ func CreateSession(c common.Client, uri string, username string, password string
 
 // DeleteSession deletes a session using the location as argument
 func DeleteSession(c common.Client, url string) (err error) {
-	return c.Delete(url)
+	resp, err := c.Delete(uri, a)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
 }
 
 // GetSession will get a Session instance from the Redfish service.


### PR DESCRIPTION
Hello Sean,

I'm proposing the PR in reference to [!82](https://github.com/stmcginnis/gofish/issues/85).

I've little tested the new APIClient.Delete call and it works. I also needed to change some other files that used that call. I've always followed the philosophy of being as less intrusive in the code as possible. 

Now the Client interface looks like this (please check the **Delete** definition):
~~~
type Client interface {
	Get(url string) (*http.Response, error)
	Post(url string, payload interface{}) (*http.Response, error)
	Patch(url string, payload interface{}) (*http.Response, error)
	Put(url string, payload interface{}) (*http.Response, error)
	Delete(url string) (*http.Response, error)
}
~~~

Files also changed apart from client.go and types.go:
- eventdestination.go
- session.go

Thanks!
/Miguel
