### PR TITLE
Update golangci-lint

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,8 +41,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    # Setup our go environment
+    - name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.16.0'
+
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.43.0
+        version: v1.45.2
         args: --timeout=5m -v

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -31,8 +31,6 @@ linters-settings:
     min-complexity: 25
   goimports:
     local-prefixes: github.com/stmcginnis
-  golint:
-    min-confidence: 0
   gomnd:
     settings:
       mnd:
@@ -62,7 +60,6 @@ linters:
     - gocyclo
     - goheader
     - goimports
-    - golint
     - gomnd
     - goprintffuncname
     - gosec
@@ -73,6 +70,7 @@ linters:
     - nakedret
     - noctx
     - nolintlint
+    - revive
     - rowserrcheck
     - staticcheck
     - structcheck
@@ -111,8 +109,3 @@ issues:
 run:
   skip-dirs:
     - examples
-
-# golangci.com configuration
-# https://github.com/golangci/golangci/wiki/Configuration
-service:
-  golangci-lint-version: 1.38.0 # use the fixed version to not introduce new linters unexpectedly

--- a/client_test.go
+++ b/client_test.go
@@ -131,9 +131,7 @@ func TestServiceGetter(t *testing.T) {
 		GetService() *Service
 	}
 
-	var sg serviceGetter
-	sg = &APIClient{}
-
+	var sg serviceGetter = &APIClient{}
 	if sg.GetService() != nil {
 		t.Errorf("Empty client should return a nil service")
 	}

--- a/common/testclient.go
+++ b/common/testclient.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 // TestAPICall captures the arguments to one of the API calls.
@@ -122,8 +123,10 @@ func (c *TestClient) performAction(action, url string, payload interface{}, cust
 	c.recordCall(action, url, payload, customHeaders)
 	customReturnForAction := c.getCustomReturnForAction(action)
 	if customReturnForAction == nil {
-		return nil, nil
+		body := io.NopCloser(strings.NewReader(""))
+		return &http.Response{Body: body}, nil
 	}
+
 	resp := customReturnForAction.(*http.Response)
 	if resp.StatusCode != 200 && resp.StatusCode != 201 && resp.StatusCode != 202 && resp.StatusCode != 204 {
 		payload, err := io.ReadAll(resp.Body)

--- a/redfish/bios.go
+++ b/redfish/bios.go
@@ -210,7 +210,11 @@ func (bios *Bios) ChangePassword(passwordName, oldPassword, newPassword string) 
 		NewPassword:  newPassword,
 	}
 
-	_, err := bios.Client.Post(bios.changePasswordTarget, t)
+	resp, err := bios.Client.Post(bios.changePasswordTarget, t)
+	if err == nil {
+		defer resp.Body.Close()
+	}
+
 	return err
 }
 
@@ -218,7 +222,10 @@ func (bios *Bios) ChangePassword(passwordName, oldPassword, newPassword string) 
 // A system reset may be required for the default values to be applied. This
 // action may impact other resources.
 func (bios *Bios) ResetBios() error {
-	_, err := bios.Client.Post(bios.resetBiosTarget, nil)
+	resp, err := bios.Client.Post(bios.resetBiosTarget, nil)
+	if err == nil {
+		defer resp.Body.Close()
+	}
 	return err
 }
 
