### PR TITLE
Return Error struct also for 404

### DIFF
--- a/client.go
+++ b/client.go
@@ -440,11 +440,7 @@ func (c *APIClient) runRawRequest(method string, url string, payloadBuffer io.Re
 			return nil, err
 		}
 		defer resp.Body.Close()
-		if resp.StatusCode == 400 || resp.StatusCode == 404 {
-			return nil, common.ConstructError(resp.StatusCode, payload)
-		}
-
-		return nil, fmt.Errorf("%d: %s", resp.StatusCode, string(payload))
+		return nil, common.ConstructError(resp.StatusCode, payload)
 	}
 
 	return resp, err

--- a/client.go
+++ b/client.go
@@ -440,11 +440,11 @@ func (c *APIClient) runRawRequest(method string, url string, payloadBuffer io.Re
 			return nil, err
 		}
 		defer resp.Body.Close()
-		if resp.StatusCode != 400 {
-			return nil, fmt.Errorf("%d: %s", resp.StatusCode, string(payload))
+		if resp.StatusCode == 400 || resp.StatusCode == 404 {
+			return nil, common.ConstructError(resp.StatusCode, payload)
 		}
 
-		return nil, common.ConstructError(resp.StatusCode, payload)
+		return nil, fmt.Errorf("%d: %s", resp.StatusCode, string(payload))
 	}
 
 	return resp, err

--- a/client_test.go
+++ b/client_test.go
@@ -62,33 +62,15 @@ func TestError400(t *testing.T) {
 	if !ok {
 		t.Errorf("400 should return known error type: %v", err)
 	}
+	if errStruct.HTTPReturnedStatusCode != 400 {
+		t.Errorf("The error code is different from 400")
+	}
 	errBody, err := json.MarshalIndent(errStruct, "  ", "    ")
 	if err != nil {
 		t.Errorf("Marshall error %v got: %s", errStruct, err)
 	}
 	if errMsg != string(errBody) {
 		t.Errorf("Expect:\n%s\nGot:\n%s", errMsg, string(errBody))
-	}
-}
-
-// TestErrorNon400 tests the parsing of error reply for non 400 reply.
-func TestErrorNon400(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(404)
-		w.Write([]byte(expectErrorStatus400))
-	}))
-	defer ts.Close()
-
-	_, err := Connect(ClientConfig{Endpoint: ts.URL, HTTPClient: ts.Client()})
-	if err == nil {
-		t.Error("Update call should fail")
-	}
-	_, ok := err.(*common.Error)
-	if ok {
-		t.Errorf("404 should not return known error type: %v", err)
-	}
-	if expectErrorStatus404 != err.Error() {
-		t.Errorf("Expect:\n%s\nGot:\n%s", expectErrorStatus404, err.Error())
 	}
 }
 

--- a/common/types.go
+++ b/common/types.go
@@ -725,7 +725,7 @@ func ConstructError(statusCode int, b []byte) error {
 type Error struct {
 	rawData []byte
 	// An integer that represents the status code returned by the API
-	HTTPReturnedStatusCode int
+	HTTPReturnedStatusCode int `json:"-"`
 	// A string indicating a specific MessageId from the message registry.
 	Code string `json:"code"`
 	// A human readable error message corresponding to the message in the message registry.

--- a/common/types.go
+++ b/common/types.go
@@ -716,13 +716,16 @@ func ConstructError(statusCode int, b []byte) error {
 		// return normal error
 		return fmt.Errorf("%d: %s", statusCode, string(b))
 	}
+	err.Error.HTTPReturnedStatusCode = statusCode
 	err.Error.rawData = b
 	return err.Error
 }
 
-// Error is redfish error response object for 400 or 404
+// Error is redfish error response object for HTTP status codes different from 200, 201 and 204
 type Error struct {
 	rawData []byte
+	// An integer that represents the status code returned by the API
+	HTTPReturnedStatusCode int
 	// A string indicating a specific MessageId from the message registry.
 	Code string `json:"code"`
 	// A human readable error message corresponding to the message in the message registry.

--- a/common/types.go
+++ b/common/types.go
@@ -712,7 +712,7 @@ func ConstructError(statusCode int, b []byte) error {
 	var err struct {
 		Error *Error
 	}
-	if e := json.Unmarshal(b, &err); e != nil || err.Error == nil{
+	if e := json.Unmarshal(b, &err); e != nil || err.Error == nil {
 		// return normal error
 		return fmt.Errorf("%d: %s", statusCode, string(b))
 	}
@@ -720,7 +720,7 @@ func ConstructError(statusCode int, b []byte) error {
 	return err.Error
 }
 
-// Error is redfish error response object for 400
+// Error is redfish error response object for 400 or 404
 type Error struct {
 	rawData []byte
 	// A string indicating a specific MessageId from the message registry.


### PR DESCRIPTION
Hi Sean,

Working in our Terraform project, I found very useful that when the Redfish API returns also a 404, the client returns an Error struct rather than a generic error. That will allow us to actually distinguish between an actual error or a simple "doesn't exist".

I'm sending this PR to meet this specific case. I need to find out if the GetVolume() function below actually fails or returns 404.

~~~
v, err := redfish.GetVolume(c, "/redfish/v1/Systems/System.Embedded.1/Storage/RAID.Integrated.1-1/Volumes/Disk.Virtual.0:RAID.Integrated.1-1")
	if val, ok := err.(*common.Error); !ok {
		panic(err)
	}
~~~

Please let me know.
Best regards!
/Miguel