### PR TITLE
Volume OperationApplyTimeSupport added

### DIFF
--- a/redfish/storage.go
+++ b/redfish/storage.go
@@ -187,6 +187,12 @@ func (storage *Storage) SetEncryptionKey(key string) error {
 	return err
 }
 
+// GetOperationApplyTimeValues returns the OperationApplyTime values applicable for this storage
+func (storage *Storage) GetOperationApplyTimeValues() ([]common.OperationApplyTime, error) {
+	return AllowedVolumesUpdateApplyTimes(storage.Client, storage.volumes)
+
+}
+
 // StorageController is used to represent a resource that represents a
 // storage controller in the Redfish specification.
 type StorageController struct {

--- a/redfish/volume.go
+++ b/redfish/volume.go
@@ -192,15 +192,6 @@ type Volume struct {
 	drives []string
 }
 
-// Volumes is used to represent the volumes information related to a Storage
-type Volumes struct {
-	common.Entity
-	// OperationApplyTimeSupport contains, among other things, the types
-	// of apply times the client is allowed request when performing a Create,
-	// Delete, or Action operation.
-	OperationApplyTimeSupport common.OperationApplyTimeSupport `json:"@Redfish.OperationApplyTimeSupport"`
-}
-
 // UnmarshalJSON unmarshals a Volume object from the raw JSON.
 func (volume *Volume) UnmarshalJSON(b []byte) error {
 	type temp Volume
@@ -290,15 +281,17 @@ func AllowedVolumesUpdateApplyTimes(c common.Client, link string) ([]common.Oper
 		return nil, err
 	}
 	defer resp.Body.Close()
-	var volumes Volumes
+	var temp struct {
+		OperationApplyTimeSupport common.OperationApplyTimeSupport `json:"@Redfish.OperationApplyTimeSupport"`
+	}
 
-	err = json.NewDecoder(resp.Body).Decode(&volumes)
+	err = json.NewDecoder(resp.Body).Decode(&temp)
 	if err != nil {
 		return nil, err
 	}
 
 	var applyTimes []common.OperationApplyTime
-	for _, v := range volumes.OperationApplyTimeSupport.SupportedValues {
+	for _, v := range temp.OperationApplyTimeSupport.SupportedValues {
 		applyTimes = append(applyTimes, v)
 	}
 	return applyTimes, nil

--- a/redfish/volume.go
+++ b/redfish/volume.go
@@ -192,6 +192,15 @@ type Volume struct {
 	drives []string
 }
 
+// Volumes is used to represent the volumes information related to a Storage
+type Volumes struct {
+	common.Entity
+	// OperationApplyTimeSupport contains, among other things, the types
+	// of apply times the client is allowed request when performing a Create,
+	// Delete, or Action operation.
+	OperationApplyTimeSupport common.OperationApplyTimeSupport `json:"@Redfish.OperationApplyTimeSupport"`
+}
+
 // UnmarshalJSON unmarshals a Volume object from the raw JSON.
 func (volume *Volume) UnmarshalJSON(b []byte) error {
 	type temp Volume
@@ -272,4 +281,25 @@ func (volume *Volume) Drives() ([]*Drive, error) {
 	}
 
 	return result, nil
+}
+
+// AllowedVolumesUpdateApplyTimes returns the set of allowed apply times to request when setting the volumes values
+func AllowedVolumesUpdateApplyTimes(c common.Client, link string) ([]common.OperationApplyTime, error) {
+	resp, err := c.Get(link)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var volumes Volumes
+
+	err = json.NewDecoder(resp.Body).Decode(&volumes)
+	if err != nil {
+		return nil, err
+	}
+
+	var applyTimes []common.OperationApplyTime
+	for _, v := range volumes.OperationApplyTimeSupport.SupportedValues {
+		applyTimes = append(applyTimes, v)
+	}
+	return applyTimes, nil
 }


### PR DESCRIPTION
Hello Sean,

I've created this pull request to address something that was missing in the current implementation.

I needed to figure out the *OperationApplyTimeValues* for Storage controllers. This is very useful to see if you can perform a disk operation rightraway (Immediate) or you need to reboot the server (OnReset).

Having these values is highly valuable to see what strategy to follow when it comes to create virtual disks on top of disk controllers 😄 

Let me know!
/Miguel