@@ -259,10 +266,11 @@ func (bios *Bios) UpdateBiosAttributes(attrs BiosAttributes) error {
 	// return the result.
 	if len(payload) > 0 {
 		data := map[string]interface{}{"Attributes": payload}
-		_, err := bios.Client.Patch(bios.settingsTarget, data)
+		resp, err := bios.Client.Patch(bios.settingsTarget, data)
 		if err != nil {
 			return err
 		}
+		defer resp.Body.Close()
 	}
 
 	return nil

--- a/redfish/chassis.go
+++ b/redfish/chassis.go
@@ -470,6 +470,7 @@ func (chassis *Chassis) NetworkAdapters() ([]*NetworkAdapter, error) {
 
 // Reset shall reset the chassis. This action shall not reset Systems or other
 // contained resource, although side effects may occur which affect those resources.
+//nolint:dupl
 func (chassis *Chassis) Reset(resetType ResetType) error {
 	// Make sure the requested reset type is supported by the chassis
 	valid := false
@@ -497,6 +498,9 @@ func (chassis *Chassis) Reset(resetType ResetType) error {
 		ResetType: resetType,
 	}
 
-	_, err := chassis.Client.Post(chassis.resetTarget, t)
+	resp, err := chassis.Client.Post(chassis.resetTarget, t)
+	if err == nil {
+		defer resp.Body.Close()
+	}
 	return err
 }

--- a/redfish/computersystem.go
+++ b/redfish/computersystem.go
@@ -742,7 +742,10 @@ func (computersystem *ComputerSystem) SetBoot(b Boot) error { // nolint
 		Boot: b,
 	}
 
-	_, err := computersystem.Client.Patch(computersystem.ODataID, t)
+	resp, err := computersystem.Client.Patch(computersystem.ODataID, t)
+	if err == nil {
+		return resp.Body.Close()
+	}
 	return err
 }
 
@@ -752,6 +755,7 @@ func (computersystem *ComputerSystem) SetBoot(b Boot) error { // nolint
 // the system or perform an ACPI Power Button Override (commonly known as a
 // 4-second hold of the Power Button). The ForceRestart value shall perform a
 // ForceOff action followed by a On action.
+//nolint:dupl
 func (computersystem *ComputerSystem) Reset(resetType ResetType) error {
 	// Make sure the requested reset type is supported by the system
 	valid := false
@@ -779,7 +783,10 @@ func (computersystem *ComputerSystem) Reset(resetType ResetType) error {
 		ResetType: resetType,
 	}
 
-	_, err := computersystem.Client.Post(computersystem.resetTarget, t)
+	resp, err := computersystem.Client.Post(computersystem.resetTarget, t)
+	if err == nil {
+		defer resp.Body.Close()
+	}
 	return err
 }
 
@@ -790,7 +797,10 @@ func (computersystem *ComputerSystem) SetDefaultBootOrder() error {
 		return fmt.Errorf("SetDefaultBootOrder is not supported by this system") // nolint:golint
 	}
 
-	_, err := computersystem.Client.Post(computersystem.setDefaultBootOrderTarget, nil)
+	resp, err := computersystem.Client.Post(computersystem.setDefaultBootOrderTarget, nil)
+	if err == nil {
+		defer resp.Body.Close()
+	}
 	return err
 }
 

--- a/redfish/drive.go
+++ b/redfish/drive.go
@@ -457,6 +457,9 @@ func (drive *Drive) PCIeFunctions() ([]*PCIeFunction, error) {
 
 // SecureErase shall perform a secure erase of the drive.
 func (drive *Drive) SecureErase() error {
-	_, err := drive.Client.Post(drive.secureEraseTarget, nil)
+	resp, err := drive.Client.Post(drive.secureEraseTarget, nil)
+	if err == nil {
+		defer resp.Body.Close()
+	}
 	return err
 }

--- a/redfish/eventdestination.go
+++ b/redfish/eventdestination.go
@@ -394,12 +394,16 @@ func CreateEventDestination(
 }
 
 // DeleteEventDestination will delete a EventDestination.
-func DeleteEventDestination(c common.Client, uri string) (err error) {
+func DeleteEventDestination(c common.Client, uri string) error {
 	// validate uri
 	if strings.TrimSpace(uri) == "" {
 		return fmt.Errorf("uri should not be empty")
 	}
-	_, err = c.Delete(uri)
+
+	resp, err := c.Delete(uri)
+	if err == nil {
+		defer resp.Body.Close()
+	}
 
 	return err
 }

--- a/redfish/eventservice.go
+++ b/redfish/eventservice.go
@@ -354,7 +354,10 @@ func (eventservice *EventService) SubmitTestEvent(message string) error {
 		Severity:          "Informational",
 	}
 
-	_, err := eventservice.Client.Post(eventservice.submitTestEventTarget, t)
+	resp, err := eventservice.Client.Post(eventservice.submitTestEventTarget, t)
+	if err == nil {
+		defer resp.Body.Close()
+	}
 	return err
 }
 

--- a/redfish/logservice.go
+++ b/redfish/logservice.go
@@ -202,6 +202,9 @@ func (logservice *LogService) ClearLog() error {
 		Action: "LogService.ClearLog",
 	}
 
-	_, err := logservice.Client.Post(logservice.clearLogTarget, t)
+	resp, err := logservice.Client.Post(logservice.clearLogTarget, t)
+	if err == nil {
+		defer resp.Body.Close()
+	}
 	return err
 }

--- a/redfish/manager.go
+++ b/redfish/manager.go
@@ -437,7 +437,10 @@ func (manager *Manager) Reset(resetType ResetType) error {
 			Action: "Manager.Reset",
 		}
 
-		_, err := manager.Client.Post(manager.resetTarget, t)
+		resp, err := manager.Client.Post(manager.resetTarget, t)
+		if err == nil {
+			defer resp.Body.Close()
+		}
 		return err
 	}
 	// Make sure the requested reset type is supported by the manager.
