### PR TITLE
redfish/updateservice: struct field MultipartHTTPPushURI

### DIFF
--- a/redfish/updateservice.go
+++ b/redfish/updateservice.go
@@ -26,6 +26,8 @@ type UpdateService struct {
 	SoftwareInventory string
 	// HTTPPushURI endpoint is used to push (POST) firmware updates
 	HTTPPushURI string `json:"HttpPushUri"`
+	// MultipartHTTPPushURI endpoint is used to perform a multipart push (POST) updates
+	MultipartHTTPPushURI string `json:"MultiPartHttpPushUri"`
 	// ServiceEnabled indicates whether this service isenabled.
 	ServiceEnabled bool
 	// Status describes the status and health of a resource and its children.


### PR DESCRIPTION
This field enables clients to determine if the updateservice supports Multipart push updates.


_A service may support the `MultipartHttpPushUri` property within the
UpdateService resource. A client can perform an HTTP or HTTPS POST request on the URI specified by this property to initiate a push-based update._

https://www.dmtf.org/sites/default/files/standards/documents/DSP2062_1.0.0.pdf
