### PR TITLE
Add Chassis Drives linkage

### DIFF
--- a/redfish/chassis_test.go
+++ b/redfish/chassis_test.go
@@ -33,6 +33,9 @@ var chassisBody = `{
 			"State": "Enabled",
 			"Health": "OK"
 		},
+		"Drives": {
+			"@odata.id": "/redfish/v1/Chassis/Chassis-1/Drives"
+		},
 		"Thermal": {
 			"@odata.id": "/redfish/v1/Chassis/Chassis-1/Thermal"
 		},
@@ -128,6 +131,10 @@ func TestChassis(t *testing.T) {
 
 	if result.Status.Health != common.OKHealth {
 		t.Errorf("Received invalid health status: %s", result.Status.Health)
+	}
+
+	if result.drives != "/redfish/v1/Chassis/Chassis-1/Drives" {
+		t.Errorf("Received invalid drive reference: %s", result.drives)
 	}
 
 	if result.thermal != "/redfish/v1/Chassis/Chassis-1/Thermal" {

--- a/tools/gen_script.sh
+++ b/tools/gen_script.sh
@@ -7,7 +7,7 @@
 
 # Set correct name for python3 executable. Some platforms just call it python
 # while others call it python3.
-PYTHON="python"
+PYTHON="python3"
 
 # Find the schema document name by going here:
 #
@@ -15,7 +15,7 @@ PYTHON="python"
 #
 # Inspect the url for the schema you want - for example, the 2020.1 update
 # document is "DSP8010_2020.1.zip" on this page. The base name then is:
-schemadoc="DSP8010_2020.1"
+schemadoc="DSP8010_2020.4"
 
 # Check if filename provided on the command line
 if [[ "$#" -eq 1 ]]; then


### PR DESCRIPTION
This adds the ability to get the drives associated with a Chassis object.

Also includes a few small cleanups.