### PR TITLE
Implement software inventory objects and link off Update service for Firmware Inventory

### DIFF
--- a/examples/upload_firmware.go
+++ b/examples/upload_firmware.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/stmcginnis/gofish"
+)
+
+func main() {
+	// Create a new instance of gofish client, ignoring self-signed certs
+	config := gofish.ClientConfig{
+		Endpoint: "https://bmc-ip",
+		Username: "my-username",
+		Password: "my-password",
+		Insecure: true,
+	}
+
+	c, err := gofish.Connect(config)
+	if err != nil {
+		panic(err)
+	}
+	defer c.Logout()
+
+	// Attached the client to service root
+	service := c.Service
+
+	// Query the update service
+	update, err := service.UpdateService()
+	if err != nil {
+		panic(err)
+	}
+
+	// Fetch the firmware inventory
+	inventory, err := update.FirmwareInventory()
+	if err != nil {
+		panic(err)
+	}
+
+	// Fetch the inventory members
+	firmwares, err := inventory.Members()
+	if err != nil {
+		panic(err)
+	}
+
+	// Loop over the inventory, printing the details
+	for _, f := range firmwares {
+		fmt.Printf("%v@%v: %v", f.Name, f.Version, f.Description)
+	}
+
+	// Get the session token
+	session, err := c.GetSession()
+	if err != nil {
+		// Didn't have a token. Upgrade to a session
+		c, err = c.CloneWithSession()
+		if err != nil {
+			panic(err)
+		}
+		defer c.Logout()
+	}
+
+	// Open the firmware binary
+	firmwareReader, err := os.Open("firmware.bin")
+	if err != nil {
+		panic(err)
+	}
+	defer firmwareReader.Close()
+
+	if service.Vendor == "HPE" {
+		// For HPE systems, need a "parameters" JSON blob
+		parameters := map[string]interface{}{
+			"UpdateRepository": true,
+			"UpdateTarget":     true,
+			"ETag":             "sometag",
+			"Section":          0,
+		}
+
+		// Marshal that to a reader
+		parameterBytes, err := json.Marshal(parameters)
+		if err != nil {
+			panic(err)
+		}
+		payloadBuffer := bytes.NewReader(parameterBytes)
+
+		// Also need the session key and file contents.
+		// Wrap strings in readers
+		values := map[string]io.Reader{
+			"sessionKey": strings.NewReader(session.Token),
+			"parameters": payloadBuffer,
+			"file":       firmwareReader,
+		}
+
+		// Post the upload to the specified URL
+		response, err := c.PostMultipart(update.HTTPPushURI, values)
+		if err != nil {
+			panic(err)
+		}
+		defer response.Body.Close()
+	} else {
+		panic(fmt.Sprintf("I don't know how to upload firmware to %s", service.Vendor))
+	}
+}

