### PR TITLE
Collect errors in a custom error type when fetching a collection

### DIFF
--- a/common/collection.go
+++ b/common/collection.go
@@ -58,19 +58,20 @@ func GetCollection(c Client, uri string) (*Collection, error) {
 	return &result, nil
 }
 
-type collectionError struct {
+// CollectionError is used for collecting errors when working with collections
+type CollectionError struct {
 	Failures map[string]error
 }
 
-// NewCollectionError gets you a new *collectionError
+// NewCollectionError gets you a new *CollectionError
 // it's useful for collecting and formatting errors that occur when fetching a collection
-func NewCollectionError() *collectionError {
-	return &collectionError{
+func NewCollectionError() *CollectionError {
+	return &CollectionError{
 		Failures: make(map[string]error),
 	}
 }
 
-func (cr *collectionError) Empty() bool {
+func (cr *CollectionError) Empty() bool {
 	return len(cr.Failures) == 0
 }
 
@@ -80,7 +81,7 @@ type entityError struct {
 	Error string `json:"error"`
 }
 
-func (cr *collectionError) Error() string {
+func (cr *CollectionError) Error() string {
 	var entityErrors []entityError
 	for link, err := range cr.Failures {
 		entityErrors = append(entityErrors, entityError{

--- a/common/collection.go
+++ b/common/collection.go
@@ -6,6 +6,7 @@ package common
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // Collection represents a collection of entity references.
@@ -55,4 +56,43 @@ func GetCollection(c Client, uri string) (*Collection, error) {
 		return nil, err
 	}
 	return &result, nil
+}
+
+type collectionError struct {
+	Failures map[string]error
+}
+
+// NewCollectionError gets you a new *collectionError
+// it's useful for collecting and formatting errors that occur when fetching a collection
+func NewCollectionError() *collectionError {
+	return &collectionError{
+		Failures: make(map[string]error),
+	}
+}
+
+func (cr *collectionError) Empty() bool {
+	return len(cr.Failures) == 0
+}
+
+// for associating a linked entity with its error
+type entityError struct {
+	Link  string `json:"link"`
+	Error string `json:"error"`
+}
+
+func (cr *collectionError) Error() string {
+	var entityErrors []entityError
+	for link, err := range cr.Failures {
+		entityErrors = append(entityErrors, entityError{
+			Link:  link,
+			Error: err.Error(),
+		})
+	}
+
+	errorsJSON, err := json.Marshal(entityErrors)
+	if err != nil {
+		panic(err)
+	}
+
+	return fmt.Sprintf("failed to retrieve some items: %s", errorsJSON)
 }

--- a/common/message.go
+++ b/common/message.go
@@ -66,13 +66,19 @@ func ListReferencedMessages(c Client, link string) ([]*Message, error) {
 		return result, err
 	}
 
+	collectionError := NewCollectionError()
 	for _, messageLink := range links.ItemLinks {
 		message, err := GetMessage(c, messageLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[messageLink] = err
+		} else {
+			result = append(result, message)
 		}
-		result = append(result, message)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }

--- a/common/message.go
+++ b/common/message.go
@@ -78,7 +78,7 @@ func ListReferencedMessages(c Client, link string) ([]*Message, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }

--- a/redfish/assembly.go
+++ b/redfish/assembly.go
@@ -89,7 +89,7 @@ func GetAssembly(c common.Client, uri string) (*Assembly, error) {
 	return &assembly, nil
 }
 
-// ListReferencedAssemblys gets the collection of Assembly from
+//nolint:dupl // ListReferencedAssemblys gets the collection of Assembly from
 // a provided reference.
 func ListReferencedAssemblys(c common.Client, link string) ([]*Assembly, error) {
 	var result []*Assembly
@@ -114,9 +114,9 @@ func ListReferencedAssemblys(c common.Client, link string) ([]*Assembly, error) 
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // AssemblyData is information about an assembly.

--- a/redfish/assembly.go
+++ b/redfish/assembly.go
@@ -102,15 +102,21 @@ func ListReferencedAssemblys(c common.Client, link string) ([]*Assembly, error) 
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, assemblyLink := range links.ItemLinks {
 		assembly, err := GetAssembly(c, assemblyLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[assemblyLink] = err
+		} else {
+			result = append(result, assembly)
 		}
-		result = append(result, assembly)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // AssemblyData is information about an assembly.

--- a/redfish/bios.go
+++ b/redfish/bios.go
@@ -160,15 +160,21 @@ func ListReferencedBioss(c common.Client, link string) ([]*Bios, error) {
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, biosLink := range links.ItemLinks {
 		bios, err := GetBios(c, biosLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[biosLink] = err
+		} else {
+			result = append(result, bios)
 		}
-		result = append(result, bios)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // ChangePassword shall change the selected BIOS password.

--- a/redfish/bios.go
+++ b/redfish/bios.go
@@ -148,7 +148,7 @@ func GetBios(c common.Client, uri string) (*Bios, error) {
 	return &bios, nil
 }
 
-// ListReferencedBioss gets the collection of Bios from a provided reference.
+//nolint:dupl // ListReferencedBioss gets the collection of Bios from a provided reference.
 func ListReferencedBioss(c common.Client, link string) ([]*Bios, error) {
 	var result []*Bios
 	if link == "" {
@@ -172,9 +172,9 @@ func ListReferencedBioss(c common.Client, link string) ([]*Bios, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // ChangePassword shall change the selected BIOS password.

--- a/redfish/chassis.go
+++ b/redfish/chassis.go
@@ -339,15 +339,21 @@ func ListReferencedChassis(c common.Client, link string) ([]*Chassis, error) {
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, chassisLink := range links.ItemLinks {
 		chassis, err := GetChassis(c, chassisLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[chassisLink] = err
+		} else {
+			result = append(result, chassis)
 		}
-		result = append(result, chassis)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // Drives gets the drives attached to the storage controllers that this
@@ -370,14 +376,21 @@ func (chassis *Chassis) Drives() ([]*Drive, error) {
 		driveLinks = drives.ItemLinks
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, driveLink := range driveLinks {
 		drive, err := GetDrive(chassis.Client, driveLink)
 		if err != nil {
-			return result, nil
+			collectionError.Failures[driveLink] = err
+		} else {
+			result = append(result, drive)
 		}
-		result = append(result, drive)
 	}
-	return result, nil
+
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // Thermal gets the thermal temperature and cooling information for the chassis
@@ -411,31 +424,43 @@ func (chassis *Chassis) Power() (*Power, error) {
 // ComputerSystems returns the collection of systems from this chassis
 func (chassis *Chassis) ComputerSystems() ([]*ComputerSystem, error) {
 	var result []*ComputerSystem
+
+	collectionError := common.NewCollectionError()
 	for _, uri := range chassis.computerSystems {
 		cs, err := GetComputerSystem(chassis.Client, uri)
 		if err != nil {
-			return nil, err
+			collectionError.Failures[uri] = err
+		} else {
+			result = append(result, cs)
 		}
-
-		result = append(result, cs)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // ManagedBy gets the collection of managers of this chassis
 func (chassis *Chassis) ManagedBy() ([]*Manager, error) {
 	var result []*Manager
+
+	collectionError := common.NewCollectionError()
 	for _, uri := range chassis.managedBy {
 		manager, err := GetManager(chassis.Client, uri)
 		if err != nil {
-			return nil, err
+			collectionError.Failures[uri] = err
+		} else {
+			result = append(result, manager)
 		}
-
-		result = append(result, manager)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // NetworkAdapters gets the collection of network adapters of this chassis

--- a/redfish/chassis.go
+++ b/redfish/chassis.go
@@ -351,9 +351,9 @@ func ListReferencedChassis(c common.Client, link string) ([]*Chassis, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // Drives gets the drives attached to the storage controllers that this
@@ -388,9 +388,9 @@ func (chassis *Chassis) Drives() ([]*Drive, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // Thermal gets the thermal temperature and cooling information for the chassis
@@ -437,9 +437,9 @@ func (chassis *Chassis) ComputerSystems() ([]*ComputerSystem, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // ManagedBy gets the collection of managers of this chassis
@@ -458,9 +458,9 @@ func (chassis *Chassis) ManagedBy() ([]*Manager, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // NetworkAdapters gets the collection of network adapters of this chassis

--- a/redfish/compositionservice.go
+++ b/redfish/compositionservice.go
@@ -105,7 +105,7 @@ func GetCompositionService(c common.Client, uri string) (*CompositionService, er
 	return &compositionservice, nil
 }
 
-// ListReferencedCompositionServices gets the collection of CompositionService from
+//nolint:dupl // ListReferencedCompositionServices gets the collection of CompositionService from
 // a provided reference.
 func ListReferencedCompositionServices(c common.Client, link string) ([]*CompositionService, error) {
 	var result []*CompositionService
@@ -130,7 +130,7 @@ func ListReferencedCompositionServices(c common.Client, link string) ([]*Composi
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }

--- a/redfish/compositionservice.go
+++ b/redfish/compositionservice.go
@@ -118,13 +118,19 @@ func ListReferencedCompositionServices(c common.Client, link string) ([]*Composi
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, compositionserviceLink := range links.ItemLinks {
 		compositionservice, err := GetCompositionService(c, compositionserviceLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[compositionserviceLink] = err
+		} else {
+			result = append(result, compositionservice)
 		}
-		result = append(result, compositionservice)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }

--- a/redfish/computersystem.go
+++ b/redfish/computersystem.go
@@ -626,15 +626,21 @@ func ListReferencedComputerSystems(c common.Client, link string) ([]*ComputerSys
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, computersystemLink := range links.ItemLinks {
 		computersystem, err := GetComputerSystem(c, computersystemLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[computersystemLink] = err
+		} else {
+			result = append(result, computersystem)
 		}
-		result = append(result, computersystem)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // Bios gets the Bios information for this ComputerSystem.
@@ -674,27 +680,43 @@ func (computersystem *ComputerSystem) NetworkInterfaces() ([]*NetworkInterface, 
 // PCIeDevices gets all PCIeDevices for this system.
 func (computersystem *ComputerSystem) PCIeDevices() ([]*PCIeDevice, error) {
 	var result []*PCIeDevice
+
+	collectionError := common.NewCollectionError()
 	for _, pciedeviceLink := range computersystem.pcieDevices {
 		pciedevice, err := GetPCIeDevice(computersystem.Client, pciedeviceLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[pciedeviceLink] = err
+		} else {
+			result = append(result, pciedevice)
 		}
-		result = append(result, pciedevice)
 	}
-	return result, nil
+
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // PCIeFunctions gets all PCIeFunctions for this system.
 func (computersystem *ComputerSystem) PCIeFunctions() ([]*PCIeFunction, error) {
 	var result []*PCIeFunction
+
+	collectionError := common.NewCollectionError()
 	for _, pciefunctionLink := range computersystem.pcieFunctions {
 		pciefunction, err := GetPCIeFunction(computersystem.Client, pciefunctionLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[pciefunctionLink] = err
+		} else {
+			result = append(result, pciefunction)
 		}
-		result = append(result, pciefunction)
 	}
-	return result, nil
+
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // Processors returns a collection of processors from this system

--- a/redfish/computersystem.go
+++ b/redfish/computersystem.go
@@ -638,9 +638,9 @@ func ListReferencedComputerSystems(c common.Client, link string) ([]*ComputerSys
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // Bios gets the Bios information for this ComputerSystem.
@@ -693,9 +693,9 @@ func (computersystem *ComputerSystem) PCIeDevices() ([]*PCIeDevice, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // PCIeFunctions gets all PCIeFunctions for this system.
@@ -714,9 +714,9 @@ func (computersystem *ComputerSystem) PCIeFunctions() ([]*PCIeFunction, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // Processors returns a collection of processors from this system

--- a/redfish/drive.go
+++ b/redfish/drive.go
@@ -342,15 +342,21 @@ func ListReferencedDrives(c common.Client, link string) ([]*Drive, error) {
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, driveLink := range links.ItemLinks {
 		drive, err := GetDrive(c, driveLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[driveLink] = err
+		} else {
+			result = append(result, drive)
 		}
-		result = append(result, drive)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // Assembly gets the Assembly for this drive.
@@ -375,45 +381,63 @@ func (drive *Drive) Chassis() (*Chassis, error) {
 func (drive *Drive) Endpoints() ([]*Endpoint, error) {
 	var result []*Endpoint
 
+	collectionError := common.NewCollectionError()
 	for _, endpointLink := range drive.endpoints {
 		endpoint, err := GetEndpoint(drive.Client, endpointLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[endpointLink] = err
+		} else {
+			result = append(result, endpoint)
 		}
-		result = append(result, endpoint)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // Volumes references the Volumes that this drive is associated with.
 func (drive *Drive) Volumes() ([]*Volume, error) {
 	var result []*Volume
 
+	collectionError := common.NewCollectionError()
 	for _, volumeLink := range drive.volumes {
 		volume, err := GetVolume(drive.Client, volumeLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[volumeLink] = err
+		} else {
+			result = append(result, volume)
 		}
-		result = append(result, volume)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // PCIeFunctions references the PCIeFunctions that this drive is associated with.
 func (drive *Drive) PCIeFunctions() ([]*PCIeFunction, error) {
 	var result []*PCIeFunction
 
+	collectionError := common.NewCollectionError()
 	for _, pcieFunctionLink := range drive.pcieFunctions {
 		pcieFunction, err := GetPCIeFunction(drive.Client, pcieFunctionLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[pcieFunctionLink] = err
+		} else {
+			result = append(result, pcieFunction)
 		}
-		result = append(result, pcieFunction)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // // StoragePools references the StoragePools that this drive is associated with.

--- a/redfish/drive.go
+++ b/redfish/drive.go
@@ -330,7 +330,7 @@ func GetDrive(c common.Client, uri string) (*Drive, error) {
 	return &drive, nil
 }
 
-// ListReferencedDrives gets the collection of Drives from a provided reference.
+//nolint:dupl // ListReferencedDrives gets the collection of Drives from a provided reference.
 func ListReferencedDrives(c common.Client, link string) ([]*Drive, error) {
 	var result []*Drive
 	if link == "" {
@@ -354,9 +354,9 @@ func ListReferencedDrives(c common.Client, link string) ([]*Drive, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // Assembly gets the Assembly for this drive.
@@ -393,9 +393,9 @@ func (drive *Drive) Endpoints() ([]*Endpoint, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // Volumes references the Volumes that this drive is associated with.
@@ -414,9 +414,9 @@ func (drive *Drive) Volumes() ([]*Volume, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // PCIeFunctions references the PCIeFunctions that this drive is associated with.
@@ -435,9 +435,9 @@ func (drive *Drive) PCIeFunctions() ([]*PCIeFunction, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // // StoragePools references the StoragePools that this drive is associated with.

--- a/redfish/endpoint.go
+++ b/redfish/endpoint.go
@@ -233,7 +233,7 @@ func GetEndpoint(c common.Client, uri string) (*Endpoint, error) {
 	return &endpoint, nil
 }
 
-// ListReferencedEndpoints gets the collection of Endpoint from
+//nolint:dupl // ListReferencedEndpoints gets the collection of Endpoint from
 // a provided reference.
 func ListReferencedEndpoints(c common.Client, link string) ([]*Endpoint, error) {
 	var result []*Endpoint
@@ -258,9 +258,9 @@ func ListReferencedEndpoints(c common.Client, link string) ([]*Endpoint, error) 
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // GCID shall contain the Gen-Z Core Specification-defined Global

--- a/redfish/endpoint.go
+++ b/redfish/endpoint.go
@@ -246,15 +246,21 @@ func ListReferencedEndpoints(c common.Client, link string) ([]*Endpoint, error) 
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, endpointLink := range links.ItemLinks {
 		endpoint, err := GetEndpoint(c, endpointLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[endpointLink] = err
+		} else {
+			result = append(result, endpoint)
 		}
-		result = append(result, endpoint)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // GCID shall contain the Gen-Z Core Specification-defined Global

--- a/redfish/ethernetinterface.go
+++ b/redfish/ethernetinterface.go
@@ -308,15 +308,21 @@ func ListReferencedEthernetInterfaces(c common.Client, link string) ([]*Ethernet
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, ethernetinterfaceLink := range links.ItemLinks {
 		ethernetinterface, err := GetEthernetInterface(c, ethernetinterfaceLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[ethernetinterfaceLink] = err
+		} else {
+			result = append(result, ethernetinterface)
 		}
-		result = append(result, ethernetinterface)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // IPv6AddressPolicyEntry describes and entry in the Address Selection Policy

--- a/redfish/ethernetinterface.go
+++ b/redfish/ethernetinterface.go
@@ -295,7 +295,7 @@ func GetEthernetInterface(c common.Client, uri string) (*EthernetInterface, erro
 	return &ethernetinterface, nil
 }
 
-// ListReferencedEthernetInterfaces gets the collection of EthernetInterface from
+//nolint:dupl // ListReferencedEthernetInterfaces gets the collection of EthernetInterface from
 // a provided reference.
 func ListReferencedEthernetInterfaces(c common.Client, link string) ([]*EthernetInterface, error) {
 	var result []*EthernetInterface
@@ -320,9 +320,9 @@ func ListReferencedEthernetInterfaces(c common.Client, link string) ([]*Ethernet
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // IPv6AddressPolicyEntry describes and entry in the Address Selection Policy

--- a/redfish/eventdestination.go
+++ b/redfish/eventdestination.go
@@ -417,15 +417,21 @@ func ListReferencedEventDestinations(c common.Client, link string) ([]*EventDest
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, eventdestinationLink := range links.ItemLinks {
 		eventdestination, err := GetEventDestination(c, eventdestinationLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[eventdestinationLink] = err
+		} else {
+			result = append(result, eventdestination)
 		}
-		result = append(result, eventdestination)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // HTTPHeaderProperty shall a names and value of an HTTP header to be included

--- a/redfish/eventdestination.go
+++ b/redfish/eventdestination.go
@@ -404,7 +404,7 @@ func DeleteEventDestination(c common.Client, uri string) (err error) {
 	return err
 }
 
-// ListReferencedEventDestinations gets the collection of EventDestination from
+//nolint:dupl // ListReferencedEventDestinations gets the collection of EventDestination from
 // a provided reference.
 func ListReferencedEventDestinations(c common.Client, link string) ([]*EventDestination, error) {
 	var result []*EventDestination
@@ -429,9 +429,9 @@ func ListReferencedEventDestinations(c common.Client, link string) ([]*EventDest
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // HTTPHeaderProperty shall a names and value of an HTTP header to be included

--- a/redfish/eventservice.go
+++ b/redfish/eventservice.go
@@ -256,15 +256,21 @@ func ListReferencedEventServices(c common.Client, link string) ([]*EventService,
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, eventserviceLink := range links.ItemLinks {
 		eventservice, err := GetEventService(c, eventserviceLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[eventserviceLink] = err
+		} else {
+			result = append(result, eventservice)
 		}
-		result = append(result, eventservice)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // GetEventSubscriptions gets all the subscriptions using the event service.

--- a/redfish/eventservice.go
+++ b/redfish/eventservice.go
@@ -174,7 +174,7 @@ type EventService struct {
 }
 
 // UnmarshalJSON unmarshals a EventService object from the raw JSON.
-func (eventservice *EventService) UnmarshalJSON(b []byte) error { // nolint:dupl
+func (eventservice *EventService) UnmarshalJSON(b []byte) error {
 	type temp EventService
 	type Actions struct {
 		SubmitTestEvent struct {
@@ -243,7 +243,7 @@ func GetEventService(c common.Client, uri string) (*EventService, error) {
 	return &eventservice, nil
 }
 
-// ListReferencedEventServices gets the collection of EventService from
+//nolint:dupl // ListReferencedEventServices gets the collection of EventService from
 // a provided reference.
 func ListReferencedEventServices(c common.Client, link string) ([]*EventService, error) {
 	var result []*EventService
@@ -268,9 +268,9 @@ func ListReferencedEventServices(c common.Client, link string) ([]*EventService,
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // GetEventSubscriptions gets all the subscriptions using the event service.

--- a/redfish/hostinterface.go
+++ b/redfish/hostinterface.go
@@ -212,30 +212,42 @@ func ListReferencedHostInterfaces(c common.Client, link string) ([]*HostInterfac
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, hostinterfaceLink := range links.ItemLinks {
 		hostinterface, err := GetHostInterface(c, hostinterfaceLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[hostinterfaceLink] = err
+		} else {
+			result = append(result, hostinterface)
 		}
-		result = append(result, hostinterface)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // ComputerSystems references the ComputerSystems that this host interface is associated with.
 func (hostinterface *HostInterface) ComputerSystems() ([]*ComputerSystem, error) {
 	var result []*ComputerSystem
 
+	collectionError := common.NewCollectionError()
 	for _, computerSystemLink := range hostinterface.computerSystems {
 		computerSystem, err := GetComputerSystem(hostinterface.Client, computerSystemLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[computerSystemLink] = err
+		} else {
+			result = append(result, computerSystem)
 		}
-		result = append(result, computerSystem)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // HostNetworkInterfaces gets the network interface controllers or cards (NICs)

--- a/redfish/hostinterface.go
+++ b/redfish/hostinterface.go
@@ -199,7 +199,7 @@ func GetHostInterface(c common.Client, uri string) (*HostInterface, error) {
 	return &hostinterface, nil
 }
 
-// ListReferencedHostInterfaces gets the collection of HostInterface from
+//nolint:dupl // ListReferencedHostInterfaces gets the collection of HostInterface from
 // a provided reference.
 func ListReferencedHostInterfaces(c common.Client, link string) ([]*HostInterface, error) {
 	var result []*HostInterface
@@ -224,9 +224,9 @@ func ListReferencedHostInterfaces(c common.Client, link string) ([]*HostInterfac
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // ComputerSystems references the ComputerSystems that this host interface is associated with.
@@ -245,9 +245,9 @@ func (hostinterface *HostInterface) ComputerSystems() ([]*ComputerSystem, error)
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // HostNetworkInterfaces gets the network interface controllers or cards (NICs)

--- a/redfish/logentry.go
+++ b/redfish/logentry.go
@@ -447,13 +447,19 @@ func ListReferencedLogEntrys(c common.Client, link string) ([]*LogEntry, error) 
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, logentryLink := range links.ItemLinks {
 		logentry, err := GetLogEntry(c, logentryLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[logentryLink] = err
+		} else {
+			result = append(result, logentry)
 		}
-		result = append(result, logentry)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }

--- a/redfish/logentry.go
+++ b/redfish/logentry.go
@@ -434,7 +434,7 @@ func GetLogEntry(c common.Client, uri string) (*LogEntry, error) {
 	return &logentry, nil
 }
 
-// ListReferencedLogEntrys gets the collection of LogEntry from
+//nolint:dupl // ListReferencedLogEntrys gets the collection of LogEntry from
 // a provided reference.
 func ListReferencedLogEntrys(c common.Client, link string) ([]*LogEntry, error) {
 	var result []*LogEntry
@@ -459,7 +459,7 @@ func ListReferencedLogEntrys(c common.Client, link string) ([]*LogEntry, error) 
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }

--- a/redfish/logservice.go
+++ b/redfish/logservice.go
@@ -170,15 +170,21 @@ func ListReferencedLogServices(c common.Client, link string) ([]*LogService, err
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, logserviceLink := range links.ItemLinks {
 		logservice, err := GetLogService(c, logserviceLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[logserviceLink] = err
+		} else {
+			result = append(result, logservice)
 		}
-		result = append(result, logservice)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // Entries gets the log entries of this service.

--- a/redfish/logservice.go
+++ b/redfish/logservice.go
@@ -89,7 +89,7 @@ type LogService struct {
 }
 
 // UnmarshalJSON unmarshals a LogService object from the raw JSON.
-func (logservice *LogService) UnmarshalJSON(b []byte) error { // nolint:dupl
+func (logservice *LogService) UnmarshalJSON(b []byte) error {
 	type temp LogService
 	type Actions struct {
 		ClearLog struct {
@@ -158,7 +158,7 @@ func GetLogService(c common.Client, uri string) (*LogService, error) {
 	return &logservice, nil
 }
 
-// ListReferencedLogServices gets the collection of LogService from a provided reference.
+//nolint:dupl // ListReferencedLogServices gets the collection of LogService from a provided reference.
 func ListReferencedLogServices(c common.Client, link string) ([]*LogService, error) {
 	var result []*LogService
 	if link == "" {
@@ -182,9 +182,9 @@ func ListReferencedLogServices(c common.Client, link string) ([]*LogService, err
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // Entries gets the log entries of this service.

--- a/redfish/manager.go
+++ b/redfish/manager.go
@@ -402,15 +402,21 @@ func ListReferencedManagers(c common.Client, link string) ([]*Manager, error) {
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, managerLink := range links.ItemLinks {
 		manager, err := GetManager(c, managerLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[managerLink] = err
+		} else {
+			result = append(result, manager)
 		}
-		result = append(result, manager)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // Reset shall perform a reset of the manager.

--- a/redfish/manager.go
+++ b/redfish/manager.go
@@ -421,9 +421,9 @@ func ListReferencedManagers(c common.Client, link string) ([]*Manager, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // Reset shall perform a reset of the manager.

--- a/redfish/manageraccount.go
+++ b/redfish/manageraccount.go
@@ -176,15 +176,21 @@ func ListReferencedManagerAccounts(c common.Client, link string) ([]*ManagerAcco
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, manageraccountLink := range links.ItemLinks {
 		manageraccount, err := GetManagerAccount(c, manageraccountLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[manageraccountLink] = err
+		} else {
+			result = append(result, manageraccount)
 		}
-		result = append(result, manageraccount)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // SNMPUserInfo is shall contain the SNMP settings for an account.

--- a/redfish/manageraccount.go
+++ b/redfish/manageraccount.go
@@ -163,7 +163,7 @@ func GetManagerAccount(c common.Client, uri string) (*ManagerAccount, error) {
 	return &manageraccount, nil
 }
 
-// ListReferencedManagerAccounts gets the collection of ManagerAccount from
+//nolint:dupl // ListReferencedManagerAccounts gets the collection of ManagerAccount from
 // a provided reference.
 func ListReferencedManagerAccounts(c common.Client, link string) ([]*ManagerAccount, error) {
 	var result []*ManagerAccount
@@ -188,9 +188,9 @@ func ListReferencedManagerAccounts(c common.Client, link string) ([]*ManagerAcco
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // SNMPUserInfo is shall contain the SNMP settings for an account.

--- a/redfish/memory.go
+++ b/redfish/memory.go
@@ -402,7 +402,7 @@ func GetMemory(c common.Client, uri string) (*Memory, error) {
 	return &memory, nil
 }
 
-// ListReferencedMemorys gets the collection of Memory from
+//nolint:dupl // ListReferencedMemorys gets the collection of Memory from
 // a provided reference.
 func ListReferencedMemorys(c common.Client, link string) ([]*Memory, error) {
 	var result []*Memory
@@ -427,9 +427,9 @@ func ListReferencedMemorys(c common.Client, link string) ([]*Memory, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // Assembly gets this memory's assembly.

--- a/redfish/memory.go
+++ b/redfish/memory.go
@@ -415,15 +415,21 @@ func ListReferencedMemorys(c common.Client, link string) ([]*Memory, error) {
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, memoryLink := range links.ItemLinks {
 		memory, err := GetMemory(c, memoryLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[memoryLink] = err
+		} else {
+			result = append(result, memory)
 		}
-		result = append(result, memory)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // Assembly gets this memory's assembly.

--- a/redfish/memorydomain.go
+++ b/redfish/memorydomain.go
@@ -77,7 +77,7 @@ func GetMemoryDomain(c common.Client, uri string) (*MemoryDomain, error) {
 	return &memorydomain, nil
 }
 
-// ListReferencedMemoryDomains gets the collection of MemoryDomain from
+//nolint:dupl // ListReferencedMemoryDomains gets the collection of MemoryDomain from
 // a provided reference.
 func ListReferencedMemoryDomains(c common.Client, link string) ([]*MemoryDomain, error) {
 	var result []*MemoryDomain
@@ -102,9 +102,9 @@ func ListReferencedMemoryDomains(c common.Client, link string) ([]*MemoryDomain,
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // MemorySet shall represent the interleave sets for a memory chunk.

--- a/redfish/memorydomain.go
+++ b/redfish/memorydomain.go
@@ -90,15 +90,21 @@ func ListReferencedMemoryDomains(c common.Client, link string) ([]*MemoryDomain,
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, memorydomainLink := range links.ItemLinks {
 		memorydomain, err := GetMemoryDomain(c, memorydomainLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[memorydomainLink] = err
+		} else {
+			result = append(result, memorydomain)
 		}
-		result = append(result, memorydomain)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // MemorySet shall represent the interleave sets for a memory chunk.

--- a/redfish/memorymetrics.go
+++ b/redfish/memorymetrics.go
@@ -131,13 +131,19 @@ func ListReferencedMemoryMetricss(c common.Client, link string) ([]*MemoryMetric
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, memorymetricsLink := range links.ItemLinks {
 		memorymetrics, err := GetMemoryMetrics(c, memorymetricsLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[memorymetricsLink] = err
+		} else {
+			result = append(result, memorymetrics)
 		}
-		result = append(result, memorymetrics)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }

--- a/redfish/memorymetrics.go
+++ b/redfish/memorymetrics.go
@@ -118,7 +118,7 @@ func GetMemoryMetrics(c common.Client, uri string) (*MemoryMetrics, error) {
 	return &memorymetrics, nil
 }
 
-// ListReferencedMemoryMetricss gets the collection of MemoryMetrics from
+//nolint:dupl // ListReferencedMemoryMetricss gets the collection of MemoryMetrics from
 // a provided reference.
 func ListReferencedMemoryMetricss(c common.Client, link string) ([]*MemoryMetrics, error) {
 	var result []*MemoryMetrics
@@ -143,7 +143,7 @@ func ListReferencedMemoryMetricss(c common.Client, link string) ([]*MemoryMetric
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }

--- a/redfish/messageregistryfile.go
+++ b/redfish/messageregistryfile.go
@@ -69,13 +69,19 @@ func ListReferencedMessageRegistryFiles(
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, sLink := range links.ItemLinks {
 		s, err := GetMessageRegistryFile(c, sLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[sLink] = err
+		} else {
+			result = append(result, s)
 		}
-		result = append(result, s)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }

--- a/redfish/messageregistryfile.go
+++ b/redfish/messageregistryfile.go
@@ -81,7 +81,7 @@ func ListReferencedMessageRegistryFiles(
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }

--- a/redfish/networkadapter.go
+++ b/redfish/networkadapter.go
@@ -262,15 +262,21 @@ func ListReferencedNetworkAdapter(c common.Client, link string) ([]*NetworkAdapt
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, networkAdapterLink := range links.ItemLinks {
 		networkAdapter, err := GetNetworkAdapter(c, networkAdapterLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[networkAdapterLink] = err
+		} else {
+			result = append(result, networkAdapter)
 		}
-		result = append(result, networkAdapter)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // Assembly gets this adapter's assembly.

--- a/redfish/networkadapter.go
+++ b/redfish/networkadapter.go
@@ -274,9 +274,9 @@ func ListReferencedNetworkAdapter(c common.Client, link string) ([]*NetworkAdapt
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // Assembly gets this adapter's assembly.

--- a/redfish/networkdevicefunction.go
+++ b/redfish/networkdevicefunction.go
@@ -379,15 +379,21 @@ func ListReferencedNetworkDeviceFunctions(c common.Client, link string) ([]*Netw
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, networkdevicefunctionLink := range links.ItemLinks {
 		networkdevicefunction, err := GetNetworkDeviceFunction(c, networkdevicefunctionLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[networkdevicefunctionLink] = err
+		} else {
+			result = append(result, networkdevicefunction)
 		}
-		result = append(result, networkdevicefunction)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // ISCSIBoot shall describe the iSCSI boot capabilities, status, and

--- a/redfish/networkdevicefunction.go
+++ b/redfish/networkdevicefunction.go
@@ -366,7 +366,7 @@ func GetNetworkDeviceFunction(c common.Client, uri string) (*NetworkDeviceFuncti
 	return &networkdevicefunction, nil
 }
 
-// ListReferencedNetworkDeviceFunctions gets the collection of NetworkDeviceFunction from
+//nolint:dupl // ListReferencedNetworkDeviceFunctions gets the collection of NetworkDeviceFunction from
 // a provided reference.
 func ListReferencedNetworkDeviceFunctions(c common.Client, link string) ([]*NetworkDeviceFunction, error) {
 	var result []*NetworkDeviceFunction
@@ -391,9 +391,9 @@ func ListReferencedNetworkDeviceFunctions(c common.Client, link string) ([]*Netw
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // ISCSIBoot shall describe the iSCSI boot capabilities, status, and

--- a/redfish/networkinterface.go
+++ b/redfish/networkinterface.go
@@ -85,7 +85,7 @@ func GetNetworkInterface(c common.Client, uri string) (*NetworkInterface, error)
 	return &networkinterface, nil
 }
 
-// ListReferencedNetworkInterfaces gets the collection of NetworkInterface from
+//nolint:dupl // ListReferencedNetworkInterfaces gets the collection of NetworkInterface from
 // a provided reference.
 func ListReferencedNetworkInterfaces(c common.Client, link string) ([]*NetworkInterface, error) {
 	var result []*NetworkInterface
@@ -110,9 +110,9 @@ func ListReferencedNetworkInterfaces(c common.Client, link string) ([]*NetworkIn
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // NetworkAdapter gets the NetworkAdapter for this interface.

--- a/redfish/networkinterface.go
+++ b/redfish/networkinterface.go
@@ -98,15 +98,21 @@ func ListReferencedNetworkInterfaces(c common.Client, link string) ([]*NetworkIn
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, networkinterfaceLink := range links.ItemLinks {
 		networkinterface, err := GetNetworkInterface(c, networkinterfaceLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[networkinterfaceLink] = err
+		} else {
+			result = append(result, networkinterface)
 		}
-		result = append(result, networkinterface)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // NetworkAdapter gets the NetworkAdapter for this interface.

--- a/redfish/networkport.go
+++ b/redfish/networkport.go
@@ -265,7 +265,7 @@ func GetNetworkPort(c common.Client, uri string) (*NetworkPort, error) {
 	return &networkport, nil
 }
 
-// ListReferencedNetworkPorts gets the collection of NetworkPort from
+//nolint:dupl // ListReferencedNetworkPorts gets the collection of NetworkPort from
 // a provided reference.
 func ListReferencedNetworkPorts(c common.Client, link string) ([]*NetworkPort, error) {
 	var result []*NetworkPort
@@ -290,9 +290,9 @@ func ListReferencedNetworkPorts(c common.Client, link string) ([]*NetworkPort, e
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // SupportedLinkCapabilities shall describe the static capabilities of an

--- a/redfish/networkport.go
+++ b/redfish/networkport.go
@@ -278,15 +278,21 @@ func ListReferencedNetworkPorts(c common.Client, link string) ([]*NetworkPort, e
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, networkportLink := range links.ItemLinks {
 		networkport, err := GetNetworkPort(c, networkportLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[networkportLink] = err
+		} else {
+			result = append(result, networkport)
 		}
-		result = append(result, networkport)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // SupportedLinkCapabilities shall describe the static capabilities of an

--- a/redfish/pciedevice.go
+++ b/redfish/pciedevice.go
@@ -178,15 +178,21 @@ func ListReferencedPCIeDevices(c common.Client, link string) ([]*PCIeDevice, err
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, pciedeviceLink := range links.ItemLinks {
 		pciedevice, err := GetPCIeDevice(c, pciedeviceLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[pciedeviceLink] = err
+		} else {
+			result = append(result, pciedevice)
 		}
-		result = append(result, pciedevice)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // PCIeInterface properties shall be the definition for a PCIe Interface for a
@@ -214,25 +220,41 @@ func (pciedevice *PCIeDevice) Assembly() (*Assembly, error) {
 // Chassis gets the chassis in which the PCIe device is contained.
 func (pciedevice *PCIeDevice) Chassis() ([]*Chassis, error) {
 	var result []*Chassis
+
+	collectionError := common.NewCollectionError()
 	for _, chassisLink := range pciedevice.chassis {
 		chassis, err := GetChassis(pciedevice.Client, chassisLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[chassisLink] = err
+		} else {
+			result = append(result, chassis)
 		}
-		result = append(result, chassis)
 	}
-	return result, nil
+
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // PCIeFunctions get the PCIe functions that this device exposes.
 func (pciedevice *PCIeDevice) PCIeFunctions() ([]*PCIeDevice, error) {
 	var result []*PCIeDevice
+
+	collectionError := common.NewCollectionError()
 	for _, funcLink := range pciedevice.pcieFunctions {
 		pciFunction, err := GetPCIeDevice(pciedevice.Client, funcLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[funcLink] = err
+		} else {
+			result = append(result, pciFunction)
 		}
-		result = append(result, pciFunction)
 	}
-	return result, nil
+
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }

--- a/redfish/pciedevice.go
+++ b/redfish/pciedevice.go
@@ -93,7 +93,7 @@ type PCIeDevice struct {
 }
 
 // UnmarshalJSON unmarshals a PCIeDevice object from the raw JSON.
-func (pciedevice *PCIeDevice) UnmarshalJSON(b []byte) error { // nolint:dupl
+func (pciedevice *PCIeDevice) UnmarshalJSON(b []byte) error {
 	type temp PCIeDevice
 	type links struct {
 		Chassis            common.Links
@@ -165,7 +165,7 @@ func GetPCIeDevice(c common.Client, uri string) (*PCIeDevice, error) {
 	return &pciedevice, nil
 }
 
-// ListReferencedPCIeDevices gets the collection of PCIeDevice from
+//nolint:dupl // ListReferencedPCIeDevices gets the collection of PCIeDevice from
 // a provided reference.
 func ListReferencedPCIeDevices(c common.Client, link string) ([]*PCIeDevice, error) {
 	var result []*PCIeDevice
@@ -190,9 +190,9 @@ func ListReferencedPCIeDevices(c common.Client, link string) ([]*PCIeDevice, err
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // PCIeInterface properties shall be the definition for a PCIe Interface for a
@@ -233,9 +233,9 @@ func (pciedevice *PCIeDevice) Chassis() ([]*Chassis, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // PCIeFunctions get the PCIe functions that this device exposes.
@@ -254,7 +254,7 @@ func (pciedevice *PCIeDevice) PCIeFunctions() ([]*PCIeDevice, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }

--- a/redfish/pciefunction.go
+++ b/redfish/pciefunction.go
@@ -195,7 +195,7 @@ func GetPCIeFunction(c common.Client, uri string) (*PCIeFunction, error) {
 	return &pciefunction, nil
 }
 
-// ListReferencedPCIeFunctions gets the collection of PCIeFunction from
+//nolint:dupl // ListReferencedPCIeFunctions gets the collection of PCIeFunction from
 // a provided reference.
 func ListReferencedPCIeFunctions(c common.Client, link string) ([]*PCIeFunction, error) {
 	var result []*PCIeFunction
@@ -220,9 +220,9 @@ func ListReferencedPCIeFunctions(c common.Client, link string) ([]*PCIeFunction,
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // Drives gets the PCIe function's drives.
@@ -241,9 +241,9 @@ func (pciefunction *PCIeFunction) Drives() ([]*Drive, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // EthernetInterfaces gets the PCIe function's ethernet interfaces.
@@ -262,9 +262,9 @@ func (pciefunction *PCIeFunction) EthernetInterfaces() ([]*EthernetInterface, er
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // NetworkDeviceFunctions gets the PCIe function's ethernet interfaces.
@@ -283,9 +283,9 @@ func (pciefunction *PCIeFunction) NetworkDeviceFunctions() ([]*NetworkDeviceFunc
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // PCIeDevice gets the associated PCIe device for this function.
@@ -312,7 +312,7 @@ func (pciefunction *PCIeFunction) StorageControllers() ([]*StorageController, er
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }

--- a/redfish/pciefunction.go
+++ b/redfish/pciefunction.go
@@ -208,54 +208,84 @@ func ListReferencedPCIeFunctions(c common.Client, link string) ([]*PCIeFunction,
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, pciefunctionLink := range links.ItemLinks {
 		pciefunction, err := GetPCIeFunction(c, pciefunctionLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[pciefunctionLink] = err
+		} else {
+			result = append(result, pciefunction)
 		}
-		result = append(result, pciefunction)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // Drives gets the PCIe function's drives.
 func (pciefunction *PCIeFunction) Drives() ([]*Drive, error) {
 	var result []*Drive
+
+	collectionError := common.NewCollectionError()
 	for _, driveLink := range pciefunction.drives {
 		drive, err := GetDrive(pciefunction.Client, driveLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[driveLink] = err
+		} else {
+			result = append(result, drive)
 		}
-		result = append(result, drive)
 	}
-	return result, nil
+
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // EthernetInterfaces gets the PCIe function's ethernet interfaces.
 func (pciefunction *PCIeFunction) EthernetInterfaces() ([]*EthernetInterface, error) {
 	var result []*EthernetInterface
+
+	collectionError := common.NewCollectionError()
 	for _, ethLink := range pciefunction.ethernetInterfaces {
 		eth, err := GetEthernetInterface(pciefunction.Client, ethLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[ethLink] = err
+		} else {
+			result = append(result, eth)
 		}
-		result = append(result, eth)
 	}
-	return result, nil
+
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // NetworkDeviceFunctions gets the PCIe function's ethernet interfaces.
 func (pciefunction *PCIeFunction) NetworkDeviceFunctions() ([]*NetworkDeviceFunction, error) {
 	var result []*NetworkDeviceFunction
+
+	collectionError := common.NewCollectionError()
 	for _, netLink := range pciefunction.networkDeviceFunctions {
 		net, err := GetNetworkDeviceFunction(pciefunction.Client, netLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[netLink] = err
+		} else {
+			result = append(result, net)
 		}
-		result = append(result, net)
 	}
-	return result, nil
+
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // PCIeDevice gets the associated PCIe device for this function.
@@ -269,12 +299,20 @@ func (pciefunction *PCIeFunction) PCIeDevice() (*PCIeDevice, error) {
 // StorageControllers gets the associated storage controllers.
 func (pciefunction *PCIeFunction) StorageControllers() ([]*StorageController, error) {
 	var result []*StorageController
+
+	collectionError := common.NewCollectionError()
 	for _, scLink := range pciefunction.storageControllers {
 		sc, err := GetStorageController(pciefunction.Client, scLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[scLink] = err
+		} else {
+			result = append(result, sc)
 		}
-		result = append(result, sc)
 	}
-	return result, nil
+
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }

--- a/redfish/power.go
+++ b/redfish/power.go
@@ -176,15 +176,21 @@ func ListReferencedPowers(c common.Client, link string) ([]*Power, error) {
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, powerLink := range links.ItemLinks {
 		power, err := GetPower(c, powerLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[powerLink] = err
+		} else {
+			result = append(result, power)
 		}
-		result = append(result, power)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // PowerControl is

--- a/redfish/power.go
+++ b/redfish/power.go
@@ -163,7 +163,7 @@ func GetPower(c common.Client, uri string) (*Power, error) {
 	return &power, nil
 }
 
-// ListReferencedPowers gets the collection of Power from
+//nolint:dupl // ListReferencedPowers gets the collection of Power from
 // a provided reference.
 func ListReferencedPowers(c common.Client, link string) ([]*Power, error) {
 	var result []*Power
@@ -188,9 +188,9 @@ func ListReferencedPowers(c common.Client, link string) ([]*Power, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // PowerControl is

--- a/redfish/processor.go
+++ b/redfish/processor.go
@@ -408,7 +408,8 @@ func (processor *Processor) UnmarshalJSON(b []byte) error {
 		// the parsed string version
 		t = t2.t1
 		if t2.MaxSpeedMHz != "" {
-			mhz, err := strconv.ParseFloat(t2.MaxSpeedMHz, 32)
+			bitSize := 32
+			mhz, err := strconv.ParseFloat(t2.MaxSpeedMHz, bitSize)
 			if err != nil {
 				t.MaxSpeedMHz = float32(mhz)
 			}
@@ -472,9 +473,9 @@ func ListReferencedProcessors(c common.Client, link string) ([]*Processor, error
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // ProcessorID shall contain identification information for a processor.

--- a/redfish/processor.go
+++ b/redfish/processor.go
@@ -460,15 +460,21 @@ func ListReferencedProcessors(c common.Client, link string) ([]*Processor, error
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, processorLink := range links.ItemLinks {
 		processor, err := GetProcessor(c, processorLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[processorLink] = err
+		} else {
+			result = append(result, processor)
 		}
-		result = append(result, processor)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // ProcessorID shall contain identification information for a processor.

--- a/redfish/redundancy.go
+++ b/redfish/redundancy.go
@@ -131,7 +131,7 @@ func GetRedundancy(c common.Client, uri string) (*Redundancy, error) {
 	return &redundancy, nil
 }
 
-// ListReferencedRedundancies gets the collection of Redundancy from
+//nolint:dupl // ListReferencedRedundancies gets the collection of Redundancy from
 // a provided reference.
 func ListReferencedRedundancies(c common.Client, link string) ([]*Redundancy, error) {
 	var result []*Redundancy
@@ -156,7 +156,7 @@ func ListReferencedRedundancies(c common.Client, link string) ([]*Redundancy, er
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }

--- a/redfish/redundancy.go
+++ b/redfish/redundancy.go
@@ -144,13 +144,19 @@ func ListReferencedRedundancies(c common.Client, link string) ([]*Redundancy, er
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, redundancyLink := range links.ItemLinks {
 		redundancy, err := GetRedundancy(c, redundancyLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[redundancyLink] = err
+		} else {
+			result = append(result, redundancy)
 		}
-		result = append(result, redundancy)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }

--- a/redfish/role.go
+++ b/redfish/role.go
@@ -123,7 +123,7 @@ func GetRole(c common.Client, uri string) (*Role, error) {
 	return &role, nil
 }
 
-// ListReferencedRoles gets the collection of Role from
+//nolint:dupl // ListReferencedRoles gets the collection of Role from
 // a provided reference.
 func ListReferencedRoles(c common.Client, link string) ([]*Role, error) {
 	var result []*Role
@@ -148,7 +148,7 @@ func ListReferencedRoles(c common.Client, link string) ([]*Role, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }

--- a/redfish/role.go
+++ b/redfish/role.go
@@ -136,13 +136,19 @@ func ListReferencedRoles(c common.Client, link string) ([]*Role, error) {
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, roleLink := range links.ItemLinks {
 		role, err := GetRole(c, roleLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[roleLink] = err
+		} else {
+			result = append(result, role)
 		}
-		result = append(result, role)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }

--- a/redfish/secureboot.go
+++ b/redfish/secureboot.go
@@ -144,7 +144,7 @@ func GetSecureBoot(c common.Client, uri string) (*SecureBoot, error) {
 	return &secureboot, nil
 }
 
-// ListReferencedSecureBoots gets the collection of SecureBoot from
+//nolint:dupl // ListReferencedSecureBoots gets the collection of SecureBoot from
 // a provided reference.
 func ListReferencedSecureBoots(c common.Client, link string) ([]*SecureBoot, error) {
 	var result []*SecureBoot
@@ -169,9 +169,9 @@ func ListReferencedSecureBoots(c common.Client, link string) ([]*SecureBoot, err
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // ResetKeys shall perform a reset of the Secure Boot key databases. The

--- a/redfish/secureboot.go
+++ b/redfish/secureboot.go
@@ -157,15 +157,21 @@ func ListReferencedSecureBoots(c common.Client, link string) ([]*SecureBoot, err
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, securebootLink := range links.ItemLinks {
 		secureboot, err := GetSecureBoot(c, securebootLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[securebootLink] = err
+		} else {
+			result = append(result, secureboot)
 		}
-		result = append(result, secureboot)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // ResetKeys shall perform a reset of the Secure Boot key databases. The

--- a/redfish/session.go
+++ b/redfish/session.go
@@ -149,7 +149,7 @@ func ListReferencedSessions(c common.Client, link string) ([]*Session, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }

--- a/redfish/session.go
+++ b/redfish/session.go
@@ -137,13 +137,19 @@ func ListReferencedSessions(c common.Client, link string) ([]*Session, error) {
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, sLink := range links.ItemLinks {
 		s, err := GetSession(c, sLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[sLink] = err
+		} else {
+			result = append(result, s)
 		}
-		result = append(result, s)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }

--- a/redfish/simplestorage.go
+++ b/redfish/simplestorage.go
@@ -94,7 +94,7 @@ func GetSimpleStorage(c common.Client, uri string) (*SimpleStorage, error) {
 	return &simplestorage, nil
 }
 
-// ListReferencedSimpleStorages gets the collection of SimpleStorage from
+//nolint:dupl // ListReferencedSimpleStorages gets the collection of SimpleStorage from
 // a provided reference.
 func ListReferencedSimpleStorages(c common.Client, link string) ([]*SimpleStorage, error) {
 	var result []*SimpleStorage
@@ -119,9 +119,9 @@ func ListReferencedSimpleStorages(c common.Client, link string) ([]*SimpleStorag
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // Chassis gets the chassis containing this storage service.

--- a/redfish/simplestorage.go
+++ b/redfish/simplestorage.go
@@ -107,15 +107,21 @@ func ListReferencedSimpleStorages(c common.Client, link string) ([]*SimpleStorag
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, simplestorageLink := range links.ItemLinks {
 		simplestorage, err := GetSimpleStorage(c, simplestorageLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[simplestorageLink] = err
+		} else {
+			result = append(result, simplestorage)
 		}
-		result = append(result, simplestorage)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // Chassis gets the chassis containing this storage service.

--- a/redfish/softwareinventory.go
+++ b/redfish/softwareinventory.go
@@ -92,13 +92,19 @@ func ListReferencedSoftwareInventories(c common.Client, link string) ([]*Softwar
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, softwareinventoryLink := range links.ItemLinks {
 		softwareinventory, err := GetSoftwareInventory(c, softwareinventoryLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[softwareinventoryLink] = err
+		} else {
+			result = append(result, softwareinventory)
 		}
-		result = append(result, softwareinventory)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }

--- a/redfish/softwareinventory.go
+++ b/redfish/softwareinventory.go
@@ -79,7 +79,7 @@ func GetSoftwareInventory(c common.Client, uri string) (*SoftwareInventory, erro
 	return &softwareinventory, nil
 }
 
-// ListReferencedSoftwareInventories gets the collection of SoftwareInventory from
+//nolint:dupl // ListReferencedSoftwareInventories gets the collection of SoftwareInventory from
 // a provided reference.
 func ListReferencedSoftwareInventories(c common.Client, link string) ([]*SoftwareInventory, error) {
 	var result []*SoftwareInventory
@@ -104,7 +104,7 @@ func ListReferencedSoftwareInventories(c common.Client, link string) ([]*Softwar
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }

--- a/redfish/storage.go
+++ b/redfish/storage.go
@@ -120,7 +120,7 @@ func GetStorage(c common.Client, uri string) (*Storage, error) {
 	return &storage, nil
 }
 
-// ListReferencedStorages gets the collection of Storage from a provided
+//nolint:dupl // ListReferencedStorages gets the collection of Storage from a provided
 // reference.
 func ListReferencedStorages(c common.Client, link string) ([]*Storage, error) {
 	var result []*Storage
@@ -145,9 +145,9 @@ func ListReferencedStorages(c common.Client, link string) ([]*Storage, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // Enclosures gets the physical containers attached to this resource.
@@ -166,9 +166,9 @@ func (storage *Storage) Enclosures() ([]*Chassis, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // Drives gets the drives attached to the storage controllers that this
@@ -188,9 +188,9 @@ func (storage *Storage) Drives() ([]*Drive, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // Volumes gets the volumes associated with this storage subsystem.
@@ -288,7 +288,7 @@ type StorageController struct {
 }
 
 // UnmarshalJSON unmarshals a StorageController object from the raw JSON.
-func (storagecontroller *StorageController) UnmarshalJSON(b []byte) error { // nolint:dupl
+func (storagecontroller *StorageController) UnmarshalJSON(b []byte) error {
 	type temp StorageController
 	type links struct {
 		Endpoints            common.Links
@@ -360,7 +360,7 @@ func GetStorageController(c common.Client, uri string) (*StorageController, erro
 	return &storage, nil
 }
 
-// ListReferencedStorageControllers gets the collection of StorageControllers
+//nolint:dupl // ListReferencedStorageControllers gets the collection of StorageControllers
 // from a provided reference.
 func ListReferencedStorageControllers(c common.Client, link string) ([]*StorageController, error) {
 	var result []*StorageController
@@ -385,9 +385,9 @@ func ListReferencedStorageControllers(c common.Client, link string) ([]*StorageC
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // Assembly gets the storage controller's assembly.
@@ -414,7 +414,7 @@ func (storagecontroller *StorageController) Endpoints() ([]*Endpoint, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }

--- a/redfish/storage.go
+++ b/redfish/storage.go
@@ -133,42 +133,64 @@ func ListReferencedStorages(c common.Client, link string) ([]*Storage, error) {
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, storageLink := range links.ItemLinks {
 		storage, err := GetStorage(c, storageLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[storageLink] = err
+		} else {
+			result = append(result, storage)
 		}
-		result = append(result, storage)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // Enclosures gets the physical containers attached to this resource.
 func (storage *Storage) Enclosures() ([]*Chassis, error) {
 	var result []*Chassis
+
+	collectionError := common.NewCollectionError()
 	for _, chassisLink := range storage.enclosures {
 		chassis, err := GetChassis(storage.Client, chassisLink)
 		if err != nil {
-			return result, nil
+			collectionError.Failures[chassisLink] = err
+		} else {
+			result = append(result, chassis)
 		}
-		result = append(result, chassis)
 	}
-	return result, nil
+
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // Drives gets the drives attached to the storage controllers that this
 // resource represents.
 func (storage *Storage) Drives() ([]*Drive, error) {
 	var result []*Drive
+
+	collectionError := common.NewCollectionError()
 	for _, driveLink := range storage.drives {
 		drive, err := GetDrive(storage.Client, driveLink)
 		if err != nil {
-			return result, nil
+			collectionError.Failures[driveLink] = err
+		} else {
+			result = append(result, drive)
 		}
-		result = append(result, drive)
 	}
-	return result, nil
+
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // Volumes gets the volumes associated with this storage subsystem.
@@ -351,15 +373,21 @@ func ListReferencedStorageControllers(c common.Client, link string) ([]*StorageC
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, storageLink := range links.ItemLinks {
 		storage, err := GetStorageController(c, storageLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[storageLink] = err
+		} else {
+			result = append(result, storage)
 		}
-		result = append(result, storage)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // Assembly gets the storage controller's assembly.
@@ -373,12 +401,20 @@ func (storagecontroller *StorageController) Assembly() (*Assembly, error) {
 // Endpoints gets the storage controller's endpoints.
 func (storagecontroller *StorageController) Endpoints() ([]*Endpoint, error) {
 	var result []*Endpoint
+
+	collectionError := common.NewCollectionError()
 	for _, endpointLink := range storagecontroller.endpoints {
 		endpoint, err := GetEndpoint(storagecontroller.Client, endpointLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[endpointLink] = err
+		} else {
+			result = append(result, endpoint)
 		}
-		result = append(result, endpoint)
 	}
-	return result, nil
+
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }

--- a/redfish/task.go
+++ b/redfish/task.go
@@ -169,7 +169,7 @@ func GetTask(c common.Client, uri string) (*Task, error) {
 	return &task, nil
 }
 
-// ListReferencedTasks gets the collection of Task from
+//nolint:dupl // ListReferencedTasks gets the collection of Task from
 // a provided reference.
 func ListReferencedTasks(c common.Client, link string) ([]*Task, error) {
 	var result []*Task
@@ -194,7 +194,7 @@ func ListReferencedTasks(c common.Client, link string) ([]*Task, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }

--- a/redfish/task.go
+++ b/redfish/task.go
@@ -182,13 +182,19 @@ func ListReferencedTasks(c common.Client, link string) ([]*Task, error) {
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, taskLink := range links.ItemLinks {
 		task, err := GetTask(c, taskLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[taskLink] = err
+		} else {
+			result = append(result, task)
 		}
-		result = append(result, task)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }

--- a/redfish/thermal.go
+++ b/redfish/thermal.go
@@ -342,7 +342,7 @@ func GetThermal(c common.Client, uri string) (*Thermal, error) {
 	return &thermal, nil
 }
 
-// ListReferencedThermals gets the collection of Thermal from a provided reference.
+//nolint:dupl // ListReferencedThermals gets the collection of Thermal from a provided reference.
 func ListReferencedThermals(c common.Client, link string) ([]*Thermal, error) {
 	var result []*Thermal
 	if link == "" {
@@ -366,7 +366,7 @@ func ListReferencedThermals(c common.Client, link string) ([]*Thermal, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }

--- a/redfish/thermal.go
+++ b/redfish/thermal.go
@@ -354,13 +354,19 @@ func ListReferencedThermals(c common.Client, link string) ([]*Thermal, error) {
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, thermalLink := range links.ItemLinks {
 		thermal, err := GetThermal(c, thermalLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[thermalLink] = err
+		} else {
+			result = append(result, thermal)
 		}
-		result = append(result, thermal)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }

--- a/redfish/virtualmedia.go
+++ b/redfish/virtualmedia.go
@@ -265,7 +265,7 @@ func GetVirtualMedia(c common.Client, uri string) (*VirtualMedia, error) {
 	return &virtualmedia, nil
 }
 
-// ListReferencedVirtualMedias gets the collection of VirtualMedia from
+//nolint:dupl // ListReferencedVirtualMedias gets the collection of VirtualMedia from
 // a provided reference.
 func ListReferencedVirtualMedias(c common.Client, link string) ([]*VirtualMedia, error) {
 	var result []*VirtualMedia
@@ -289,7 +289,7 @@ func ListReferencedVirtualMedias(c common.Client, link string) ([]*VirtualMedia,
 	}
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }

--- a/redfish/virtualmedia.go
+++ b/redfish/virtualmedia.go
@@ -278,13 +278,18 @@ func ListReferencedVirtualMedias(c common.Client, link string) ([]*VirtualMedia,
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, virtualmediaLink := range links.ItemLinks {
 		virtualmedia, err := GetVirtualMedia(c, virtualmediaLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[virtualmediaLink] = err
+		} else {
+			result = append(result, virtualmedia)
 		}
-		result = append(result, virtualmedia)
 	}
-
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }

--- a/redfish/vlannetworkinterface.go
+++ b/redfish/vlannetworkinterface.go
@@ -98,7 +98,7 @@ func GetVLanNetworkInterface(c common.Client, uri string) (*VLanNetworkInterface
 	return &vlannetworkinterface, nil
 }
 
-// ListReferencedVLanNetworkInterfaces gets the collection of VLanNetworkInterface from
+//nolint:dupl // ListReferencedVLanNetworkInterfaces gets the collection of VLanNetworkInterface from
 // a provided reference.
 func ListReferencedVLanNetworkInterfaces(c common.Client, link string) ([]*VLanNetworkInterface, error) {
 	var result []*VLanNetworkInterface
@@ -123,7 +123,7 @@ func ListReferencedVLanNetworkInterfaces(c common.Client, link string) ([]*VLanN
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }

--- a/redfish/vlannetworkinterface.go
+++ b/redfish/vlannetworkinterface.go
@@ -111,13 +111,19 @@ func ListReferencedVLanNetworkInterfaces(c common.Client, link string) ([]*VLanN
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, vlannetworkinterfaceLink := range links.ItemLinks {
 		vlannetworkinterface, err := GetVLanNetworkInterface(c, vlannetworkinterfaceLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[vlannetworkinterfaceLink] = err
+		} else {
+			result = append(result, vlannetworkinterface)
 		}
-		result = append(result, vlannetworkinterface)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }

--- a/redfish/volume.go
+++ b/redfish/volume.go
@@ -248,30 +248,42 @@ func ListReferencedVolumes(c common.Client, link string) ([]*Volume, error) {
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, volumeLink := range links.ItemLinks {
 		volume, err := GetVolume(c, volumeLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[volumeLink] = err
+		} else {
+			result = append(result, volume)
 		}
-		result = append(result, volume)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // Drives references the Drives that this volume is associated with.
 func (volume *Volume) Drives() ([]*Drive, error) {
 	var result []*Drive
 
+	collectionError := common.NewCollectionError()
 	for _, driveLink := range volume.drives {
 		drive, err := GetDrive(volume.Client, driveLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[driveLink] = err
+		} else {
+			result = append(result, drive)
 		}
-		result = append(result, drive)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // AllowedVolumesUpdateApplyTimes returns the set of allowed apply times to request when setting the volumes values

--- a/redfish/volume.go
+++ b/redfish/volume.go
@@ -236,7 +236,7 @@ func GetVolume(c common.Client, uri string) (*Volume, error) {
 	return &volume, nil
 }
 
-// ListReferencedVolumes gets the collection of Volumes from a provided reference.
+//nolint:dupl // ListReferencedVolumes gets the collection of Volumes from a provided reference.
 func ListReferencedVolumes(c common.Client, link string) ([]*Volume, error) {
 	var result []*Volume
 	if link == "" {
@@ -260,9 +260,9 @@ func ListReferencedVolumes(c common.Client, link string) ([]*Volume, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // Drives references the Drives that this volume is associated with.
@@ -281,9 +281,9 @@ func (volume *Volume) Drives() ([]*Drive, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // AllowedVolumesUpdateApplyTimes returns the set of allowed apply times to request when setting the volumes values

--- a/swordfish/classofservice.go
+++ b/swordfish/classofservice.go
@@ -103,7 +103,7 @@ func GetClassOfService(c common.Client, uri string) (*ClassOfService, error) {
 	return &classofservice, nil
 }
 
-// ListReferencedClassOfServices gets the collection of ClassOfService from
+//nolint:dupl // ListReferencedClassOfServices gets the collection of ClassOfService from
 // a provided reference.
 func ListReferencedClassOfServices(c common.Client, link string) ([]*ClassOfService, error) {
 	var result []*ClassOfService
@@ -128,9 +128,9 @@ func ListReferencedClassOfServices(c common.Client, link string) ([]*ClassOfServ
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // DataProtectionLinesOfServices gets the DataProtectionLinesOfService that are
@@ -150,9 +150,9 @@ func (classofservice *ClassOfService) DataProtectionLinesOfServices() ([]*DataPr
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // DataSecurityLinesOfServices gets the DataSecurityLinesOfService that are
@@ -172,9 +172,9 @@ func (classofservice *ClassOfService) DataSecurityLinesOfServices() ([]*DataSecu
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // DataStorageLinesOfServices gets the DataStorageLinesOfService that are
@@ -194,9 +194,9 @@ func (classofservice *ClassOfService) DataStorageLinesOfServices() ([]*DataStora
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // IOConnectivityLinesOfServices gets the IOConnectivityLinesOfService that are
@@ -216,9 +216,9 @@ func (classofservice *ClassOfService) IOConnectivityLinesOfServices() ([]*IOConn
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // IOPerformanceLinesOfServices gets the IOPerformanceLinesOfService that are
@@ -238,7 +238,7 @@ func (classofservice *ClassOfService) IOPerformanceLinesOfServices() ([]*IOPerfo
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }

--- a/swordfish/classofservice.go
+++ b/swordfish/classofservice.go
@@ -116,83 +116,129 @@ func ListReferencedClassOfServices(c common.Client, link string) ([]*ClassOfServ
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, classofserviceLink := range links.ItemLinks {
 		classofservice, err := GetClassOfService(c, classofserviceLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[classofserviceLink] = err
+		} else {
+			result = append(result, classofservice)
 		}
-		result = append(result, classofservice)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // DataProtectionLinesOfServices gets the DataProtectionLinesOfService that are
 // part of this ClassOfService.
 func (classofservice *ClassOfService) DataProtectionLinesOfServices() ([]*DataProtectionLineOfService, error) {
 	var result []*DataProtectionLineOfService
+
+	collectionError := common.NewCollectionError()
 	for _, dpLosLink := range classofservice.dataProtectionLinesOfService {
 		dpLos, err := GetDataProtectionLineOfService(classofservice.Client, dpLosLink)
 		if err != nil {
-			return result, nil
+			collectionError.Failures[dpLosLink] = err
+		} else {
+			result = append(result, dpLos)
 		}
-		result = append(result, dpLos)
 	}
-	return result, nil
+
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // DataSecurityLinesOfServices gets the DataSecurityLinesOfService that are
 // part of this ClassOfService.
 func (classofservice *ClassOfService) DataSecurityLinesOfServices() ([]*DataSecurityLineOfService, error) {
 	var result []*DataSecurityLineOfService
+
+	collectionError := common.NewCollectionError()
 	for _, dsLosLink := range classofservice.dataSecurityLinesOfService {
 		dsLos, err := GetDataSecurityLineOfService(classofservice.Client, dsLosLink)
 		if err != nil {
-			return result, nil
+			collectionError.Failures[dsLosLink] = err
+		} else {
+			result = append(result, dsLos)
 		}
-		result = append(result, dsLos)
 	}
-	return result, nil
+
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // DataStorageLinesOfServices gets the DataStorageLinesOfService that are
 // part of this ClassOfService.
 func (classofservice *ClassOfService) DataStorageLinesOfServices() ([]*DataStorageLineOfService, error) {
 	var result []*DataStorageLineOfService
+
+	collectionError := common.NewCollectionError()
 	for _, dsLosLink := range classofservice.dataStorageLinesOfService {
 		dsLos, err := GetDataStorageLineOfService(classofservice.Client, dsLosLink)
 		if err != nil {
-			return result, nil
+			collectionError.Failures[dsLosLink] = err
+		} else {
+			result = append(result, dsLos)
 		}
-		result = append(result, dsLos)
 	}
-	return result, nil
+
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // IOConnectivityLinesOfServices gets the IOConnectivityLinesOfService that are
 // part of this ClassOfService.
 func (classofservice *ClassOfService) IOConnectivityLinesOfServices() ([]*IOConnectivityLineOfService, error) {
 	var result []*IOConnectivityLineOfService
+
+	collectionError := common.NewCollectionError()
 	for _, ioLosLink := range classofservice.dataSecurityLinesOfService {
 		ioLos, err := GetIOConnectivityLineOfService(classofservice.Client, ioLosLink)
 		if err != nil {
-			return result, nil
+			collectionError.Failures[ioLosLink] = err
+		} else {
+			result = append(result, ioLos)
 		}
-		result = append(result, ioLos)
 	}
-	return result, nil
+
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // IOPerformanceLinesOfServices gets the IOPerformanceLinesOfService that are
 // part of this ClassOfService.
 func (classofservice *ClassOfService) IOPerformanceLinesOfServices() ([]*IOPerformanceLineOfService, error) {
 	var result []*IOPerformanceLineOfService
+
+	collectionError := common.NewCollectionError()
 	for _, ioLosLink := range classofservice.dataSecurityLinesOfService {
 		ioLos, err := GetIOPerformanceLineOfService(classofservice.Client, ioLosLink)
 		if err != nil {
-			return result, nil
+			collectionError.Failures[ioLosLink] = err
+		} else {
+			result = append(result, ioLos)
 		}
-		result = append(result, ioLos)
 	}
-	return result, nil
+
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }

--- a/swordfish/dataprotectionlineofservice.go
+++ b/swordfish/dataprotectionlineofservice.go
@@ -90,15 +90,21 @@ func ListReferencedDataProtectionLineOfServices(c common.Client, link string) ([
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, dataprotectionlineofserviceLink := range links.ItemLinks {
 		dataprotectionlineofservice, err := GetDataProtectionLineOfService(c, dataprotectionlineofserviceLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[dataprotectionlineofserviceLink] = err
+		} else {
+			result = append(result, dataprotectionlineofservice)
 		}
-		result = append(result, dataprotectionlineofservice)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // ReplicaRequest is a request for a replica.

--- a/swordfish/dataprotectionlineofservice.go
+++ b/swordfish/dataprotectionlineofservice.go
@@ -77,7 +77,7 @@ func GetDataProtectionLineOfService(c common.Client, uri string) (*DataProtectio
 	return &dataprotectionlineofservice, nil
 }
 
-// ListReferencedDataProtectionLineOfServices gets the collection of DataProtectionLineOfService from
+//nolint:dupl // ListReferencedDataProtectionLineOfServices gets the collection of DataProtectionLineOfService from
 // a provided reference.
 func ListReferencedDataProtectionLineOfServices(c common.Client, link string) ([]*DataProtectionLineOfService, error) {
 	var result []*DataProtectionLineOfService
@@ -102,9 +102,9 @@ func ListReferencedDataProtectionLineOfServices(c common.Client, link string) ([
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // ReplicaRequest is a request for a replica.

--- a/swordfish/dataprotectionloscapabilities.go
+++ b/swordfish/dataprotectionloscapabilities.go
@@ -206,43 +206,61 @@ func ListReferencedDataProtectionLoSCapabilities(c common.Client, link string) (
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, dataprotectionloscapabilitiesLink := range links.ItemLinks {
 		dataprotectionloscapabilities, err := GetDataProtectionLoSCapabilities(c, dataprotectionloscapabilitiesLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[dataprotectionloscapabilitiesLink] = err
+		} else {
+			result = append(result, dataprotectionloscapabilities)
 		}
-		result = append(result, dataprotectionloscapabilities)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // SupportedReplicaOptions gets the support replica ClassesOfService.
 func (dataprotectionloscapabilities *DataProtectionLoSCapabilities) SupportedReplicaOptions() ([]*ClassOfService, error) {
 	var result []*ClassOfService
 
+	collectionError := common.NewCollectionError()
 	for _, link := range dataprotectionloscapabilities.supportedReplicaOptions {
 		classOfService, err := GetClassOfService(dataprotectionloscapabilities.Client, link)
 		if err != nil {
-			return result, err
+			collectionError.Failures[link] = err
+		} else {
+			result = append(result, classOfService)
 		}
-		result = append(result, classOfService)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // SupportedLinesOfService gets the supported lines of service.
 func (dataprotectionloscapabilities *DataProtectionLoSCapabilities) SupportedLinesOfService() ([]*DataProtectionLineOfService, error) {
 	var result []*DataProtectionLineOfService
 
+	collectionError := common.NewCollectionError()
 	for _, link := range dataprotectionloscapabilities.supportedLinesOfService {
 		lineOfService, err := GetDataProtectionLineOfService(dataprotectionloscapabilities.Client, link)
 		if err != nil {
-			return result, err
+			collectionError.Failures[link] = err
+		} else {
+			result = append(result, lineOfService)
 		}
-		result = append(result, lineOfService)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }

--- a/swordfish/dataprotectionloscapabilities.go
+++ b/swordfish/dataprotectionloscapabilities.go
@@ -193,7 +193,7 @@ func GetDataProtectionLoSCapabilities(c common.Client, uri string) (*DataProtect
 	return &dataprotectionloscapabilities, nil
 }
 
-// ListReferencedDataProtectionLoSCapabilities gets the collection of DataProtectionLoSCapabilities from
+//nolint:dupl // ListReferencedDataProtectionLoSCapabilities gets the collection of DataProtectionLoSCapabilities from
 // a provided reference.
 func ListReferencedDataProtectionLoSCapabilities(c common.Client, link string) ([]*DataProtectionLoSCapabilities, error) {
 	var result []*DataProtectionLoSCapabilities
@@ -218,9 +218,9 @@ func ListReferencedDataProtectionLoSCapabilities(c common.Client, link string) (
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // SupportedReplicaOptions gets the support replica ClassesOfService.
@@ -239,9 +239,9 @@ func (dataprotectionloscapabilities *DataProtectionLoSCapabilities) SupportedRep
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // SupportedLinesOfService gets the supported lines of service.
@@ -260,7 +260,7 @@ func (dataprotectionloscapabilities *DataProtectionLoSCapabilities) SupportedLin
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }

--- a/swordfish/datasecurityloscapabilities.go
+++ b/swordfish/datasecurityloscapabilities.go
@@ -230,13 +230,19 @@ func ListReferencedDataSecurityLoSCapabilities(c common.Client, link string) ([]
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, datasecurityloscapabilitiesLink := range links.ItemLinks {
 		datasecurityloscapabilities, err := GetDataSecurityLoSCapabilities(c, datasecurityloscapabilitiesLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[datasecurityloscapabilitiesLink] = err
+		} else {
+			result = append(result, datasecurityloscapabilities)
 		}
-		result = append(result, datasecurityloscapabilities)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }

--- a/swordfish/datasecurityloscapabilities.go
+++ b/swordfish/datasecurityloscapabilities.go
@@ -217,7 +217,7 @@ func GetDataSecurityLoSCapabilities(c common.Client, uri string) (*DataSecurityL
 	return &datasecurityloscapabilities, nil
 }
 
-// ListReferencedDataSecurityLoSCapabilities gets the collection of DataSecurityLoSCapabilities from
+//nolint:dupl // ListReferencedDataSecurityLoSCapabilities gets the collection of DataSecurityLoSCapabilities from
 // a provided reference.
 func ListReferencedDataSecurityLoSCapabilities(c common.Client, link string) ([]*DataSecurityLoSCapabilities, error) {
 	var result []*DataSecurityLoSCapabilities
@@ -242,7 +242,7 @@ func ListReferencedDataSecurityLoSCapabilities(c common.Client, link string) ([]
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }

--- a/swordfish/datastoragelineofservice.go
+++ b/swordfish/datastoragelineofservice.go
@@ -86,7 +86,7 @@ func GetDataStorageLineOfService(c common.Client, uri string) (*DataStorageLineO
 	return &datastoragelineofservice, nil
 }
 
-// ListReferencedDataStorageLineOfServices gets the collection of DataStorageLineOfService from
+//nolint:dupl // ListReferencedDataStorageLineOfServices gets the collection of DataStorageLineOfService from
 // a provided reference.
 func ListReferencedDataStorageLineOfServices(c common.Client, link string) ([]*DataStorageLineOfService, error) {
 	var result []*DataStorageLineOfService
@@ -111,7 +111,7 @@ func ListReferencedDataStorageLineOfServices(c common.Client, link string) ([]*D
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }

--- a/swordfish/datastoragelineofservice.go
+++ b/swordfish/datastoragelineofservice.go
@@ -99,13 +99,19 @@ func ListReferencedDataStorageLineOfServices(c common.Client, link string) ([]*D
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, datastoragelineofserviceLink := range links.ItemLinks {
 		datastoragelineofservice, err := GetDataStorageLineOfService(c, datastoragelineofserviceLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[datastoragelineofserviceLink] = err
+		} else {
+			result = append(result, datastoragelineofservice)
 		}
-		result = append(result, datastoragelineofservice)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }

--- a/swordfish/datastorageloscapabilities.go
+++ b/swordfish/datastorageloscapabilities.go
@@ -146,7 +146,7 @@ func GetDataStorageLoSCapabilities(c common.Client, uri string) (*DataStorageLoS
 	return &datastorageloscapabilities, nil
 }
 
-// ListReferencedDataStorageLoSCapabilities gets the collection of DataStorageLoSCapabilities from
+//nolint:dupl // ListReferencedDataStorageLoSCapabilities gets the collection of DataStorageLoSCapabilities from
 // a provided reference.
 func ListReferencedDataStorageLoSCapabilities(c common.Client, link string) ([]*DataStorageLoSCapabilities, error) {
 	var result []*DataStorageLoSCapabilities
@@ -171,7 +171,7 @@ func ListReferencedDataStorageLoSCapabilities(c common.Client, link string) ([]*
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }

--- a/swordfish/datastorageloscapabilities.go
+++ b/swordfish/datastorageloscapabilities.go
@@ -159,13 +159,19 @@ func ListReferencedDataStorageLoSCapabilities(c common.Client, link string) ([]*
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, datastorageloscapabilitiesLink := range links.ItemLinks {
 		datastorageloscapabilities, err := GetDataStorageLoSCapabilities(c, datastorageloscapabilitiesLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[datastorageloscapabilitiesLink] = err
+		} else {
+			result = append(result, datastorageloscapabilities)
 		}
-		result = append(result, datastorageloscapabilities)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }

--- a/swordfish/endpointgroup.go
+++ b/swordfish/endpointgroup.go
@@ -146,7 +146,7 @@ func GetEndpointGroup(c common.Client, uri string) (*EndpointGroup, error) {
 	return &endpointgroup, nil
 }
 
-// ListReferencedEndpointGroups gets the collection of EndpointGroup from
+//nolint:dupl // ListReferencedEndpointGroups gets the collection of EndpointGroup from
 // a provided reference.
 func ListReferencedEndpointGroups(c common.Client, link string) ([]*EndpointGroup, error) {
 	var result []*EndpointGroup
@@ -171,9 +171,9 @@ func ListReferencedEndpointGroups(c common.Client, link string) ([]*EndpointGrou
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // Endpoints gets the group's endpoints.

--- a/swordfish/endpointgroup.go
+++ b/swordfish/endpointgroup.go
@@ -159,15 +159,21 @@ func ListReferencedEndpointGroups(c common.Client, link string) ([]*EndpointGrou
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, endpointgroupLink := range links.ItemLinks {
 		endpointgroup, err := GetEndpointGroup(c, endpointgroupLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[endpointgroupLink] = err
+		} else {
+			result = append(result, endpointgroup)
 		}
-		result = append(result, endpointgroup)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // Endpoints gets the group's endpoints.

--- a/swordfish/filesystem.go
+++ b/swordfish/filesystem.go
@@ -288,15 +288,21 @@ func ListReferencedFileSystems(c common.Client, link string) ([]*FileSystem, err
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, filesystemLink := range links.ItemLinks {
 		filesystem, err := GetFileSystem(c, filesystemLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[filesystemLink] = err
+		} else {
+			result = append(result, filesystem)
 		}
-		result = append(result, filesystem)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // ExportedShares gets the exported file shares for this file system.
@@ -316,13 +322,20 @@ func (filesystem *FileSystem) ClassOfService() (*ClassOfService, error) {
 // SpareResourceSets gets the spare resource sets used for this filesystem.
 func (filesystem *FileSystem) SpareResourceSets() ([]*SpareResourceSet, error) {
 	var result []*SpareResourceSet
+
+	collectionError := common.NewCollectionError()
 	for _, rsLink := range filesystem.spareResourceSets {
 		rs, err := GetSpareResourceSet(filesystem.Client, rsLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[rsLink] = err
+		} else {
+			result = append(result, rs)
 		}
-		result = append(result, rs)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }

--- a/swordfish/filesystem.go
+++ b/swordfish/filesystem.go
@@ -275,7 +275,7 @@ func GetFileSystem(c common.Client, uri string) (*FileSystem, error) {
 	return &filesystem, nil
 }
 
-// ListReferencedFileSystems gets the collection of FileSystem from
+//nolint:dupl // ListReferencedFileSystems gets the collection of FileSystem from
 // a provided reference.
 func ListReferencedFileSystems(c common.Client, link string) ([]*FileSystem, error) {
 	var result []*FileSystem
@@ -300,9 +300,9 @@ func ListReferencedFileSystems(c common.Client, link string) ([]*FileSystem, err
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // ExportedShares gets the exported file shares for this file system.
@@ -335,7 +335,7 @@ func (filesystem *FileSystem) SpareResourceSets() ([]*SpareResourceSet, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }

--- a/swordfish/ioconnectivitylineofservice.go
+++ b/swordfish/ioconnectivitylineofservice.go
@@ -66,13 +66,19 @@ func ListReferencedIOConnectivityLineOfServices(c common.Client, link string) ([
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, ioconnectivitylineofserviceLink := range links.ItemLinks {
 		ioconnectivitylineofservice, err := GetIOConnectivityLineOfService(c, ioconnectivitylineofserviceLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[ioconnectivitylineofserviceLink] = err
+		} else {
+			result = append(result, ioconnectivitylineofservice)
 		}
-		result = append(result, ioconnectivitylineofservice)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }

--- a/swordfish/ioconnectivitylineofservice.go
+++ b/swordfish/ioconnectivitylineofservice.go
@@ -53,7 +53,7 @@ func GetIOConnectivityLineOfService(c common.Client, uri string) (*IOConnectivit
 	return &ioconnectivitylineofservice, nil
 }
 
-// ListReferencedIOConnectivityLineOfServices gets the collection of IOConnectivityLineOfService from
+//nolint:dupl // ListReferencedIOConnectivityLineOfServices gets the collection of IOConnectivityLineOfService from
 // a provided reference.
 func ListReferencedIOConnectivityLineOfServices(c common.Client, link string) ([]*IOConnectivityLineOfService, error) {
 	var result []*IOConnectivityLineOfService
@@ -78,7 +78,7 @@ func ListReferencedIOConnectivityLineOfServices(c common.Client, link string) ([
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }

--- a/swordfish/ioconnectivityloscapabilities.go
+++ b/swordfish/ioconnectivityloscapabilities.go
@@ -119,13 +119,19 @@ func ListReferencedIOConnectivityLoSCapabilitiess(c common.Client, link string) 
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, ioconnectivityloscapabilitiesLink := range links.ItemLinks {
 		ioconnectivityloscapabilities, err := GetIOConnectivityLoSCapabilities(c, ioconnectivityloscapabilitiesLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[ioconnectivityloscapabilitiesLink] = err
+		} else {
+			result = append(result, ioconnectivityloscapabilities)
 		}
-		result = append(result, ioconnectivityloscapabilities)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }

--- a/swordfish/ioconnectivityloscapabilities.go
+++ b/swordfish/ioconnectivityloscapabilities.go
@@ -106,7 +106,7 @@ func GetIOConnectivityLoSCapabilities(c common.Client, uri string) (*IOConnectiv
 	return &ioconnectivityloscapabilities, nil
 }
 
-// ListReferencedIOConnectivityLoSCapabilitiess gets the collection of
+//nolint:dupl // ListReferencedIOConnectivityLoSCapabilitiess gets the collection of
 // IOConnectivityLoSCapabilities from a provided reference.
 func ListReferencedIOConnectivityLoSCapabilitiess(c common.Client, link string) ([]*IOConnectivityLoSCapabilities, error) {
 	var result []*IOConnectivityLoSCapabilities
@@ -131,7 +131,7 @@ func ListReferencedIOConnectivityLoSCapabilitiess(c common.Client, link string) 
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }

--- a/swordfish/ioperformancelineofservice.go
+++ b/swordfish/ioperformancelineofservice.go
@@ -64,7 +64,7 @@ func GetIOPerformanceLineOfService(c common.Client, uri string) (*IOPerformanceL
 	return &ioperformancelineofservice, nil
 }
 
-// ListReferencedIOPerformanceLineOfServices gets the collection of IOPerformanceLineOfService from
+//nolint:dupl // ListReferencedIOPerformanceLineOfServices gets the collection of IOPerformanceLineOfService from
 // a provided reference.
 func ListReferencedIOPerformanceLineOfServices(c common.Client, link string) ([]*IOPerformanceLineOfService, error) {
 	var result []*IOPerformanceLineOfService
@@ -89,7 +89,7 @@ func ListReferencedIOPerformanceLineOfServices(c common.Client, link string) ([]
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }

--- a/swordfish/ioperformancelineofservice.go
+++ b/swordfish/ioperformancelineofservice.go
@@ -77,13 +77,19 @@ func ListReferencedIOPerformanceLineOfServices(c common.Client, link string) ([]
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, ioperformancelineofserviceLink := range links.ItemLinks {
 		ioperformancelineofservice, err := GetIOPerformanceLineOfService(c, ioperformancelineofserviceLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[ioperformancelineofserviceLink] = err
+		} else {
+			result = append(result, ioperformancelineofservice)
 		}
-		result = append(result, ioperformancelineofservice)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }

--- a/swordfish/ioperformanceloscapabilities.go
+++ b/swordfish/ioperformanceloscapabilities.go
@@ -147,15 +147,21 @@ func ListReferencedIOPerformanceLoSCapabilitiess(c common.Client, link string) (
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, ioperformanceloscapabilitiesLink := range links.ItemLinks {
 		ioperformanceloscapabilities, err := GetIOPerformanceLoSCapabilities(c, ioperformanceloscapabilitiesLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[ioperformanceloscapabilitiesLink] = err
+		} else {
+			result = append(result, ioperformanceloscapabilities)
 		}
-		result = append(result, ioperformanceloscapabilities)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // IOWorkload is used to describe an IO Workload.

--- a/swordfish/ioperformanceloscapabilities.go
+++ b/swordfish/ioperformanceloscapabilities.go
@@ -134,7 +134,7 @@ func GetIOPerformanceLoSCapabilities(c common.Client, uri string) (*IOPerformanc
 	return &ioperformanceloscapabilities, nil
 }
 
-// ListReferencedIOPerformanceLoSCapabilitiess gets the collection of IOPerformanceLoSCapabilities from
+//nolint:dupl // ListReferencedIOPerformanceLoSCapabilitiess gets the collection of IOPerformanceLoSCapabilities from
 // a provided reference.
 func ListReferencedIOPerformanceLoSCapabilitiess(c common.Client, link string) ([]*IOPerformanceLoSCapabilities, error) {
 	var result []*IOPerformanceLoSCapabilities
@@ -159,9 +159,9 @@ func ListReferencedIOPerformanceLoSCapabilitiess(c common.Client, link string) (
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // IOWorkload is used to describe an IO Workload.

--- a/swordfish/spareresourceset.go
+++ b/swordfish/spareresourceset.go
@@ -124,7 +124,7 @@ func GetSpareResourceSet(c common.Client, uri string) (*SpareResourceSet, error)
 	return &spareresourceset, nil
 }
 
-// ListReferencedSpareResourceSets gets the collection of SpareResourceSet from
+//nolint:dupl // ListReferencedSpareResourceSets gets the collection of SpareResourceSet from
 // a provided reference.
 func ListReferencedSpareResourceSets(c common.Client, link string) ([]*SpareResourceSet, error) {
 	var result []*SpareResourceSet
@@ -149,9 +149,9 @@ func ListReferencedSpareResourceSets(c common.Client, link string) ([]*SpareReso
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // ReplacementSpareSets gets other spare sets that can be utilized to replenish

--- a/swordfish/spareresourceset.go
+++ b/swordfish/spareresourceset.go
@@ -137,15 +137,21 @@ func ListReferencedSpareResourceSets(c common.Client, link string) ([]*SpareReso
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, spareresourcesetLink := range links.ItemLinks {
 		spareresourceset, err := GetSpareResourceSet(c, spareresourcesetLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[spareresourcesetLink] = err
+		} else {
+			result = append(result, spareresourceset)
 		}
-		result = append(result, spareresourceset)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // ReplacementSpareSets gets other spare sets that can be utilized to replenish

--- a/swordfish/storagegroup.go
+++ b/swordfish/storagegroup.go
@@ -237,43 +237,63 @@ func ListReferencedStorageGroups(c common.Client, link string) ([]*StorageGroup,
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, storagegroupLink := range links.ItemLinks {
 		storagegroup, err := GetStorageGroup(c, storagegroupLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[storagegroupLink] = err
+		} else {
+			result = append(result, storagegroup)
 		}
-		result = append(result, storagegroup)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // ChildStorageGroups gets child groups of this group.
 func (storagegroup *StorageGroup) ChildStorageGroups() ([]*StorageGroup, error) {
 	var result []*StorageGroup
+
+	collectionError := common.NewCollectionError()
 	for _, sgLink := range storagegroup.childStorageGroups {
 		sg, err := GetStorageGroup(storagegroup.Client, sgLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[sgLink] = err
+		} else {
+			result = append(result, sg)
 		}
-		result = append(result, sg)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // ParentStorageGroups gets parent groups of this group.
 func (storagegroup *StorageGroup) ParentStorageGroups() ([]*StorageGroup, error) {
 	var result []*StorageGroup
+
+	collectionError := common.NewCollectionError()
 	for _, sgLink := range storagegroup.parentStorageGroups {
 		sg, err := GetStorageGroup(storagegroup.Client, sgLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[sgLink] = err
+		} else {
+			result = append(result, sg)
 		}
-		result = append(result, sg)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // ClassOfService gets the ClassOfService that all storage in this StorageGroup

--- a/swordfish/storagegroup.go
+++ b/swordfish/storagegroup.go
@@ -224,7 +224,7 @@ func GetStorageGroup(c common.Client, uri string) (*StorageGroup, error) {
 	return &storagegroup, nil
 }
 
-// ListReferencedStorageGroups gets the collection of StorageGroup from
+//nolint:dupl // ListReferencedStorageGroups gets the collection of StorageGroup from
 // a provided reference.
 func ListReferencedStorageGroups(c common.Client, link string) ([]*StorageGroup, error) {
 	var result []*StorageGroup
@@ -249,9 +249,9 @@ func ListReferencedStorageGroups(c common.Client, link string) ([]*StorageGroup,
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // ChildStorageGroups gets child groups of this group.
@@ -270,9 +270,9 @@ func (storagegroup *StorageGroup) ChildStorageGroups() ([]*StorageGroup, error) 
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // ParentStorageGroups gets parent groups of this group.
@@ -291,9 +291,9 @@ func (storagegroup *StorageGroup) ParentStorageGroups() ([]*StorageGroup, error)
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // ClassOfService gets the ClassOfService that all storage in this StorageGroup

--- a/swordfish/storagepool.go
+++ b/swordfish/storagepool.go
@@ -201,43 +201,65 @@ func ListReferencedStoragePools(c common.Client, link string) ([]*StoragePool, e
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, storagepoolLink := range links.ItemLinks {
 		storagepool, err := GetStoragePool(c, storagepoolLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[storagepoolLink] = err
+		} else {
+			result = append(result, storagepool)
 		}
-		result = append(result, storagepool)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // DedicatedSpareDrives gets the Drive entities which are currently assigned as
 // a dedicated spare and are able to support this StoragePool.
 func (storagepool *StoragePool) DedicatedSpareDrives() ([]*redfish.Drive, error) {
 	var result []*redfish.Drive
+
+	collectionError := common.NewCollectionError()
 	for _, driveLink := range storagepool.dedicatedSpareDrives {
 		drive, err := redfish.GetDrive(storagepool.Client, driveLink)
 		if err != nil {
-			return result, nil
+			collectionError.Failures[driveLink] = err
+		} else {
+			result = append(result, drive)
 		}
-		result = append(result, drive)
 	}
-	return result, nil
+
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // SpareResourceSets gets resources that may be utilized to replace the capacity
 // provided by a failed resource having a compatible type.
 func (storagepool *StoragePool) SpareResourceSets() ([]*SpareResourceSet, error) {
 	var result []*SpareResourceSet
+
+	collectionError := common.NewCollectionError()
 	for _, srsLink := range storagepool.spareResourceSets {
 		srs, err := GetSpareResourceSet(storagepool.Client, srsLink)
 		if err != nil {
-			return result, nil
+			collectionError.Failures[srsLink] = err
+		} else {
+			result = append(result, srs)
 		}
-		result = append(result, srs)
 	}
-	return result, nil
+
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // AllocatedPools gets the storage pools allocated from this storage pool.
@@ -253,14 +275,22 @@ func (storagepool *StoragePool) AllocatedVolumes() ([]*Volume, error) {
 // CapacitySources gets space allocations to this pool.
 func (storagepool *StoragePool) CapacitySources() ([]*CapacitySource, error) {
 	var result []*CapacitySource
+
+	collectionError := common.NewCollectionError()
 	for _, capLink := range storagepool.capacitySources {
 		capacity, err := GetCapacitySource(storagepool.Client, capLink)
 		if err != nil {
-			return result, nil
+			collectionError.Failures[capLink] = err
+		} else {
+			result = append(result, capacity)
 		}
-		result = append(result, capacity)
 	}
-	return result, nil
+
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // ClassesOfService gets references to all classes of service supported by this

--- a/swordfish/storagepool.go
+++ b/swordfish/storagepool.go
@@ -188,7 +188,7 @@ func GetStoragePool(c common.Client, uri string) (*StoragePool, error) {
 	return &storagepool, nil
 }
 
-// ListReferencedStoragePools gets the collection of StoragePool from
+//nolint:dupl // ListReferencedStoragePools gets the collection of StoragePool from
 // a provided reference.
 func ListReferencedStoragePools(c common.Client, link string) ([]*StoragePool, error) {
 	var result []*StoragePool
@@ -213,9 +213,9 @@ func ListReferencedStoragePools(c common.Client, link string) ([]*StoragePool, e
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // DedicatedSpareDrives gets the Drive entities which are currently assigned as
@@ -235,9 +235,9 @@ func (storagepool *StoragePool) DedicatedSpareDrives() ([]*redfish.Drive, error)
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // SpareResourceSets gets resources that may be utilized to replace the capacity
@@ -257,9 +257,9 @@ func (storagepool *StoragePool) SpareResourceSets() ([]*SpareResourceSet, error)
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // AllocatedPools gets the storage pools allocated from this storage pool.
@@ -288,9 +288,9 @@ func (storagepool *StoragePool) CapacitySources() ([]*CapacitySource, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // ClassesOfService gets references to all classes of service supported by this

--- a/swordfish/storagereplicainfo.go
+++ b/swordfish/storagereplicainfo.go
@@ -461,7 +461,7 @@ func GetStorageReplicaInfo(c common.Client, uri string) (*StorageReplicaInfo, er
 	return &storagereplicainfo, nil
 }
 
-// ListReferencedStorageReplicaInfos gets the collection of StorageReplicaInfo from
+//nolint:dupl // ListReferencedStorageReplicaInfos gets the collection of StorageReplicaInfo from
 // a provided reference.
 func ListReferencedStorageReplicaInfos(c common.Client, link string) ([]*StorageReplicaInfo, error) {
 	var result []*StorageReplicaInfo
@@ -486,7 +486,7 @@ func ListReferencedStorageReplicaInfos(c common.Client, link string) ([]*Storage
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }

--- a/swordfish/storagereplicainfo.go
+++ b/swordfish/storagereplicainfo.go
@@ -474,13 +474,19 @@ func ListReferencedStorageReplicaInfos(c common.Client, link string) ([]*Storage
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, storagereplicainfoLink := range links.ItemLinks {
 		storagereplicainfo, err := GetStorageReplicaInfo(c, storagereplicainfoLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[storagereplicainfoLink] = err
+		} else {
+			result = append(result, storagereplicainfo)
 		}
-		result = append(result, storagereplicainfo)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }

--- a/swordfish/storageservice.go
+++ b/swordfish/storageservice.go
@@ -187,15 +187,21 @@ func ListReferencedStorageServices(c common.Client, link string) ([]*StorageServ
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, storageserviceLink := range links.ItemLinks {
 		storageservice, err := GetStorageService(c, storageserviceLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[storageserviceLink] = err
+		} else {
+			result = append(result, storageservice)
 		}
-		result = append(result, storageservice)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // ClassesOfService gets the storage service's classes of service.
@@ -277,44 +283,65 @@ func (storageservice *StorageService) IOPerformanceLoSCapabilities() (*IOPerform
 // Redundancy gets the redundancy information for the storage subsystem.
 func (storageservice *StorageService) Redundancy() ([]*redfish.Redundancy, error) {
 	var result []*redfish.Redundancy
+
+	collectionError := common.NewCollectionError()
 	for _, redundancyLink := range storageservice.redundancy {
 		redundancy, err := redfish.GetRedundancy(storageservice.Client, redundancyLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[redundancyLink] = err
+		} else {
+			result = append(result, redundancy)
 		}
-		result = append(result, redundancy)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // SpareResourceSets gets resources that may be utilized to replace the capacity
 // provided by a failed resource having a compatible type.
 func (storageservice *StorageService) SpareResourceSets() ([]*SpareResourceSet, error) {
 	var result []*SpareResourceSet
+
+	collectionError := common.NewCollectionError()
 	for _, srsLink := range storageservice.spareResourceSets {
 		srs, err := GetSpareResourceSet(storageservice.Client, srsLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[srsLink] = err
+		} else {
+			result = append(result, srs)
 		}
-		result = append(result, srs)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // StorageGroups gets the storage groups that are a part of this storage service.
 func (storageservice *StorageService) StorageGroups() ([]*StorageGroup, error) {
 	var result []*StorageGroup
+
+	collectionError := common.NewCollectionError()
 	for _, sgLink := range storageservice.spareResourceSets {
 		sg, err := GetStorageGroup(storageservice.Client, sgLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[sgLink] = err
+		} else {
+			result = append(result, sg)
 		}
-		result = append(result, sg)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // Volumes gets the volumes that are a part of this storage service.

--- a/swordfish/storageservice.go
+++ b/swordfish/storageservice.go
@@ -199,9 +199,9 @@ func ListReferencedStorageServices(c common.Client, link string) ([]*StorageServ
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // ClassesOfService gets the storage service's classes of service.
@@ -296,9 +296,9 @@ func (storageservice *StorageService) Redundancy() ([]*redfish.Redundancy, error
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // SpareResourceSets gets resources that may be utilized to replace the capacity
@@ -318,9 +318,9 @@ func (storageservice *StorageService) SpareResourceSets() ([]*SpareResourceSet, 
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // StorageGroups gets the storage groups that are a part of this storage service.
@@ -339,9 +339,9 @@ func (storageservice *StorageService) StorageGroups() ([]*StorageGroup, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // Volumes gets the volumes that are a part of this storage service.

--- a/swordfish/storagesystem.go
+++ b/swordfish/storagesystem.go
@@ -42,13 +42,19 @@ func ListReferencedStorageSystems(c common.Client, link string) ([]*StorageSyste
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, storageSystemLink := range links.ItemLinks {
 		storageSystem, err := GetStorageSystem(c, storageSystemLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[storageSystemLink] = err
+		} else {
+			result = append(result, storageSystem)
 		}
-		result = append(result, storageSystem)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }

--- a/swordfish/storagesystem.go
+++ b/swordfish/storagesystem.go
@@ -54,7 +54,7 @@ func ListReferencedStorageSystems(c common.Client, link string) ([]*StorageSyste
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }

--- a/swordfish/volume.go
+++ b/swordfish/volume.go
@@ -576,15 +576,21 @@ func ListReferencedVolumes(c common.Client, link string) ([]*Volume, error) {
 		return result, err
 	}
 
+	collectionError := common.NewCollectionError()
 	for _, volumeLink := range links.ItemLinks {
 		volume, err := GetVolume(c, volumeLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[volumeLink] = err
+		} else {
+			result = append(result, volume)
 		}
-		result = append(result, volume)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // ClassOfService gets the class of service that this storage volume conforms to.
@@ -600,15 +606,21 @@ func (volume *Volume) ClassOfService() (*ClassOfService, error) {
 func (volume *Volume) getDrives(links []string) ([]*redfish.Drive, error) {
 	var result []*redfish.Drive
 
+	collectionError := common.NewCollectionError()
 	for _, driveLink := range links {
 		drive, err := redfish.GetDrive(volume.Client, driveLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[driveLink] = err
+		} else {
+			result = append(result, drive)
 		}
-		result = append(result, drive)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // DedicatedSpareDrives references the Drives that are dedicated spares for this
@@ -625,43 +637,64 @@ func (volume *Volume) Drives() ([]*redfish.Drive, error) {
 // SpareResourceSets gets the spare resources that can be used for this volume.
 func (volume *Volume) SpareResourceSets() ([]*SpareResourceSet, error) {
 	var result []*SpareResourceSet
+
+	collectionError := common.NewCollectionError()
 	for _, srsLink := range volume.spareResourceSets {
 		srs, err := GetSpareResourceSet(volume.Client, srsLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[srsLink] = err
+		} else {
+			result = append(result, srs)
 		}
-		result = append(result, srs)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // StorageGroups gets the storage groups that associated with this volume.
 func (volume *Volume) StorageGroups() ([]*StorageGroup, error) {
 	var result []*StorageGroup
+
+	collectionError := common.NewCollectionError()
 	for _, sgLink := range volume.storageGroups {
 		sg, err := GetStorageGroup(volume.Client, sgLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[sgLink] = err
+		} else {
+			result = append(result, sg)
 		}
-		result = append(result, sg)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // StoragePools gets the storage pools that associated with this volume.
 func (volume *Volume) StoragePools() ([]*StoragePool, error) {
 	var result []*StoragePool
+
+	collectionError := common.NewCollectionError()
 	for _, sgLink := range volume.allocatedPools {
 		sg, err := GetStoragePool(volume.Client, sgLink)
 		if err != nil {
-			return result, err
+			collectionError.Failures[sgLink] = err
+		} else {
+			result = append(result, sg)
 		}
-		result = append(result, sg)
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	} else {
+		return result, collectionError
+	}
 }
 
 // AssignReplicaTarget is used to establish a replication relationship by

--- a/swordfish/volume.go
+++ b/swordfish/volume.go
@@ -564,7 +564,7 @@ func GetVolume(c common.Client, uri string) (*Volume, error) {
 	return &volume, nil
 }
 
-// ListReferencedVolumes gets the collection of Volume from a provided reference.
+//nolint:dupl // ListReferencedVolumes gets the collection of Volume from a provided reference.
 func ListReferencedVolumes(c common.Client, link string) ([]*Volume, error) {
 	var result []*Volume
 	if link == "" {
@@ -588,9 +588,9 @@ func ListReferencedVolumes(c common.Client, link string) ([]*Volume, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // ClassOfService gets the class of service that this storage volume conforms to.
@@ -618,9 +618,9 @@ func (volume *Volume) getDrives(links []string) ([]*redfish.Drive, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // DedicatedSpareDrives references the Drives that are dedicated spares for this
@@ -650,9 +650,9 @@ func (volume *Volume) SpareResourceSets() ([]*SpareResourceSet, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // StorageGroups gets the storage groups that associated with this volume.
@@ -671,9 +671,9 @@ func (volume *Volume) StorageGroups() ([]*StorageGroup, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // StoragePools gets the storage pools that associated with this volume.
@@ -692,9 +692,9 @@ func (volume *Volume) StoragePools() ([]*StoragePool, error) {
 
 	if collectionError.Empty() {
 		return result, nil
-	} else {
-		return result, collectionError
 	}
+
+	return result, collectionError
 }
 
 // AssignReplicaTarget is used to establish a replication relationship by

--- a/tools/source.tmpl
+++ b/tools/source.tmpl
@@ -118,15 +118,21 @@ func ListReferenced{{ class.name }}s(c common.Client, link string) ([]*{{ class.
         return result, err
     }
 
+    collectionError := common.NewCollectionError()
     for _, {{ class.name|lower }}Link := range links.ItemLinks {
         {{ class.name|lower }}, err := Get{{ class.name }}(c, {{ class.name|lower }}Link)
         if err != nil {
-            return result, err
+            collectionError.Failures[{{ class.name|lower }}Link] = err
+        } else {
+            result = append(result, {{ class.name|lower }})
         }
-        result = append(result, {{ class.name|lower }})
     }
 
-    return result, nil
+    if collectionError.Empty() {
+        return result, nil
+    } else {
+        return result, collectionError
+    }
 }
 
 {% endif %}


### PR DESCRIPTION
Relevant discussion in #147 

I updated all of the collection functions that I could find by searching for `var result []`. I appreciate the consistency of the library because I think that returned most of the collection functions. :smile: Let me know if I missed any.

I noticed while working through these changes that the case of `return result, nil` happened much less often than I thought so my worry about user code brittleness is less valid. :+1: 

Overall I think this change improves the consistency of collection error handling and should greatly improve the resilience of gofish in production. Let me know what you think!

Edit: 
Also, I chose to implement the bulk of the error message with JSON because I figure that some of the error messages could end up being quite large. I think it will be nice to format the error message and have a clear mapping of errors to the entities with which they occurred. 