### PR TITLE
Hide ComputerSystem.HostedServices property for now

### DIFF
--- a/redfish/computersystem.go
+++ b/redfish/computersystem.go
@@ -405,8 +405,8 @@ type ComputerSystem struct {
 	// describe the host watchdog timer functionality for this
 	// ComputerSystem.
 	HostWatchdogTimer WatchdogTimer
-	// HostedServices shall describe services supported by this computer system.
-	HostedServices string
+	// hostedServices shall describe services supported by this computer system.
+	hostedServices string
 	// HostingRoles shall be the hosting roles supported by this computer system.
 	HostingRoles []string
 


### PR DESCRIPTION
This property is actually an object that contains properties that link
to other services. The existing definition as a string is not correct,
so even though we don't have full support for it yet, at least mark it
private so that marshalling does not have problems if a host returns the
correct data structure.

Closes: #109