### PR TITLE
Switch to GitHub Actions for CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,41 @@
+name: Checks
+on:
+  pull_request:
+    branches:
+    - master
+  push:
+    branches:
+    - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+    # Get the code
+    - uses: actions/checkout@v2
+
+    # Setup our go environment
+    - name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.15.0'
+
+    # Install extra dependencies
+    - name: Install dependencies
+      run: |
+        go version
+        go get -u golang.org/x/lint/golint
+
+    # Build the code
+    - name: Run build
+      run: go build .
+
+    # Vet and lint
+    - name: Run vet & lint
+      run: |
+        go vet .
+        golint .
+
+    # Run unit tests
+    - name: Run tests
+      run: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: go
-
-go:
-- 1.15.x


### PR DESCRIPTION
This drops TravisCI in favor of just using GitHub Actions for PR testing needs.