### PR TITLE
Added VirtualMediaConfig struct and new method

### DIFF
--- a/redfish/virtualmedia.go
+++ b/redfish/virtualmedia.go
@@ -200,7 +200,7 @@ func (virtualmedia *VirtualMedia) EjectMedia() error {
 		return errors.New("redfish service does not support VirtualMedia.EjectMedia calls")
 	}
 
-	_, err := virtualmedia.Client.Post(virtualmedia.ejectMediaTarget, nil)
+	_, err := virtualmedia.Client.Post(virtualmedia.ejectMediaTarget, struct{}{})
 	return err
 }
 
@@ -222,6 +222,26 @@ func (virtualmedia *VirtualMedia) InsertMedia(image string, inserted bool, write
 	}
 
 	_, err := virtualmedia.Client.Post(virtualmedia.insertMediaTarget, t)
+	return err
+}
+
+// VirtualMediaConfig is an struct used to pass config data to build the HTTP body when inserting media
+type VirtualMediaConfig struct {
+	Image                string
+	Inserted             bool
+	Password             string `json:",omitempty"`
+	TransferMethod       string `json:",omitempty"`
+	TransferProtocolType string `json:",omitempty"`
+	UserName             string `json:",omitempty"`
+	WriteProtected       bool
+}
+
+// InsertMediaConfig sends a request to insert virtual media using the VirtualMediaConfig struct
+func (virtualmedia *VirtualMedia) InsertMediaConfig(config VirtualMediaConfig) error {
+	if !virtualmedia.SupportsMediaInsert {
+		return errors.New("redfish service does not support VirtualMedia.InsertMedia calls")
+	}
+	_, err := virtualmedia.Client.Post(virtualmedia.insertMediaTarget, config)
 	return err
 }
 

--- a/redfish/virtualmedia_test.go
+++ b/redfish/virtualmedia_test.go
@@ -150,7 +150,7 @@ func TestVirtualMediaEject(t *testing.T) {
 
 	calls := testClient.CapturedCalls()
 
-	if calls[0].Payload != "" {
+	if calls[0].Payload != "map[]" {
 		t.Errorf("Unexpected EjectMedia payload: %s", calls[0].Payload)
 	}
 }
@@ -185,5 +185,48 @@ func TestVirtualMediaInsert(t *testing.T) {
 
 	if !strings.Contains(calls[0].Payload, "WriteProtected:true") {
 		t.Errorf("Unexpected InsertMedia WriteProtected payload: %s", calls[0].Payload)
+	}
+}
+
+func TestVirtualMediaInsertConfig(t *testing.T) {
+	var result VirtualMedia
+	err := json.NewDecoder(strings.NewReader(vmBody)).Decode(&result)
+
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+
+	testClient := &common.TestClient{}
+	result.SetClient(testClient)
+
+	virtualMediaConfig := VirtualMediaConfig{
+		Image:          "https://example.com/image",
+		Inserted:       true,
+		Password:       "test1234",
+		UserName:       "root",
+		WriteProtected: true,
+	}
+
+	err = result.InsertMediaConfig(virtualMediaConfig)
+	if err != nil {
+		t.Errorf("Error making InsertMediaConfig call: %s", err)
+	}
+
+	calls := testClient.CapturedCalls()
+
+	if !strings.Contains(calls[0].Payload, "Image:https://example.com/image") {
+		t.Errorf("Unexpected InsertMedia Image payload: %s", calls[0].Payload)
+	}
+	if !strings.Contains(calls[0].Payload, "Inserted:true") {
+		t.Errorf("Unexpected InsertMedia Inserted payload: %s", calls[0].Payload)
+	}
+	if !strings.Contains(calls[0].Payload, "Password:test1234") {
+		t.Errorf("Unexpected InsertMedia Image payload: %s", calls[0].Payload)
+	}
+	if !strings.Contains(calls[0].Payload, "UserName:root") {
+		t.Errorf("Unexpected InsertMedia Image payload: %s", calls[0].Payload)
+	}
+	if !strings.Contains(calls[0].Payload, "WriteProtected:true") {
+		t.Errorf("Unexpected InsertMedia Inserted payload: %s", calls[0].Payload)
 	}
 }


### PR DESCRIPTION
Hello Sean,

Sorry I had to open another pull request. I've reset the two commits I had in my repo that implemented the old solution.

As we agreed, I've created a new exportable (public) struct called *VirtualMediaConfig* that can be passed to the new method *InsertMediaConfig*. Unfortunately Go doesn't support method overloading so another name had to be used. I think that method name should be ok. Tests were implemented as well.

Also I've kept what I did in the previous implementation regarding EjectMedia and avoiding sending no body at all, just sending an empty JSON object to avoid issues with different Redfish implementations.

Let me know 😄 
Best regards!

/Miguel
