### PR TITLE
Update types.go -- make PostalAddress.Country a string

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -439,7 +439,7 @@ type PostalAddress struct {
 	Community string
 	// Country shall conform the requirements of the Country
 	// field as defined in RFC5139.
-	Country int
+	Country string
 	// District is used to name a county, parish, gun (JP), or district
 	// (IN).
 	District string

--- a/swordfish/spareresourceset_test.go
+++ b/swordfish/spareresourceset_test.go
@@ -61,7 +61,7 @@ var spareResourceSetBody = `{
 			"PostalAddress": {
 				"Building": "The big one on the right",
 				"City": "London",
-				"Country": 826,
+				"Country": "UK",
 				"Floor": "Top floor",
 				"HouseNumber": 89,
 				"Name": "Big Data Center",


### PR DESCRIPTION
Request updating package `common`'s `PostalAddress` struct to make `Country` a `string` instead of an `int`.

It appears, from the comments, as if the current rationale for making this an integer value (reference to RF5139) is incorrect. Per  [RFC5139](https://datatracker.ietf.org/doc/html/rfc5139#section-3.3)

**3.3.  Country Element**

   The "country" element differs from that defined in [RFC4119] in that
   it now restricts the value space of the element to two uppercase
   characters, which correspond to the alpha-2 codes in [ISO.3166-1].

**3.4.  A1 Element**

   The "A1" element is used for the top-level subdivision within a
   country.  In the absence of a country-specific guide on how to use
   the A-series of elements, the second part of the ISO 3166-2 code
   [ISO.3166-2] for a country subdivision SHOULD be used.  The ISO
   3166-2 code is formed of a country code and hyphen plus a code of
   one, two, or three characters or numerals.  For the "A1" element, the
   leading country code and hyphen are omitted and only the subdivision
   code is included.

   For example, the codes for Canada include CA-BC, CA-ON, CA-QC;
   Luxembourg has just three single-character codes, LU-D, LU-G, and
   LU-L; Australia uses both two- and three-character codes, AU-ACT,
   AU-NSW, AU-NT; and France uses numerical codes for mainland France
   and letters for territories, FR-75, FR-NC.  This results in the
   following fragments:
      `<country>CA</country><A1>ON</A1>`
      `<country>LU</country><A1>L</A1>`
      `<country>AU</country><A1>ACT</A1>`
      `<country>FR</country><A1>75</A1>`


Additionally, per the [Redfish Resource and Schema Guide](http://redfish.dmtf.org/schemas/DSP2046_2020.3.html), `Country` is defined as 

`Country (v1.3+) | string | read-write | (null) | The country`