### PR TITLE
add protocol and context arguments for event subscriptions

### DIFF
--- a/redfish/eventdestination.go
+++ b/redfish/eventdestination.go
@@ -282,10 +282,12 @@ func GetEventDestination(c common.Client, uri string) (*EventDestination, error)
 
 // subscriptionPayload is the payload to create the event subscription
 type subscriptionPayload struct {
-	Destination string            `json:"Destination"`
-	EventTypes  []EventType       `json:"EventTypes"`
-	HTTPHeaders map[string]string `json:"HttpHeaders,omitempty"`
-	Oem         interface{}       `json:"Oem,omitempty"`
+	Destination string                   `json:"Destination"`
+	EventTypes  []EventType              `json:"EventTypes"`
+	HTTPHeaders map[string]string        `json:"HttpHeaders,omitempty"`
+	Oem         interface{}              `json:"Oem,omitempty"`
+	Protocol    EventDestinationProtocol `json:"Protocol,omitempty"`
+	Context     string                   `json:"Context,omitempty"`
 }
 
 // validateCreateEventDestinationParams will validate
@@ -328,6 +330,9 @@ func validateCreateEventDestinationParams(
 // eventTypes is a list of EventType to subscribe to.
 // httpHeaders is optional and gives the opportunity to specify any arbitrary
 // HTTP headers required for the event POST operation.
+// protocol should be the communication protocol of the event endpoint,
+// usually RedfishEventDestinationProtocol
+// context is a required client-supplied string that is sent with the event notifications
 // oem is optional and gives the opportunity to specify any OEM specific properties,
 // it should contain the vendor specific struct that goes inside the Oem session.
 // It returns the new subscription URI if the event subscription is created
@@ -338,6 +343,8 @@ func CreateEventDestination(
 	destination string,
 	eventTypes []EventType,
 	httpHeaders map[string]string,
+	protocol EventDestinationProtocol,
+	context string,
 	oem interface{},
 ) (string, error) {
 
@@ -356,6 +363,8 @@ func CreateEventDestination(
 	s := &subscriptionPayload{
 		Destination: destination,
 		EventTypes:  eventTypes,
+		Protocol:    protocol,
+		Context:     context,
 	}
 
 	// HTTP headers

--- a/redfish/eventservice.go
+++ b/redfish/eventservice.go
@@ -284,6 +284,9 @@ func (eventservice *EventService) GetEventSubscription(uri string) (*EventDestin
 // eventTypes is a list of EventType to subscribe to.
 // httpHeaders is optional and gives the opportunity to specify any arbitrary
 // HTTP headers required for the event POST operation.
+// protocol should be the communication protocol of the event endpoint,
+// usually RedfishEventDestinationProtocol
+// context is a required client-supplied string that is sent with the event notifications
 // oem is optional and gives the opportunity to specify any OEM specific properties,
 // it should contain the vendor specific struct that goes inside the Oem session.
 // It returns the new subscription URI if the event subscription is created
@@ -292,6 +295,8 @@ func (eventservice *EventService) CreateEventSubscription(
 	destination string,
 	eventTypes []EventType,
 	httpHeaders map[string]string,
+	protocol EventDestinationProtocol,
+	context string,
 	oem interface{},
 ) (string, error) {
 	if len(strings.TrimSpace(eventservice.subscriptions)) == 0 {
@@ -304,7 +309,10 @@ func (eventservice *EventService) CreateEventSubscription(
 		destination,
 		eventTypes,
 		httpHeaders,
-		oem)
+		protocol,
+		context,
+		oem,
+	)
 }
 
 // DeleteEventSubscription deletes a specific subscription using the event service.

--- a/redfish/eventservice_test.go
+++ b/redfish/eventservice_test.go
@@ -206,6 +206,8 @@ func TestEventServiceCreateEventSubscription(t *testing.T) {
 		map[string]string{
 			"Header": "HeaderValue",
 		},
+		RedfishEventDestinationProtocol,
+		"Public",
 		OemVendor{
 			Vendor: Vendor{
 				FirstVendorSpecificConfiguration:  1,
@@ -404,6 +406,8 @@ func TestEventServiceCreateEventSubscriptionWithoutOptionalParameters(t *testing
 		"https://myeventreciever/eventreceiver",
 		[]EventType{SupportedEventTypes["Alert"]},
 		nil,
+		RedfishEventDestinationProtocol,
+		"Public",
 		nil,
 	)
 
@@ -453,6 +457,8 @@ func TestEventServiceCreateEventSubscriptionInputParametersValidation(t *testing
 		invalidDestination,
 		[]EventType{SupportedEventTypes["Alert"]},
 		nil,
+		RedfishEventDestinationProtocol,
+		"Public",
 		nil,
 	)
 
@@ -470,6 +476,8 @@ func TestEventServiceCreateEventSubscriptionInputParametersValidation(t *testing
 		invalidDestination,
 		[]EventType{SupportedEventTypes["Alert"]},
 		nil,
+		RedfishEventDestinationProtocol,
+		"Public",
 		nil,
 	)
 
@@ -487,6 +495,8 @@ func TestEventServiceCreateEventSubscriptionInputParametersValidation(t *testing
 		invalidDestination,
 		[]EventType{SupportedEventTypes["Alert"]},
 		nil,
+		RedfishEventDestinationProtocol,
+		"Public",
 		nil,
 	)
 
@@ -503,6 +513,8 @@ func TestEventServiceCreateEventSubscriptionInputParametersValidation(t *testing
 		"https://myeventreciever/eventreceiver",
 		[]EventType{},
 		nil,
+		RedfishEventDestinationProtocol,
+		"Public",
 		nil,
 	)
 
@@ -519,6 +531,8 @@ func TestEventServiceCreateEventSubscriptionInputParametersValidation(t *testing
 		"https://myeventreciever/eventreceiver",
 		nil,
 		nil,
+		RedfishEventDestinationProtocol,
+		"Public",
 		nil,
 	)
 
@@ -537,6 +551,8 @@ func TestEventServiceCreateEventSubscriptionInputParametersValidation(t *testing
 		"https://myeventreciever/eventreceiver",
 		[]EventType{SupportedEventTypes["Alert"]},
 		nil,
+		RedfishEventDestinationProtocol,
+		"Public",
 		nil,
 	)
 


### PR DESCRIPTION
I had to add Protocol and Context to the payload so Dell would accept
the event subscription definition.

I did that by adding extra arguments all the way through the stack. Since
they are required, I added them before the optional `oem` argument to
those functions.