### PR TITLE
client: export method runRawRequestWithHeaders

### DIFF
--- a/client.go
+++ b/client.go
@@ -381,6 +381,11 @@ func (c *APIClient) runRawRequest(method, url string, payloadBuffer io.ReadSeeke
 	return c.runRawRequestWithHeaders(method, url, payloadBuffer, contentType, nil)
 }
 
+// RunRawRequestWithHeaders actually performs the REST calls but allowing custom headers
+func (c *APIClient) RunRawRequestWithHeaders(method, url string, payloadBuffer io.ReadSeeker, contentType string, customHeaders map[string]string) (*http.Response, error) {
+	return c.runRawRequestWithHeaders(method, url, payloadBuffer, contentType, customHeaders)
+}
+
 // runRawRequestWithHeaders actually performs the REST calls but allowing custom headers
 func (c *APIClient) runRawRequestWithHeaders(method, url string, payloadBuffer io.ReadSeeker, contentType string, customHeaders map[string]string) (*http.Response, error) {
 	if url == "" {


### PR DESCRIPTION
To enable clients to submit their own multipart payload,
it would help to export the `runRawRequestWithHeaders` method.

In my case, the multipart form-data needed to be in the following format,
which isn't directly supported within the `runRequestWithMultipartPayloadWithHeaders` 
method, and needed more work to prepare the first part of the MIME header.

```
Content-Length: 416
Content-Type: multipart/form-data; boundary=--------------------
----1771f60800cb2801

--------------------------1771f60800cb2801
Content-Disposition: form-data; name="UpdateParameters"
Content-Type: application/json

{"Targets": [], "@Redfish.OperationApplyTime": "OnReset", "Oem":
{}}
--------------------------1771f60800cb2801
Content-Disposition: form-data; name="UpdateFile"; filename="dum
myfile"
Content-Type: application/octet-stream

hey.
--------------------------1771f60800cb2801--
```