### PR TITLE
Bump golangci-lint to 1.43.0

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.15.0'
+        go-version: '1.16.0'
 
     # Install extra dependencies
     - name: Install dependencies
@@ -44,5 +44,5 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.38.0
+        version: v1.43.0
         args: --timeout=5m -v

--- a/client.go
+++ b/client.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/http/httputil"
@@ -457,7 +456,7 @@ func (c *APIClient) runRawRequestWithHeaders(method, url string, payloadBuffer i
 	}
 
 	if resp.StatusCode != 200 && resp.StatusCode != 201 && resp.StatusCode != 202 && resp.StatusCode != 204 {
-		payload, err := ioutil.ReadAll(resp.Body)
+		payload, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, common.ConstructError(0, []byte(err.Error()))
 		}

--- a/common/testclient.go
+++ b/common/testclient.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -127,7 +126,7 @@ func (c *TestClient) performAction(action, url string, payload interface{}, cust
 	}
 	resp := customReturnForAction.(*http.Response)
 	if resp.StatusCode != 200 && resp.StatusCode != 201 && resp.StatusCode != 202 && resp.StatusCode != 204 {
-		payload, err := ioutil.ReadAll(resp.Body)
+		payload, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/stmcginnis/gofish
 
-go 1.15
+go 1.16

--- a/redfish/chassis_test.go
+++ b/redfish/chassis_test.go
@@ -7,7 +7,7 @@ package redfish
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -278,7 +278,7 @@ func getCall(body string) *http.Response {
 		Proto:         "HTTP/1.1",
 		ProtoMajor:    1,
 		ProtoMinor:    1,
-		Body:          ioutil.NopCloser(bytes.NewBufferString(body)),
+		Body:          io.NopCloser(bytes.NewBufferString(body)),
 		ContentLength: int64(len(body)),
 		Header:        make(http.Header),
 	}

--- a/redfish/eventservice_test.go
+++ b/redfish/eventservice_test.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -184,7 +184,7 @@ func TestEventServiceCreateEventSubscription(t *testing.T) {
 					Proto:         "HTTP/1.1",
 					ProtoMajor:    1,
 					ProtoMinor:    1,
-					Body:          ioutil.NopCloser(bytes.NewBufferString("")),
+					Body:          io.NopCloser(bytes.NewBufferString("")),
 					ContentLength: int64(len("")),
 					Header: http.Header{
 						"Location": []string{
@@ -295,7 +295,7 @@ func TestEventServiceGetEventSubscription(t *testing.T) {
 					Proto:         "HTTP/1.1",
 					ProtoMajor:    1,
 					ProtoMinor:    1,
-					Body:          ioutil.NopCloser(bytes.NewBufferString(eventDestinationBody)),
+					Body:          io.NopCloser(bytes.NewBufferString(eventDestinationBody)),
 					ContentLength: int64(len(eventDestinationBody)),
 					Header:        make(http.Header),
 				},
@@ -333,7 +333,7 @@ func TestEventServiceGetEventSubscriptions(t *testing.T) {
 					Proto:         "HTTP/1.1",
 					ProtoMajor:    1,
 					ProtoMinor:    1,
-					Body:          ioutil.NopCloser(bytes.NewBufferString(eventDestinationsBody)),
+					Body:          io.NopCloser(bytes.NewBufferString(eventDestinationsBody)),
 					ContentLength: int64(len(eventDestinationsBody)),
 					Header:        make(http.Header),
 				},
@@ -344,7 +344,7 @@ func TestEventServiceGetEventSubscriptions(t *testing.T) {
 					Proto:         "HTTP/1.1",
 					ProtoMajor:    1,
 					ProtoMinor:    1,
-					Body:          ioutil.NopCloser(bytes.NewBufferString(eventDestinationBody)),
+					Body:          io.NopCloser(bytes.NewBufferString(eventDestinationBody)),
 					ContentLength: int64(len(eventDestinationBody)),
 					Header:        make(http.Header),
 				},
@@ -386,7 +386,7 @@ func TestEventServiceCreateEventSubscriptionWithoutOptionalParameters(t *testing
 					Proto:         "HTTP/1.1",
 					ProtoMajor:    1,
 					ProtoMinor:    1,
-					Body:          ioutil.NopCloser(bytes.NewBufferString("")),
+					Body:          io.NopCloser(bytes.NewBufferString("")),
 					ContentLength: int64(len("")),
 					Header: http.Header{
 						"Location": []string{

--- a/redfish/session_test.go
+++ b/redfish/session_test.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -81,7 +81,7 @@ func TestCreateSession(t *testing.T) {
 					Proto:         "HTTP/1.1",
 					ProtoMajor:    1,
 					ProtoMinor:    1,
-					Body:          ioutil.NopCloser(bytes.NewBufferString("")),
+					Body:          io.NopCloser(bytes.NewBufferString("")),
 					ContentLength: int64(len("")),
 					Header: http.Header{
 						"Location": []string{
@@ -160,7 +160,7 @@ func TestCreateSessionFullURIPath(t *testing.T) {
 					Proto:         "HTTP/1.1",
 					ProtoMajor:    1,
 					ProtoMinor:    1,
-					Body:          ioutil.NopCloser(bytes.NewBufferString("")),
+					Body:          io.NopCloser(bytes.NewBufferString("")),
 					ContentLength: int64(len("")),
 					Header: http.Header{
 						"Location": []string{


### PR DESCRIPTION
This version pulls in some updated linters with better checks and
version support. Some linters had an issue when running under go 1.17.

This also raises the declared go version to 1.16 to pick up the
deprecation of ioutils.