@@ -461,7 +464,10 @@ func (manager *Manager) Reset(resetType ResetType) error {
 		ResetType: resetType,
 	}
 
-	_, err := manager.Client.Post(manager.resetTarget, t)
+	resp, err := manager.Client.Post(manager.resetTarget, t)
+	if err == nil {
+		defer resp.Body.Close()
+	}
 	return err
 }
 

--- a/redfish/networkadapter.go
+++ b/redfish/networkadapter.go
@@ -300,6 +300,9 @@ func (networkadapter *NetworkAdapter) NetworkPorts() ([]*NetworkPort, error) {
 // ResetSettingsToDefault shall perform a reset of all active and pending
 // settings back to factory default settings upon reset of the network adapter.
 func (networkadapter *NetworkAdapter) ResetSettingsToDefault() error {
-	_, err := networkadapter.Client.Post(networkadapter.resetSettingsToDefaultTarget, nil)
+	resp, err := networkadapter.Client.Post(networkadapter.resetSettingsToDefaultTarget, nil)
+	if err == nil {
+		defer resp.Body.Close()
+	}
 	return err
 }

--- a/redfish/secureboot.go
+++ b/redfish/secureboot.go
@@ -185,6 +185,9 @@ func (secureboot *SecureBoot) ResetKeys(resetType ResetKeysType) error {
 	}
 	t := temp{ResetKeysType: resetType}
 
-	_, err := secureboot.Client.Post(secureboot.resetKeysTarget, t)
+	resp, err := secureboot.Client.Post(secureboot.resetKeysTarget, t)
+	if err == nil {
+		defer resp.Body.Close()
+	}
 	return err
 }

--- a/redfish/storage.go
+++ b/redfish/storage.go
@@ -205,7 +205,10 @@ func (storage *Storage) SetEncryptionKey(key string) error {
 	}
 	t := temp{EncryptionKey: key}
 
-	_, err := storage.Client.Post(storage.setEncryptionKeyTarget, t)
+	resp, err := storage.Client.Post(storage.setEncryptionKeyTarget, t)
+	if err == nil {
+		defer resp.Body.Close()
+	}
 	return err
 }
 

--- a/redfish/virtualmedia.go
+++ b/redfish/virtualmedia.go
@@ -202,7 +202,10 @@ func (virtualmedia *VirtualMedia) EjectMedia() error {
 		return errors.New("redfish service does not support VirtualMedia.EjectMedia calls")
 	}
 
-	_, err := virtualmedia.Client.Post(virtualmedia.ejectMediaTarget, struct{}{})
+	resp, err := virtualmedia.Client.Post(virtualmedia.ejectMediaTarget, struct{}{})
+	if err == nil {
+		defer resp.Body.Close()
+	}
 	return err
 }
 
@@ -223,7 +226,10 @@ func (virtualmedia *VirtualMedia) InsertMedia(image string, inserted, writeProte
 		WriteProtected: writeProtected,
 	}
 
-	_, err := virtualmedia.Client.Post(virtualmedia.insertMediaTarget, t)
+	resp, err := virtualmedia.Client.Post(virtualmedia.insertMediaTarget, t)
+	if err == nil {
+		defer resp.Body.Close()
+	}
 	return err
 }
 
@@ -243,7 +249,10 @@ func (virtualmedia *VirtualMedia) InsertMediaConfig(config VirtualMediaConfig) e
 	if !virtualmedia.SupportsMediaInsert {
 		return errors.New("redfish service does not support VirtualMedia.InsertMedia calls")
 	}
