### PR TITLE
Add ability to upgrade client security to session-based and do multi-part POST requests

### DIFF
--- a/client.go
+++ b/client.go
@@ -171,6 +171,31 @@ func ConnectDefault(endpoint string) (c *APIClient, err error) {
 	return client, err
 }
 
+// CloneWithSession will create a new Client with a session instead of basic auth.
+func (c *APIClient) CloneWithSession() (*APIClient, error) {
+	if c.auth.Session != "" {
+		return nil, fmt.Errorf("client already has a session")
+	}
+
+	newClient := APIClient(*c)
+	newClient.HTTPClient = c.HTTPClient
+	service, err := ServiceRoot(&newClient)
+	if err != nil {
+		return nil, err
+	}
+	newClient.Service = service
+
+	auth, err := newClient.Service.CreateSession(
+		newClient.auth.Username,
+		newClient.auth.Password)
+	if err != nil {
+		return nil, err
+	}
+	newClient.auth = auth
+
+	return &newClient, err
+}
+
 // GetSession retrieves the session data from an initialized APIClient. An error
 // is returned if the client is not authenticated.
 func (c *APIClient) GetSession() (*Session, error) {

--- a/client.go
+++ b/client.go
@@ -12,8 +12,10 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"mime/multipart"
 	"net/http"
 	"net/http/httputil"
+	"os"
 
 	"strings"
 	"time"

--- a/client.go
+++ b/client.go
@@ -301,7 +301,7 @@ func (c *APIClient) runRequestWithMultipartPayload(method string, url string, pa
 	return c.runRawRequest(method, url, bytes.NewReader(b.Bytes()), w.FormDataContentType())
 }
 
-// runRequest actually performs the REST calls.
+// runRawRequest actually performs the REST calls.
 func (c *APIClient) runRawRequest(method string, url string, payloadBuffer io.ReadSeeker, contentType string) (*http.Response, error) {
 	if url == "" {
 		return nil, fmt.Errorf("unable to execute request, no target provided")

--- a/client.go
+++ b/client.go
@@ -393,3 +393,8 @@ func (c *APIClient) Logout() {
 		_ = c.Service.DeleteSession(c.auth.Session)
 	}
 }
+
+// SetDumpWriter sets the client the DumpWriter dynamically
+func (c *APIClient) SetDumpWriter(writer io.Writer) {
+	c.dumpWriter = writer
+}

--- a/client.go
+++ b/client.go
@@ -326,6 +326,7 @@ func (c *APIClient) runRawRequest(method string, url string, payloadBuffer io.Re
 	if c.auth != nil {
 		if c.auth.Token != "" {
 			req.Header.Set("X-Auth-Token", c.auth.Token)
+			req.Header.Set("Cookie", fmt.Sprintf("sessionKey=%s", c.auth.Token))
 		} else {
 			if c.auth.BasicAuth == true && c.auth.Username != "" && c.auth.Password != "" {
 				encodedAuth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%v:%v", c.auth.Username, c.auth.Password)))

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/stmcginnis/gofish
+
+go 1.15


### PR DESCRIPTION
Some actions require a session token to perform. Rather than require client users to remember credentials and create new clients add a method to clone an existing client and upgrade the security using the stored credentials.

Additionally, some actions (e.g. firmware upload) require a multi-part POST of the firmware to the server. To this end this provides a new function `PostMultipart` that takes and forms a multi-part payload and POSTs it to the requested URL.

Finally, to aide in troubleshooting allow dynamic setting of the client `DumpWriter` to allow targeted request/response tracing and add a `go.mod` file so programs using the library can use a local version easier.