### PR TITLE
Fix ManagedBy in ComputerSystem

### DIFF
--- a/redfish/computersystem_test.go
+++ b/redfish/computersystem_test.go
@@ -248,6 +248,12 @@ func TestComputerSystem(t *testing.T) {
 		t.Errorf("Invalid allowable reset actions, expected 6, got %d",
 			len(result.SupportedResetTypes))
 	}
+	if len(result.ManagedBy) != 1 {
+		t.Errorf("Received invalid number of ManagedBy: %d", len(result.ManagedBy))
+	}
+	if result.ManagedBy[0] != "/redfish/v1/Managers/BMC-1" {
+		t.Errorf("Received invalid Managers reference: %s", result.ManagedBy[0])
+	}
 }
 
 // TestComputerSystemUpdate tests the Update call.


### PR DESCRIPTION
If Marshal and Unmarshal are executed in a CS struct
with ManagedBy set, the struct after Unmarshal will
have an empty ManagedBy list. This commit fix this
problem and add tests to cover this scenario.