### PR TITLE
Add GetService() method to APIClient

### DIFF
--- a/client.go
+++ b/client.go
@@ -218,6 +218,11 @@ func ConnectDefaultContext(ctx context.Context, endpoint string) (c *APIClient, 
 	return client, err
 }
 
+// GetService returns the APIClient's service.
+func (c *APIClient) GetService() *Service {
+	return c.Service
+}
+
 // CloneWithSession will create a new Client with a session instead of basic auth.
 func (c *APIClient) CloneWithSession() (*APIClient, error) {
 	if c.auth.Session != "" {

--- a/client_test.go
+++ b/client_test.go
@@ -126,6 +126,19 @@ func TestConnectContextTimeout(t *testing.T) {
 	}
 }
 
+func TestServiceGetter(t *testing.T) {
+	type serviceGetter interface {
+		GetService() *Service
+	}
+
+	var sg serviceGetter
+	sg = &APIClient{}
+
+	if sg.GetService() != nil {
+		t.Errorf("Empty client should return a nil service")
+	}
+}
+
 // TestConnectContextCancel
 func TestConnectContextCancel(t *testing.T) {
 	// ctx will be cancelled


### PR DESCRIPTION
This enables callers to write testable interfaces instead of directly accessing fields on the APIClient.

For example
```go

// defined in a caller's package
type RedfishClient interface {
    GetService() *Service
    Logout()
}

type MyType struct {
    client RedfishClient 
}

func NewMyType(endpoint string) (*MyType, error) {
    r := &MyType{}
    var err error
    r.client, err = gofish.ConnectDefault(endpoint)
    if err != nil {
        return nil, err
    }
    return r, nil
)

func main(){
    mt, _ := NewMyType("")
    fmt.Println(mt.client.GetService().Systems()[0].BIOSVersion)
    mt.client.Logout()
}

```
Signed-off-by: Micah Hausler <mhausler@amazon.com>