### PR TITLE
Update check jobs to trigger on main

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,10 +2,10 @@ name: Checks
 on:
   pull_request:
     branches:
-    - master
+    - main
   push:
     branches:
-    - master
+    - main
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Mainline branch was renamed from master to main. Check job needs to be updated to run on the new branch name.