--- a/redfish/softwareinventory.go
+++ b/redfish/softwareinventory.go
@@ -1,0 +1,62 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package redfish
+
+import (
+	"encoding/json"
+
+	"github.com/stmcginnis/gofish/common"
+)
+
+// SoftwareInventory is used to represent a software or firmware item on the server
+type SoftwareInventory struct {
+	common.Entity
+
+	Description            string
+	Status                 common.Status
+	Version                string
+	LowestSupportedVersion string
+	Manufacturer           string
+	ReleaseDate            string
+	SoftwareID             string
+	UefiDevicePaths        []string
+	Updateable             bool
+	WriteProtected         bool
+	rawData                []byte
+}
+
+// UnmarshalJSON unmarshals a SoftwareInventory object from the raw JSON
+func (softwareInventory *SoftwareInventory) UnmarshalJSON(b []byte) error {
+	type temp SoftwareInventory
+	var t struct {
+		temp
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	// Extract the links to other entities for later
+	*softwareInventory = SoftwareInventory(t.temp)
+	softwareInventory.rawData = b
+	return nil
+}
+
+// GetSoftwareInventory will get a SoftwareInventory instance from the service
+func GetSoftwareInventory(conn common.Client, uri string) (*SoftwareInventory, error) {
+	resp, err := conn.Get(uri)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var softwareInventory SoftwareInventory
+	err = json.NewDecoder(resp.Body).Decode(&softwareInventory)
+	if err != nil {
+		return nil, err
+	}
+	softwareInventory.SetClient(conn)
+	return &softwareInventory, nil
+}

--- a/redfish/softwareinventory_test.go
+++ b/redfish/softwareinventory_test.go
@@ -1,0 +1,82 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package redfish
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+var softwareInventoryBody = `{
+	"@odata.context": "/redfish/v1/$metadata#SoftwareInventory.SoftwareInventory",
+	"@odata.etag": "W/\"918DA6A4\"",
+	"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/1/",
+	"@odata.type": "#SoftwareInventory.v1_0_0.SoftwareInventory",
+	"Id": "1",
+	"Description": "SystemBMC",
+	"Name": "Bob",
+	"Oem": {},
+	"Status": {
+	  "Health": "OK",
+	  "State": "Enabled"
+	},
+	"Version": "1.2.3.4",
+	"LowestSupportedVersion": "1.1.1.1",
+	"Manufacturer": "BobCo",
+	"ReleaseDate": "1/1/2020",
+	"SoftwareId": "1234",
+	"UefiDevicePaths": [ "/1", "/2" ],
+	"Updateable": true,
+	"WriteProtected": false
+}`
+
+func TestSoftwareInventory(t *testing.T) {
+	var result SoftwareInventory
+	err := json.NewDecoder(strings.NewReader(softwareInventoryBody)).Decode(&result)
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+
+	if result.Description != "SystemBMC" {
+		t.Errorf("Description was wrong")
+	}
+
+	if result.Status.Health != "OK" {
+		t.Errorf("Health is wrong")
+	}
+
+	if result.Version != "1.2.3.4" {
+		t.Errorf("Version is wrong")
+	}
+
+	if result.LowestSupportedVersion != "1.1.1.1" {
+		t.Errorf("LowestSupportedVersion is wrong")
+	}
+
+	if result.Manufacturer != "BobCo" {
+		t.Errorf("Manufacturer is wrong")
+	}
+
+	if result.ReleaseDate != "1/1/2020" {
+		t.Errorf("ReleaseDate is wrong")
+	}
+
+	if result.SoftwareID != "1234" {
+		t.Errorf("SoftwareID is wrong")
+	}
+
+	if result.UefiDevicePaths[0] != "/1" {
+		t.Errorf("UefiDevicePaths is wrong")
+	}
+
+	if result.Updateable != true {
+		t.Errorf("Updateable is wrong")
+	}
+
+	if result.WriteProtected != false {
+		t.Errorf("WriteProtected is wrong")
+	}
+}

--- a/redfish/softwareinventorycollection.go
+++ b/redfish/softwareinventorycollection.go
@@ -1,0 +1,70 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package redfish
+
+import (
+	"encoding/json"
+
+	"github.com/stmcginnis/gofish/common"
+)
+
+// SoftwareInventoryCollection is used to represent a collection of software or firmware items on the server
+type SoftwareInventoryCollection struct {
+	common.Entity
+
+	Name        string
+	Description string
+	members     []string
+	rawData     []byte
+}
+
+// UnmarshalJSON unmarshals a SoftwareInventoryCollection object from the raw JSON
+func (softwareInventory *SoftwareInventoryCollection) UnmarshalJSON(b []byte) error {
+	type temp SoftwareInventoryCollection
+	var t struct {
+		temp
+		members common.Links
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	// Extract the links to other entities for later
+	*softwareInventory = SoftwareInventoryCollection(t.temp)
+	softwareInventory.rawData = b
+	softwareInventory.members = t.members.ToStrings()
+	return nil
+}
+
+// Members retrieves the SoftwareInventory objects that are in this collection
+func (softwareInventoryCollection *SoftwareInventoryCollection) Members() ([]*SoftwareInventory, error) {
+	var result []*SoftwareInventory
+	for _, softwareInventoryLink := range softwareInventoryCollection.members {
+		softwareInventory, err := GetSoftwareInventory(softwareInventoryCollection.Client, softwareInventoryLink)
+		if err != nil {
+			return result, nil
+		}
+		result = append(result, softwareInventory)
+	}
+	return result, nil
+}
+
+// GetSoftwareInventoryCollection will get a SoftwareInventoryCollection instance from the service
+func GetSoftwareInventoryCollection(c common.Client, uri string) (*SoftwareInventoryCollection, error) {
+	resp, err := c.Get(uri)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var softwareInventoryCollection SoftwareInventoryCollection
+	err = json.NewDecoder(resp.Body).Decode(&softwareInventoryCollection)
+	if err != nil {
+		return nil, err
+	}
+	softwareInventoryCollection.SetClient(c)
+	return &softwareInventoryCollection, nil
+}

--- a/redfish/softwareinventorycollection.go
+++ b/redfish/softwareinventorycollection.go
@@ -21,7 +21,7 @@ type SoftwareInventoryCollection struct {
 }
 
 // UnmarshalJSON unmarshals a SoftwareInventoryCollection object from the raw JSON
-func (softwareInventory *SoftwareInventoryCollection) UnmarshalJSON(b []byte) error {
+func (softwareInventoryCollection *SoftwareInventoryCollection) UnmarshalJSON(b []byte) error {
 	type temp SoftwareInventoryCollection
 	var t struct {
 		temp
@@ -34,9 +34,9 @@ func (softwareInventory *SoftwareInventoryCollection) UnmarshalJSON(b []byte) er
 	}
 
 	// Extract the links to other entities for later
-	*softwareInventory = SoftwareInventoryCollection(t.temp)
-	softwareInventory.rawData = b
-	softwareInventory.members = t.members.ToStrings()
+	*softwareInventoryCollection = SoftwareInventoryCollection(t.temp)
+	softwareInventoryCollection.rawData = b
+	softwareInventoryCollection.members = t.members.ToStrings()
 	return nil
 }
 

--- a/redfish/softwareinventorycollection_test.go
+++ b/redfish/softwareinventorycollection_test.go
@@ -1,0 +1,112 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package redfish
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+var softwareCollectionInventoryBody = `{
+	"@odata.context": "/redfish/v1/$metadata#SoftwareInventoryCollection.SoftwareInventoryCollection",
+	"@odata.etag": "W/\"A3D58239\"",
+	"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/",
+	"@odata.type": "#SoftwareInventoryCollection.SoftwareInventoryCollection",
+	"Description": "Firmware Inventory Collection",
+	"Name": "Firmware Inventory Collection",
+	"Members": [
+	  {
+		"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/1/"
+	  },
+	  {
+		"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/2/"
+	  },
+	  {
+		"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/3/"
+	  },
+	  {
+		"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/4/"
+	  },
+	  {
+		"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/5/"
+	  },
+	  {
+		"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/6/"
+	  },
+	  {
+		"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/7/"
+	  },
+	  {
+		"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/8/"
+	  },
+	  {
+		"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/9/"
+	  },
+	  {
+		"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/10/"
+	  },
+	  {
+		"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/11/"
+	  },
+	  {
+		"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/12/"
+	  },
+	  {
+		"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/13/"
+	  },
+	  {
+		"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/14/"
+	  },
+	  {
+		"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/15/"
+	  },
+	  {
+		"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/16/"
+	  },
+	  {
+		"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/17/"
+	  },
+	  {
+		"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/18/"
+	  },
+	  {
+		"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/19/"
+	  },
+	  {
+		"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/20/"
+	  },
+	  {
+		"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/21/"
+	  },
+	  {
+		"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/22/"
+	  },
+	  {
+		"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/23/"
+	  },
+	  {
+		"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/24/"
+	  },
+	  {
+		"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/25/"
+	  },
+	  {
+		"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/26/"
+	  },
+	  {
+		"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/27/"
+	  }
+	],
+	"Members@odata.count": 27
+  }`
+
+func TestSoftwareInventoryCollection(t *testing.T) {
+	var result UpdateService
+	err := json.NewDecoder(strings.NewReader(softwareCollectionInventoryBody)).Decode(&result)
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+}

--- a/redfish/updateservice.go
+++ b/redfish/updateservice.go
@@ -21,7 +21,7 @@ type UpdateService struct {
 	// Description provides a description of this resource.
 	Description string
 	// FirmwareInventory points towards the firmware store endpoint
-	FirmwareInventory string
+	firmwareInventory string
 	// HTTPPushURI endpoint is used to push (POST) firmware updates
 	HTTPPushURI string `json:"HttpPushUri"`
 	// ServiceEnabled indicates whether this service isenabled.
@@ -58,11 +58,16 @@ func (updateService *UpdateService) UnmarshalJSON(b []byte) error {
 
 	// Extract the links to other entities for later
 	*updateService = UpdateService(t.temp)
-	updateService.FirmwareInventory = string(t.FirmwareInventory)
+	updateService.firmwareInventory = string(t.FirmwareInventory)
 	updateService.TransferProtocol = t.Actions.SimpleUpdate.AllowableValues
 	updateService.UpdateServiceTarget = t.Actions.SimpleUpdate.Target
 	updateService.rawData = b
 	return nil
+}
+
+// FirmwareInventory will get the firmware inventory from the service
+func (updateService *UpdateService) FirmwareInventory() (*SoftwareInventoryCollection, error) {
+	return GetSoftwareInventoryCollection(updateService.Client, updateService.firmwareInventory)
 }
 
 // GetUpdateService will get a UpdateService instance from the service.

--- a/redfish/updateservice_test.go
+++ b/redfish/updateservice_test.go
@@ -53,7 +53,7 @@ func TestUpdateService(t *testing.T) {
 		t.Errorf("Error decoding JSON: %s", err)
 	}
 
-	if result.FirmwareInventory != "/redfish/v1/UpdateService/FirmwareInventory" {
+	if result.firmwareInventory != "/redfish/v1/UpdateService/FirmwareInventory" {
 		t.Errorf("FirmwareInventory was wrong")
 	}
 


### PR DESCRIPTION
This change modifies the `UpdateService` to change the `FirmwareInventory` string (URL) to a method to fetch the corresponding `SoftwareInventoryCollection`. From that collection hangs the individual `SoftwareInventory` entries (`Members()`) that correspond to items in the `FirmwareInventory`.

Also provided an example (`upload_firmware.go`) for how to query the firmware inventory of a server and push a firmware update using a multipart POST request.