### PR TITLE
Capitalized the 'n' in UserName when creating a Session. To conform t…

### DIFF
--- a/redfish/session.go
+++ b/redfish/session.go
@@ -74,14 +74,14 @@ type AuthToken struct {
 }
 
 type authPayload struct {
-	Username string `json:"UserName"`
+	UserName string `json:"UserName"`
 	Password string `json:"Password"`
 }
 
 // CreateSession creates a new session and returns the token and id
 func CreateSession(c common.Client, uri string, username string, password string) (auth *AuthToken, err error) {
 	a := &authPayload{
-		Username: username,
+		UserName: username,
 		Password: password,
 	}
 


### PR DESCRIPTION
…o DMTF specification.

This is in reference to https://github.com/stmcginnis/gofish/issues/102.

Upon further investigation I found that when sending a POST to a few of our devices on the `/redfish/v1/SessionService/Sessions/` endpoint, the 'username' key in the payload is case-sensitive (It should be `UserName` not `Username`). This is inline with the DMTF specification https://www.dmtf.org/sites/default/files/standards/documents/DSP0266_1.11.1.pdf 14.3.3.2