### PR TITLE
fix type of prefix length of ipv6 address

### DIFF
--- a/redfish/ethernetinterface_test.go
+++ b/redfish/ethernetinterface_test.go
@@ -165,3 +165,76 @@ func TestEthernetInterfaceUpdate(t *testing.T) {
 		t.Errorf("Unexpected update for FullDuplex in payload: %s", calls[0].Payload)
 	}
 }
+
+var ethernetInterfaceIPv6Body = `{
+		"@odata.context": "/redfish/v1/$metadata#EthernetInterface.EthernetInterface",
+		"@odata.id": "/redfish/v1/Systems/System-1/EthernetInterfaces/NIC-0",
+		"@odata.type": "#EthernetInterface.v1_3_0.EthernetInterface",
+		"IPv6Addresses": [
+			{
+				"Address": "FE80::B67A:F1FF:FECF:6462",
+				"AddressOrigin": "SLAAC",
+				"AddressState": "Preferred",
+				"PrefixLength": 64
+			},
+			{
+				"Address": "FDE1:53BA:E9A0:DE41::1649",
+				"AddressOrigin": "DHCP",
+				"AddressState": "Preferred",
+				"PrefixLength": 128
+			}
+		],
+		"Id": "NIC-0",
+		"InterfaceEnabled": true,
+		"LinkStatus": "LinkUp",
+		"Links": {
+			"Chassis": {
+				"@odata.id": "/redfish/v1/Chassis/Chassis-1"
+			}
+		},
+		"MACAddress": "f6:a9:26:e3:e6:32",
+		"MTUSize": 1500,
+		"Name": "Ethernet Interface",
+		"NameServers": [
+			"8.8.8.8"
+		],
+		"PermanentMACAddress": "f6:a9:26:e3:e6:32",
+		"SpeedMbps": 10000,
+		"Status": {
+			"Health": "OK",
+			"State": "Enabled"
+		},
+		"VLAN": {
+			"VLANId": 0
+		}
+	}`
+
+// TestEthernetInterface tests the parsing of EthernetInterface objects.
+func TestEthernetInterfaceIPv6(t *testing.T) {
+	var result EthernetInterface
+	err := json.NewDecoder(strings.NewReader(ethernetInterfaceIPv6Body)).Decode(&result)
+
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+
+	if result.ID != "NIC-0" {
+		t.Errorf("Received invalid ID: %s", result.ID)
+	}
+
+	if result.Name != "Ethernet Interface" {
+		t.Errorf("Received invalid name: %s", result.Name)
+	}
+
+	if len(result.IPv6Addresses) != 2 {
+		t.Errorf("Should be 2 IPv6 addresses, got: %d", len(result.IPv4Addresses))
+	}
+
+	if result.IPv6Addresses[0].PrefixLength != 64 {
+		t.Errorf("The 1st IPv6 address's prefix length should be 64, got: %d", result.IPv6Addresses[0].PrefixLength)
+	}
+
+	if result.IPv6Addresses[1].PrefixLength != 128 {
+		t.Errorf("The 3nd IPv6 address's prefix length should be 128, got: %d", result.IPv6Addresses[1].PrefixLength)
+	}
+}

--- a/redfish/ipaddresses.go
+++ b/redfish/ipaddresses.go
@@ -86,7 +86,7 @@ type IPv6Address struct {
 	// condition.
 	AddressState AddressState
 	// PrefixLength shall be the IPv6 address prefix length for this interface.
-	PrefixLength int8
+	PrefixLength uint8
 }
 
 // IPv6GatewayStaticAddress shall represent a single IPv6 static address to be
@@ -96,7 +96,7 @@ type IPv6GatewayStaticAddress struct {
 	//assigned on a network interface.
 	Address string
 	// PrefixLength provides the IPv6 network prefix length in bits for this address.
-	PrefixLength int8
+	PrefixLength uint8
 }
 
 // IPv6StaticAddress shall represent a single IPv6 static address to be assigned
@@ -106,5 +106,5 @@ type IPv6StaticAddress struct {
 	// assigned on a network interface.
 	Address string
 	// PrefixLength provides the IPv6 network prefix length in bits for this address.
-	PrefixLength int8
+	PrefixLength uint8
 }


### PR DESCRIPTION
range of prefix length of ipv6 address should be 1-128.

Signed-off-by: Leslie Qi Wang <leslie.qiwa@gmail.com>