### PR TITLE
Add method to get VirtualMedia for a Manager

### DIFF
--- a/redfish/manager.go
+++ b/redfish/manager.go
@@ -459,3 +459,8 @@ func (manager *Manager) EthernetInterfaces() ([]*EthernetInterface, error) {
 func (manager *Manager) LogServices() ([]*LogService, error) {
 	return ListReferencedLogServices(manager.Client, manager.logServices)
 }
+
+// VirtualMedia gets the virtual media associated with this manager.
+func (manager *Manager) VirtualMedia() ([]*VirtualMedia, error) {
+	return ListReferencedVirtualMedias(manager.Client, manager.virtualMedia)
+}

--- a/redfish/virtualmedia.go
+++ b/redfish/virtualmedia.go
@@ -125,6 +125,12 @@ type VirtualMedia struct {
 	insertMediaTarget string
 	// rawData holds the original serialized JSON so we can compare updates.
 	rawData []byte
+	// SupportsMediaEject indicates if this implementation supports ejecting
+	// virtual media or not (added in schema 1.2.0).
+	SupportsMediaEject bool
+	// SupportsMediaInsert indicates if this implementation supports inserting
+	// virtual media or not (added in schema 1.2.0).
+	SupportsMediaInsert bool
 }
 
 // UnmarshalJSON unmarshals a VirtualMedia object from the raw JSON.
@@ -153,6 +159,9 @@ func (virtualmedia *VirtualMedia) UnmarshalJSON(b []byte) error {
 	// Extract the links to other entities for later
 	virtualmedia.ejectMediaTarget = t.Actions.EjectMedia.Target
 	virtualmedia.insertMediaTarget = t.Actions.InsertMedia.Target
+
+	virtualmedia.SupportsMediaEject = (virtualmedia.ejectMediaTarget != "")
+	virtualmedia.SupportsMediaInsert = (virtualmedia.insertMediaTarget != "")
 
 	// This is a read/write object, so we need to save the raw object data for later
 	virtualmedia.rawData = b

--- a/redfish/virtualmedia.go
+++ b/redfish/virtualmedia.go
@@ -6,6 +6,7 @@ package redfish
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
@@ -191,6 +192,37 @@ func (virtualmedia *VirtualMedia) Update() error {
 	currentElement := reflect.ValueOf(virtualmedia).Elem()
 
 	return virtualmedia.Entity.Update(originalElement, currentElement, readWriteFields)
+}
+
+// EjectMedia sends a request to eject the media.
+func (virtualmedia *VirtualMedia) EjectMedia() error {
+	if !virtualmedia.SupportsMediaEject {
+		return errors.New("redfish service does not support VirtualMedia.EjectMedia calls")
+	}
+
+	_, err := virtualmedia.Client.Post(virtualmedia.ejectMediaTarget, nil)
+	return err
+}
+
+// InsertMedia sends a request to insert virtual media.
+func (virtualmedia *VirtualMedia) InsertMedia(image string, inserted bool, writeProtected bool) error {
+	if !virtualmedia.SupportsMediaInsert {
+		return errors.New("redfish service does not support VirtualMedia.InsertMedia calls")
+	}
+
+	type temp struct {
+		Image          string
+		Inserted       bool
+		WriteProtected bool
+	}
+	t := temp{
+		Image:          image,
+		Inserted:       inserted,
+		WriteProtected: writeProtected,
+	}
+
+	_, err := virtualmedia.Client.Post(virtualmedia.insertMediaTarget, t)
+	return err
 }
 
 // GetVirtualMedia will get a VirtualMedia instance from the service.

--- a/redfish/virtualmedia.go
+++ b/redfish/virtualmedia.go
@@ -1,0 +1,227 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package redfish
+
+import (
+	"encoding/json"
+	"reflect"
+
+	"github.com/stmcginnis/gofish/common"
+)
+
+// ConnectedVia are the ways the media may be connected.
+type ConnectedVia string
+
+const (
+
+	// NotConnectedConnectedVia No current connection.
+	NotConnectedConnectedVia ConnectedVia = "NotConnected"
+	// URIConnectedVia Connected to a URI location.
+	URIConnectedVia ConnectedVia = "URI"
+	// AppletConnectedVia Connected to a client application.
+	AppletConnectedVia ConnectedVia = "Applet"
+	// OemConnectedVia Connected through an OEM-defined method.
+	OemConnectedVia ConnectedVia = "Oem"
+)
+
+// VirtualMediaType is the type of media.
+type VirtualMediaType string
+
+const (
+
+	// CDMediaType A CD-ROM format (ISO) image.
+	CDMediaType VirtualMediaType = "CD"
+	// FloppyMediaType A floppy disk image.
+	FloppyMediaType VirtualMediaType = "Floppy"
+	// USBStickMediaType An emulation of a USB storage device.
+	USBStickMediaType VirtualMediaType = "USBStick"
+	// DVDMediaType A DVD-ROM format image.
+	DVDMediaType VirtualMediaType = "DVD"
+)
+
+// TransferMethod is how the data is transfered.
+type TransferMethod string
+
+const (
+
+	// StreamTransferMethod Stream image file data from the source URI.
+	StreamTransferMethod TransferMethod = "Stream"
+	// UploadTransferMethod Upload the entire image file from the source URI
+	// to the service.
+	UploadTransferMethod TransferMethod = "Upload"
+)
+
+// TransferProtocolType is the protocol used to transfer.
+type TransferProtocolType string
+
+const (
+
+	// CIFSTransferProtocolType Common Internet File System (CIFS).
+	CIFSTransferProtocolType TransferProtocolType = "CIFS"
+	// FTPTransferProtocolType File Transfer Protocol (FTP).
+	FTPTransferProtocolType TransferProtocolType = "FTP"
+	// SFTPTransferProtocolType Secure File Transfer Protocol (SFTP).
+	SFTPTransferProtocolType TransferProtocolType = "SFTP"
+	// HTTPTransferProtocolType Hypertext Transfer Protocol (HTTP).
+	HTTPTransferProtocolType TransferProtocolType = "HTTP"
+	// HTTPSTransferProtocolType Hypertext Transfer Protocol Secure (HTTPS).
+	HTTPSTransferProtocolType TransferProtocolType = "HTTPS"
+	// NFSTransferProtocolType Network File System (NFS).
+	NFSTransferProtocolType TransferProtocolType = "NFS"
+	// SCPTransferProtocolType Secure Copy Protocol (SCP).
+	SCPTransferProtocolType TransferProtocolType = "SCP"
+	// TFTPTransferProtocolType Trivial File Transfer Protocol (TFTP).
+	TFTPTransferProtocolType TransferProtocolType = "TFTP"
+	// OEMTransferProtocolType A manufacturer-defined protocol.
+	OEMTransferProtocolType TransferProtocolType = "OEM"
+)
+
+// VirtualMedia shall represent a virtual media service for a Redfish
+// implementation.
+type VirtualMedia struct {
+	common.Entity
+
+	// ODataContext is the odata context.
+	ODataContext string `json:"@odata.context"`
+	// ODataType is the odata type.
+	ODataType string `json:"@odata.type"`
+	// ConnectedVia shall contain the current connection
+	// method from a client to the virtual media that this Resource
+	// represents.
+	ConnectedVia ConnectedVia
+	// Description provides a description of this resource.
+	Description string
+	// Image shall contain an URI. A null value indicated
+	// no image connection.
+	Image string
+	// ImageName shall contain the name of the image.
+	ImageName string
+	// Inserted shall indicate whether media is present in
+	// the virtual media device.
+	Inserted bool
+	// MediaTypes shall be the supported media
+	// types for this connection.
+	MediaTypes []VirtualMediaType
+	// Password shall represent the password to access the
+	// Image parameter-specified URI. The value shall be null in responses.
+	Password string
+	// TransferMethod shall describe how the image transfer
+	// occurs.
+	TransferMethod TransferMethod
+	// TransferProtocolType shall represent the network
+	// protocol to use with the specified image URI.
+	TransferProtocolType TransferProtocolType
+	// UserName shall represent the user name to access the
+	// Image parameter-specified URI.
+	UserName string
+	// WriteProtected shall indicate whether the remote
+	// device media prevents writing to that media.
+	WriteProtected bool
+	// ejectMediaTarget is the URL to send EjectMedia requests.
+	ejectMediaTarget string
+	// insertMediaTarget is the URL to send InsertMedia requests.
+	insertMediaTarget string
+	// rawData holds the original serialized JSON so we can compare updates.
+	rawData []byte
+}
+
+// UnmarshalJSON unmarshals a VirtualMedia object from the raw JSON.
+func (virtualmedia *VirtualMedia) UnmarshalJSON(b []byte) error {
+	type temp VirtualMedia
+	type actions struct {
+		EjectMedia struct {
+			Target string
+		} `json:"#VirtualMedia.EjectMedia"`
+		InsertMedia struct {
+			Target string
+		} `json:"#VirtualMedia.InsertMedia"`
+	}
+	var t struct {
+		temp
+		Actions actions
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	*virtualmedia = VirtualMedia(t.temp)
+
+	// Extract the links to other entities for later
+	virtualmedia.ejectMediaTarget = t.Actions.EjectMedia.Target
+	virtualmedia.insertMediaTarget = t.Actions.InsertMedia.Target
+
+	// This is a read/write object, so we need to save the raw object data for later
+	virtualmedia.rawData = b
+
+	return nil
+}
+
+// Update commits updates to this object's properties to the running system.
+func (virtualmedia *VirtualMedia) Update() error {
+
+	// Get a representation of the object's original state so we can find what
+	// to update.
+	original := new(VirtualMedia)
+	original.UnmarshalJSON(virtualmedia.rawData)
+
+	readWriteFields := []string{
+		"Image",
+		"Inserted",
+		"Password",
+		"TransferMethod",
+		"TransferProtocolType",
+		"UserName",
+		"WriteProtected",
+	}
+
+	originalElement := reflect.ValueOf(original).Elem()
+	currentElement := reflect.ValueOf(virtualmedia).Elem()
+
+	return virtualmedia.Entity.Update(originalElement, currentElement, readWriteFields)
+}
+
+// GetVirtualMedia will get a VirtualMedia instance from the service.
+func GetVirtualMedia(c common.Client, uri string) (*VirtualMedia, error) {
+	resp, err := c.Get(uri)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var virtualmedia VirtualMedia
+	err = json.NewDecoder(resp.Body).Decode(&virtualmedia)
+	if err != nil {
+		return nil, err
+	}
+
+	virtualmedia.SetClient(c)
+	return &virtualmedia, nil
+}
+
+// ListReferencedVirtualMedias gets the collection of VirtualMedia from
+// a provided reference.
+func ListReferencedVirtualMedias(c common.Client, link string) ([]*VirtualMedia, error) {
+	var result []*VirtualMedia
+	if link == "" {
+		return result, nil
+	}
+
+	links, err := common.GetCollection(c, link)
+	if err != nil {
+		return result, err
+	}
+
+	for _, virtualmediaLink := range links.ItemLinks {
+		virtualmedia, err := GetVirtualMedia(c, virtualmediaLink)
+		if err != nil {
+			return result, err
+		}
+		result = append(result, virtualmedia)
+	}
+
+	return result, nil
+}

--- a/redfish/virtualmedia_test.go
+++ b/redfish/virtualmedia_test.go
@@ -1,0 +1,110 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package redfish
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stmcginnis/gofish/common"
+)
+
+var vmBody = `{
+	"@odata.context": "/redfish/v1/$metadata#VirtualMedia.VirtualMedia",
+	"@odata.etag": "W/\"\"",
+	"@odata.id": "/redfish/v1/Managers/1/VirtualMedia/1",
+	"@odata.type": "#VirtualMedia.v1_2_0.VirtualMedia",
+	"Id": "1",
+	"Actions": {
+	  "#VirtualMedia.EjectMedia": {
+		"target": "/redfish/v1/Managers/1/VirtualMedia/1/Actions/VirtualMedia.EjectMedia"
+	  },
+	  "#VirtualMedia.InsertMedia": {
+		"target": "/redfish/v1/Managers/1/VirtualMedia/1/Actions/VirtualMedia.InsertMedia"
+	  }
+	},
+	"ConnectedVia": "NotConnected",
+	"Description": "Virtual Removable Media",
+	"Image": "",
+	"Inserted": false,
+	"MediaTypes": [
+	  "Floppy",
+	  "USBStick"
+	],
+	"Name": "VirtualMedia",
+	"Oem": {
+	  "Hpe": {
+		"@odata.context": "/redfish/v1/$metadata#HpeiLOVirtualMedia.HpeiLOVirtualMedia",
+		"@odata.type": "#HpeiLOVirtualMedia.v2_2_0.HpeiLOVirtualMedia",
+		"Actions": {
+		  "#HpeiLOVirtualMedia.EjectVirtualMedia": {
+			"target": "/redfish/v1/Managers/1/VirtualMedia/1/Actions/Oem/Hpe/HpeiLOVirtualMedia.EjectVirtualMedia"
+		  },
+		  "#HpeiLOVirtualMedia.InsertVirtualMedia": {
+			"target": "/redfish/v1/Managers/1/VirtualMedia/1/Actions/Oem/Hpe/HpeiLOVirtualMedia.InsertVirtualMedia"
+		  }
+		}
+	  }
+	},
+	"WriteProtected": true
+  }`
+
+// TestVirtualMedia tests the parsing of VirtualMedia objects.
+func TestVirtualMedia(t *testing.T) {
+	var result VirtualMedia
+	err := json.NewDecoder(strings.NewReader(vmBody)).Decode(&result)
+
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+
+	if result.ID != "1" {
+		t.Errorf("Received invalid ID: %s", result.ID)
+	}
+
+	if result.Name != "VirtualMedia" {
+		t.Errorf("Received invalid name: %s", result.Name)
+	}
+
+	if result.ejectMediaTarget != "/redfish/v1/Managers/1/VirtualMedia/1/Actions/VirtualMedia.EjectMedia" {
+		t.Errorf("Received invalid EjectMedia Action target: %s", result.ejectMediaTarget)
+	}
+
+	if result.insertMediaTarget != "/redfish/v1/Managers/1/VirtualMedia/1/Actions/VirtualMedia.InsertMedia" {
+		t.Errorf("Received invalid InsertMedaiaAction target: %s", result.insertMediaTarget)
+	}
+}
+
+// TestVirtualMediaUpdate tests the Update call.
+func TestVirtualMediaUpdate(t *testing.T) {
+	var result VirtualMedia
+	err := json.NewDecoder(strings.NewReader(vmBody)).Decode(&result)
+
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+
+	testClient := &common.TestClient{}
+	result.SetClient(testClient)
+
+	result.UserName = "Fred"
+	result.WriteProtected = false
+	err = result.Update()
+
+	if err != nil {
+		t.Errorf("Error making Update call: %s", err)
+	}
+
+	calls := testClient.CapturedCalls()
+
+	if !strings.Contains(calls[0].Payload, "UserName:Fred") {
+		t.Errorf("Unexpected UserName update payload: %s", calls[0].Payload)
+	}
+
+	if !strings.Contains(calls[0].Payload, "WriteProtected:false") {
+		t.Errorf("Unexpected WriteProtected update payload: %s", calls[0].Payload)
+	}
+}

--- a/redfish/virtualmedia_test.go
+++ b/redfish/virtualmedia_test.go
@@ -112,3 +112,61 @@ func TestVirtualMediaUpdate(t *testing.T) {
 		t.Errorf("Unexpected WriteProtected update payload: %s", calls[0].Payload)
 	}
 }
+
+// TestVirtualMediaEject tests the EjectMedia call.
+func TestVirtualMediaEject(t *testing.T) {
+	var result VirtualMedia
+	err := json.NewDecoder(strings.NewReader(vmBody)).Decode(&result)
+
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+
+	testClient := &common.TestClient{}
+	result.SetClient(testClient)
+
+	err = result.EjectMedia()
+
+	if err != nil {
+		t.Errorf("Error making EjectMedia call: %s", err)
+	}
+
+	calls := testClient.CapturedCalls()
+
+	if calls[0].Payload != "" {
+		t.Errorf("Unexpected EjectMedia payload: %s", calls[0].Payload)
+	}
+}
+
+// TestVirtualMediaInser tests the InsertMedia call.
+func TestVirtualMediaInsert(t *testing.T) {
+	var result VirtualMedia
+	err := json.NewDecoder(strings.NewReader(vmBody)).Decode(&result)
+
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+
+	testClient := &common.TestClient{}
+	result.SetClient(testClient)
+
+	err = result.InsertMedia("https://example.com/image", false, true)
+
+	if err != nil {
+		t.Errorf("Error making InsertMedia call: %s", err)
+	}
+
+	calls := testClient.CapturedCalls()
+
+	if !strings.Contains(calls[0].Payload, "Image:https://example.com/image") {
+		t.Errorf("Unexpected InsertMedia Image payload: %s", calls[0].Payload)
+	}
+
+	if !strings.Contains(calls[0].Payload, "Inserted:false") {
+		t.Errorf("Unexpected InsertMedia Inserted payload: %s", calls[0].Payload)
+	}
+
+	if !strings.Contains(calls[0].Payload, "WriteProtected:true") {
+		t.Errorf("Unexpected InsertMedia WriteProtected payload: %s", calls[0].Payload)
+	}
+}

--- a/redfish/virtualmedia_test.go
+++ b/redfish/virtualmedia_test.go
@@ -76,6 +76,10 @@ func TestVirtualMedia(t *testing.T) {
 	if result.insertMediaTarget != "/redfish/v1/Managers/1/VirtualMedia/1/Actions/VirtualMedia.InsertMedia" {
 		t.Errorf("Received invalid InsertMedaiaAction target: %s", result.insertMediaTarget)
 	}
+
+	if result.SupportsMediaInsert == false {
+		t.Error("Expected SupportsMediaInsert to be true since target is set")
+	}
 }
 
 // TestVirtualMediaUpdate tests the Update call.

--- a/redfish/virtualmedia_test.go
+++ b/redfish/virtualmedia_test.go
@@ -28,7 +28,8 @@ var vmBody = `{
 	},
 	"ConnectedVia": "NotConnected",
 	"Description": "Virtual Removable Media",
-	"Image": "",
+	"Image": "https://example.com/mygoldimage.iso",
+	"ImageName": "mygoldimage.iso",
 	"Inserted": false,
 	"MediaTypes": [
 	  "Floppy",
@@ -75,6 +76,22 @@ func TestVirtualMedia(t *testing.T) {
 
 	if result.insertMediaTarget != "/redfish/v1/Managers/1/VirtualMedia/1/Actions/VirtualMedia.InsertMedia" {
 		t.Errorf("Received invalid InsertMedaiaAction target: %s", result.insertMediaTarget)
+	}
+
+	if result.Inserted == true {
+		t.Error("Expected Inserted to be false")
+	}
+
+	if result.WriteProtected == false {
+		t.Error("Expected WriteProtected to be true")
+	}
+
+	if result.Image != "https://example.com/mygoldimage.iso" {
+		t.Errorf("Expected Image to be 'https://example.com/mygoldimage.iso', got %s", result.Image)
+	}
+
+	if result.ImageName != "mygoldimage.iso" {
+		t.Errorf("Expected ImageName to be 'mygoldimage.iso', got %s", result.ImageName)
 	}
 
 	if result.SupportsMediaInsert == false {


### PR DESCRIPTION
The Manager object has a VirtualMediaCollection link that links to zero
or more VirtualMedia objects. This update adds a call to be able to
retrieve those VirtualMedia objects from a Manager.