### PR TITLE
Adding ability to list firmware and software inventories from Redfish UpdateService.

### DIFF
--- a/redfish/softwareinventory.go
+++ b/redfish/softwareinventory.go
@@ -1,0 +1,104 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package redfish
+
+import (
+	"encoding/json"
+
+	"github.com/stmcginnis/gofish/common"
+)
+
+// SoftwareInventory is This Resource contains a single software
+// component that this Redfish Service manages.
+type SoftwareInventory struct {
+	common.Entity
+
+	// ODataContext is the odata context.
+	ODataContext string `json:"@odata.context"`
+	// ODataEtag is the odata etag.
+	ODataEtag string `json:"@odata.etag"`
+	// ODataType is the odata type.
+	ODataType string `json:"@odata.type"`
+	// Description provides a description of this resource.
+	Description string
+	// LowestSupportedVersion is used for the Version property.
+	LowestSupportedVersion string
+	// Manufacturer is This property shall represent the name of the
+	// manufacturer or producer of this software.
+	Manufacturer string
+	// Oem is This property shall contain the Oem extensions.  All values for
+	// properties that this object contains shall conform to the Redfish
+	// Specification-described requirements.
+	Oem interface{}
+	// ReleaseDate is This property shall contain the date of release or
+	// production for this software.  If the time of day is unknown, the time
+	// of day portion of the property shall contain `00:00:00Z`.
+	ReleaseDate string
+	// SoftwareID is This property shall represent an implementation-specific
+	// label that identifies this software.  This string correlates with a
+	// component repository or database.
+	SoftwareID string
+	// Status is This property shall contain any status or health properties
+	// of the Resource.
+	Status common.Status
+	// UefiDevicePaths is This property shall contain a list UEFI device
+	// paths of the components associated with this software inventory item.
+	// The UEFI device paths shall be formatted as defined by the UEFI
+	// Specification.
+	UefiDevicePaths []string
+	// Updateable is This property shall indicate whether the Update Service
+	// can update this software.  If `true`, the Service can update this
+	// software.  If `false`, the Service cannot update this software and the
+	// software is for reporting purposes only.
+	Updateable bool
+	// Version is This property shall contain the version of this software.
+	Version string
+	// WriteProtected is This property shall indicate whether the software
+	// image can be overwritten, where a value `true` shall indicate that the
+	// software cannot be altered or overwritten.
+	WriteProtected bool
+}
+
+// GetSoftwareInventory will get a SoftwareInventory instance from the service.
+func GetSoftwareInventory(c common.Client, uri string) (*SoftwareInventory, error) {
+	resp, err := c.Get(uri)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var softwareinventory SoftwareInventory
+	err = json.NewDecoder(resp.Body).Decode(&softwareinventory)
+	if err != nil {
+		return nil, err
+	}
+
+	softwareinventory.SetClient(c)
+	return &softwareinventory, nil
+}
+
+// ListReferencedSoftwareInventories gets the collection of SoftwareInventory from
+// a provided reference.
+func ListReferencedSoftwareInventories(c common.Client, link string) ([]*SoftwareInventory, error) {
+	var result []*SoftwareInventory
+	if link == "" {
+		return result, nil
+	}
+
+	links, err := common.GetCollection(c, link)
+	if err != nil {
+		return result, err
+	}
+
+	for _, softwareinventoryLink := range links.ItemLinks {
+		softwareinventory, err := GetSoftwareInventory(c, softwareinventoryLink)
+		if err != nil {
+			return result, err
+		}
+		result = append(result, softwareinventory)
+	}
+
+	return result, nil
+}