-	_, err := virtualmedia.Client.Post(virtualmedia.insertMediaTarget, config)
+	resp, err := virtualmedia.Client.Post(virtualmedia.insertMediaTarget, config)
+	if err == nil {
+		defer resp.Body.Close()
+	}
 	return err
 }
 

--- a/swordfish/volume.go
+++ b/swordfish/volume.go
@@ -703,7 +703,7 @@ func (volume *Volume) StoragePools() ([]*StoragePool, error) {
 func (volume *Volume) AssignReplicaTarget(replicaType ReplicaType, updateMode ReplicaUpdateMode, targetVolumeODataID string) error {
 	// This action wasn't added until later revisions
 	if volume.assignReplicaTargetTarget == "" {
-		return fmt.Errorf("AssignReplicaTarget action is not supported by this system") // nolint
+		return fmt.Errorf("AssignReplicaTarget action is not supported by this system")
 	}
 
 	// Define this action's parameters
@@ -728,7 +728,7 @@ func (volume *Volume) AssignReplicaTarget(replicaType ReplicaType, updateMode Re
 // data to ensure it matches calculated values.
 func (volume *Volume) CheckConsistency() error {
 	if volume.checkConsistencyTarget == "" {
-		return fmt.Errorf("CheckConsistency action is not supported by this system") // nolint
+		return fmt.Errorf("CheckConsistency action is not supported by this system")
 	}
 
 	_, err := volume.Client.Post(volume.checkConsistencyTarget, nil)
@@ -759,7 +759,7 @@ func (volume *Volume) Initialize(initType InitializeType) error {
 func (volume *Volume) RemoveReplicaRelationship(deleteTarget bool, targetVolumeODataID string) error {
 	// This action wasn't added until later revisions
 	if volume.removeReplicaRelationshipTarget == "" {
-		return fmt.Errorf("RemoveReplicaRelationship action is not supported by this system") // nolint
+		return fmt.Errorf("RemoveReplicaRelationship action is not supported by this system")
 	}
 
 	// Define this action's parameters
@@ -784,7 +784,7 @@ func (volume *Volume) RemoveReplicaRelationship(deleteTarget bool, targetVolumeO
 func (volume *Volume) ResumeReplication(targetVolumeODataID string) error {
 	// This action wasn't added until later revisions
 	if volume.resumeReplicationTarget == "" {
-		return fmt.Errorf("ResumeReplication action is not supported by this system") // nolint
+		return fmt.Errorf("ResumeReplication action is not supported by this system")
 	}
 
 	// Define this action's parameters
@@ -804,7 +804,7 @@ func (volume *Volume) ResumeReplication(targetVolumeODataID string) error {
 func (volume *Volume) ReverseReplicationRelationship(targetVolumeODataID string) error {
 	// This action wasn't added until later revisions
 	if volume.reverseReplicationRelationshipTarget == "" {
-		return fmt.Errorf("ReverseReplicationRelationship action is not supported by this system") // nolint
+		return fmt.Errorf("ReverseReplicationRelationship action is not supported by this system")
 	}
 
 	// Define this action's parameters
@@ -824,7 +824,7 @@ func (volume *Volume) ReverseReplicationRelationship(targetVolumeODataID string)
 func (volume *Volume) SplitReplication(targetVolumeODataID string) error {
 	// This action wasn't added until later revisions
 	if volume.splitReplicationTarget == "" {
-		return fmt.Errorf("SplitReplication action is not supported by this system") // nolint
+		return fmt.Errorf("SplitReplication action is not supported by this system")
 	}
 
 	// Define this action's parameters
@@ -845,7 +845,7 @@ func (volume *Volume) SplitReplication(targetVolumeODataID string) error {
 func (volume *Volume) SuspendReplication(targetVolumeODataID string) error {
 	// This action wasn't added until later revisions
 	if volume.suspendReplicationTarget == "" {
-		return fmt.Errorf("SuspendReplication action is not supported by this system") // nolint
+		return fmt.Errorf("SuspendReplication action is not supported by this system")
 	}
 
 	// Define this action's parameters


### PR DESCRIPTION
There have been a few updates to the linter causing problems for systems
with newer environments. This replaces the deprecated golint linter with
the recommended revive replacement and addresses a few issues found.

Signed-off-by: Sean McGinnis <sean.mcginnis@gmail.com>