### PR TITLE
Added UpdateService to the API

### DIFF
--- a/redfish/updateservice.go
+++ b/redfish/updateservice.go
@@ -1,0 +1,78 @@
+package redfish
+
+import (
+	"encoding/json"
+
+	"github.com/stmcginnis/gofish/common"
+)
+
+// UpdateService is used to represent the update service offered by the redfish API
+type UpdateService struct {
+	common.Entity
+
+	// ODataContext is the odata context.
+	ODataContext string `json:"@odata.context"`
+	// ODataType is the odata type.
+	ODataType string `json:"@odata.type"`
+	// Description provides a description of this resource.
+	Description string
+	// FirmwareInventory points towards the firmware store endpoint
+	FirmwareInventory string
+	// HTTPPushURI endpoint is used to push (POST) firmware updates
+	HTTPPushURI string `json:"HttpPushUri"`
+	// ServiceEnabled indicates whether this service isenabled.
+	ServiceEnabled bool
+	// Status describes the status and health of a resource and its children.
+	Status common.Status
+	// TransferProtocol is the list of network protocols used by the UpdateService to retrieve the software image file
+	TransferProtocol []string
+	// UpdateServiceTarget indicates where theupdate image is to be applied.
+	UpdateServiceTarget string
+	// rawData holds the original serialized JSON so we can compare updates.
+	rawData []byte
+}
+
+// UnmarshalJSON unmarshals a UpdateService object from the raw JSON.
+func (updateService *UpdateService) UnmarshalJSON(b []byte) error {
+	type temp UpdateService
+	type actions struct {
+		SimpleUpdate struct {
+			AllowableValues []string `json:"TransferProtocol@Redfish.AllowableValues"`
+			Target          string
+		} `json:"#UpdateService.SimpleUpdate"`
+	}
+	var t struct {
+		temp
+		Actions           actions
+		FirmwareInventory common.Link
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	// Extract the links to other entities for later
+	*updateService = UpdateService(t.temp)
+	updateService.FirmwareInventory = string(t.FirmwareInventory)
+	updateService.TransferProtocol = t.Actions.SimpleUpdate.AllowableValues
+	updateService.UpdateServiceTarget = t.Actions.SimpleUpdate.Target
+	updateService.rawData = b
+	return nil
+}
+
+// GetUpdateService will get a UpdateService instance from the service.
+func GetUpdateService(c common.Client, uri string) (*UpdateService, error) {
+	resp, err := c.Get(uri)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var updateService UpdateService
+	err = json.NewDecoder(resp.Body).Decode(&updateService)
+	if err != nil {
+		return nil, err
+	}
+	updateService.SetClient(c)
+	return &updateService, nil
+}

--- a/redfish/updateservice_test.go
+++ b/redfish/updateservice_test.go
@@ -1,0 +1,67 @@
+package redfish
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+var simpleUpdateBody = `{
+    "@odata.context": "/redfish/v1/$metadata#UpdateService.UpdateService",
+    "@odata.id": "/redfish/v1/UpdateService",
+    "@odata.type": "#UpdateService.v1_6_0.UpdateService",
+    "Actions": {
+        "#UpdateService.SimpleUpdate": {
+            "TransferProtocol@Redfish.AllowableValues": [
+                "HTTP"
+            ],
+            "target": "/redfish/v1/UpdateService/Actions/UpdateService.SimpleUpdate"
+        },
+        "Oem": {
+            "DellUpdateService.v1_0_0#DellUpdateService.Install": {
+                "InstallUpon@Redfish.AllowableValues": [
+                    "Now",
+                    "NowAndReboot",
+                    "NextReboot"
+                ],
+                "target": "/redfish/v1/UpdateService/Actions/Oem/DellUpdateService.Install"
+            }
+        }
+    },
+    "Description": "Represents the properties for the Update Service",
+    "FirmwareInventory": {
+        "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory"
+    },
+    "HttpPushUri": "/redfish/v1/UpdateService/FirmwareInventory",
+    "Id": "UpdateService",
+    "Name": "Update Service",
+    "ServiceEnabled": true,
+    "Status": {
+        "Health": "OK",
+        "State": "Enabled"
+    }
+}`
+
+func TestUpdateService(t *testing.T) {
+	var result UpdateService
+	err := json.NewDecoder(strings.NewReader(simpleUpdateBody)).Decode(&result)
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+
+	if result.FirmwareInventory != "/redfish/v1/UpdateService/FirmwareInventory" {
+		t.Errorf("FirmwareInventory was wrong")
+	}
+
+	if result.HTTPPushURI != "/redfish/v1/UpdateService/FirmwareInventory" {
+		t.Errorf("HTTPPushURI was wrong")
+	}
+
+	if result.TransferProtocol[0] != "HTTP" {
+		t.Errorf("TransferProtocol was wrong")
+	}
+
+	if result.UpdateServiceTarget != "/redfish/v1/UpdateService/Actions/UpdateService.SimpleUpdate" {
+		t.Errorf("UpdateServiceTarget was wrong")
+	}
+}

--- a/serviceroot.go
+++ b/serviceroot.go
@@ -284,3 +284,8 @@ func (serviceroot *Service) Systems() ([]*redfish.ComputerSystem, error) {
 func (serviceroot *Service) CompositionService() (*redfish.CompositionService, error) {
 	return redfish.GetCompositionService(serviceroot.Client, serviceroot.compositionService)
 }
+
+// UpdateService gets the update service instance
+func (serviceroot *Service) UpdateService() (*redfish.UpdateService, error) {
+	return redfish.GetUpdateService(serviceroot.Client, serviceroot.updateService)
+}


### PR DESCRIPTION
Hello Sean,

Hope you're doing well 😄 

Recently I've noticed that the gofish API was missing from the *UpdateService* part, which allow operators to update the firmware from their infrastructure.
What I've done is to implement the standard way of upgrading firmware (via **/redfish/v1/UpdateService/Actions/UpdateService.SimpleUpdate**) and left apart the "OEM" functions (which vary from vendor to vendor, i.e. in Dell infra would be **/redfish/v1/UpdateService/Actions/Oem/DellUpdateService.Install**).
This should be portable across vendors.

Also I've added the unit tests needed for the new struct (*UpdateService*) and JSON unmarshalling.

Best regards!