### PR TITLE
Handle json name being different than property name

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -64,6 +64,10 @@ func (e *Entity) Update(originalEntity, currentEntity reflect.Value, allowedUpda
 			continue
 		}
 		fieldName := originalEntity.Type().Field(i).Name
+		jsonName := originalEntity.Type().Field(i).Tag.Get("json")
+		if jsonName != "" {
+			fieldName = jsonName
+		}
 		originalValue := originalEntity.Field(i).Interface()
 		currentValue := currentEntity.Field(i).Interface()
 		if originalValue == nil && currentValue == nil {
@@ -72,11 +76,9 @@ func (e *Entity) Update(originalEntity, currentEntity reflect.Value, allowedUpda
 			payload[fieldName] = currentValue
 		} else if reflect.TypeOf(originalValue).Kind() != reflect.Map {
 			if originalValue != currentValue {
-				// TODO: Handle JSON name being different than field name
 				payload[fieldName] = currentValue
 			}
 		} else if !reflect.DeepEqual(originalValue, currentValue) {
-			// TODO: Handle JSON name being different than field name
 			payload[fieldName] = currentValue
 		}
 	}

--- a/redfish/manageraccount_test.go
+++ b/redfish/manageraccount_test.go
@@ -73,6 +73,7 @@ func TestManagerAccountUpdate(t *testing.T) {
 	result.Enabled = false
 	result.Locked = false
 	result.Password = "Test"
+	result.RoleID = "Administrator"
 	err = result.Update()
 
 	if err != nil {
@@ -91,5 +92,9 @@ func TestManagerAccountUpdate(t *testing.T) {
 
 	if !strings.Contains(calls[0].Payload, "Password:Test") {
 		t.Errorf("Unexpected Password update payload: %s", calls[0].Payload)
+	}
+
+	if !strings.Contains(calls[0].Payload, "RoleId:Administrator") {
+		t.Errorf("Unexpected Role ID update payload: %s", calls[0].Payload)
 	}
 }


### PR DESCRIPTION
There are several read/write fields that have different property names
to conform to go standards than their json names. A common one being
something like RoleID (go) versus RoleId (json).

This updates the common Update logic account for the names being
different so we don't try to update a field that the system will not
recognize.

Closes: #124