--- a/redfish/softwareinventory_test.go
+++ b/redfish/softwareinventory_test.go
@@ -1,0 +1,82 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package redfish
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+var softwareInventoryBody = `{
+	"@odata.context": "/redfish/v1/$metadata#SoftwareInventory.SoftwareInventory",
+	"@odata.etag": "W/\"918DA6A4\"",
+	"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/1/",
+	"@odata.type": "#SoftwareInventory.v1_0_0.SoftwareInventory",
+	"Id": "1",
+	"Description": "SystemBMC",
+	"Name": "Bob",
+	"Oem": {},
+	"Status": {
+	  "Health": "OK",
+	  "State": "Enabled"
+	},
+	"Version": "1.2.3.4",
+	"LowestSupportedVersion": "1.1.1.1",
+	"Manufacturer": "BobCo",
+	"ReleaseDate": "1/1/2020",
+	"SoftwareId": "1234",
+	"UefiDevicePaths": [ "/1", "/2" ],
+	"Updateable": true,
+	"WriteProtected": false
+}`
+
+func TestSoftwareInventory(t *testing.T) {
+	var result SoftwareInventory
+	err := json.NewDecoder(strings.NewReader(softwareInventoryBody)).Decode(&result)
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+
+	if result.Description != "SystemBMC" {
+		t.Errorf("Description was wrong")
+	}
+
+	if result.Status.Health != "OK" {
+		t.Errorf("Health is wrong")
+	}
+
+	if result.Version != "1.2.3.4" {
+		t.Errorf("Version is wrong")
+	}
+
+	if result.LowestSupportedVersion != "1.1.1.1" {
+		t.Errorf("LowestSupportedVersion is wrong")
+	}
+
+	if result.Manufacturer != "BobCo" {
+		t.Errorf("Manufacturer is wrong")
+	}
+
+	if result.ReleaseDate != "1/1/2020" {
+		t.Errorf("ReleaseDate is wrong")
+	}
+
+	if result.SoftwareID != "1234" {
+		t.Errorf("SoftwareID is wrong")
+	}
+
+	if result.UefiDevicePaths[0] != "/1" {
+		t.Errorf("UefiDevicePaths is wrong")
+	}
+
+	if result.Updateable != true {
+		t.Errorf("Updateable is wrong")
+	}
+
+	if result.WriteProtected != false {
+		t.Errorf("WriteProtected is wrong")
+	}
+}

--- a/redfish/updateservice.go
+++ b/redfish/updateservice.go
@@ -22,6 +22,8 @@ type UpdateService struct {
 	Description string
 	// FirmwareInventory points towards the firmware store endpoint
 	FirmwareInventory string
+	// SoftwareInventory points towards the firmware store endpoint
+	SoftwareInventory string
 	// HTTPPushURI endpoint is used to push (POST) firmware updates
 	HTTPPushURI string `json:"HttpPushUri"`
 	// ServiceEnabled indicates whether this service isenabled.
@@ -53,6 +55,7 @@ func (updateService *UpdateService) UnmarshalJSON(b []byte) error {
 		temp
 		Actions           actions
 		FirmwareInventory common.Link
+		SoftwareInventory common.Link
 	}
 
 	err := json.Unmarshal(b, &t)
@@ -63,6 +66,7 @@ func (updateService *UpdateService) UnmarshalJSON(b []byte) error {
 	// Extract the links to other entities for later
 	*updateService = UpdateService(t.temp)
 	updateService.FirmwareInventory = string(t.FirmwareInventory)
+	updateService.SoftwareInventory = string(t.SoftwareInventory)
 	updateService.TransferProtocol = t.Actions.SimpleUpdate.AllowableValues
 	updateService.UpdateServiceTarget = t.Actions.SimpleUpdate.Target
 	updateService.rawData = b
@@ -83,4 +87,14 @@ func GetUpdateService(c common.Client, uri string) (*UpdateService, error) {
 	}
 	updateService.SetClient(c)
 	return &updateService, nil
+}
+
+// SoftwareInventories gets the collection of software inventories of this update service
+func (updateService *UpdateService) SoftwareInventories() ([]*SoftwareInventory, error) {
+	return ListReferencedSoftwareInventories(updateService.Client, updateService.SoftwareInventory)
+}
+
+// FirmwareInventories gets the collection of firmware inventories of this update service
+func (updateService *UpdateService) FirmwareInventories() ([]*SoftwareInventory, error) {
+	return ListReferencedSoftwareInventories(updateService.Client, updateService.FirmwareInventory)
 }


### PR DESCRIPTION
This PR adds ability to list firmware and software inventories from Redfish updateService.
More details here: https://github.com/stmcginnis/gofish/pull/106/files#r573121773

@stmcginnis  I noted there is a script to help to generate the objects from the Redfish schema "gen_script.sh", very nice. 
This time I used the script to generate softwareinventory.go. Just cleared a little bit the generated file to have only some basic initial functionalities. Also, changed somethings in the generated file, for example the Oem type to be an interface{} We can fix this in the script later.

I copied the test file "softwareinventory_test.go" from @DanDanN00dle PR (https://github.com/stmcginnis/gofish/pull/106) and the tests are passing.

Also, I did a test with a real Redfish server and I was able to list firmware and software inventories from using updateService.

Some suggestions: 
This PR can be used just for reference to do the additional implementations requested in https://github.com/stmcginnis/gofish/pull/106
Or we can merge this PR and close https://github.com/stmcginnis/gofish/pull/106 then if @DanDanN00dle wants he could create a new PR to merge the additional code (the upload firmware example application, etc).

Thanks!
