### PR TITLE
feature: support pass apply time when set BIOS Attr

### DIFF
--- a/redfish/bios.go
+++ b/redfish/bios.go
@@ -244,6 +244,41 @@ func (bios *Bios) AllowedAttributeUpdateApplyTimes() []common.ApplyTime {
 	return bios.settingsApplyTimes
 }
 
+// UpdateBiosAttributesApplyAt is used to update attribute values and set apply time together
+func (bios *Bios) UpdateBiosAttributesApplyAt(attrs BiosAttributes, applyTime common.ApplyTime) error {
+	payload := make(map[string]interface{})
+
+	// Get a representation of the object's original state so we can find what
+	// to update.
+	original := new(Bios)
+	err := original.UnmarshalJSON(bios.rawData)
+	if err != nil {
+		return err
+	}
+
+	for key := range attrs {
+		if original.Attributes[key] != attrs[key] {
+			payload[key] = attrs[key]
+		}
+	}
+
+	// If there are any allowed updates, try to send updates to the system and
+	// return the result.
+	if len(payload) > 0 {
+		data := map[string]interface{}{"Attributes": payload}
+		if applyTime != "" {
+			data["@Redfish.SettingsApplyTime"] = map[string]string{"ApplyTime": string(applyTime)}
+		}
+		resp, err := bios.Client.Patch(bios.settingsTarget, data)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+	}
+
+	return nil
+}
+
 // UpdateBiosAttributes is used to update attribute values.
 func (bios *Bios) UpdateBiosAttributes(attrs BiosAttributes) error {
 	payload := make(map[string]interface{})


### PR DESCRIPTION
In many cases. I think that if `UpdateBiosAttributes`  function can pass apply time is easy to use .

this case is convert from the DELL bios setting

```shell
RACADM set bios.SysProfileSettings.SysProfile PerfPerWattOptimizedOs
RACADM jobqueue create BIOS.Setup.1-1
```

to set the logger to show the http request of setting as follow

```go
type PrintHttp2OutputWrite struct {
}

func (p *PrintHttp2OutputWrite) Write(b []byte) (n int, err error) {
	return fmt.Printf("%s", string(b))
}
```

and set the Write to gofish config

```go
		config := gofish.ClientConfig{
...
			DumpWriter: PrintOut,
		}
```

```log
PATCH /redfish/v1/Systems/System.Embedded.1/Bios/Settings HTTP/1.1
Host: 192.168.156.16
User-Agent: gofish/1.0
Connection: close
Content-Length: 91
Accept: application/json
Content-Type: application/json
Cookie: sessionKey=fa0aeb6a19ca6813deb08b933a0cc5b3
X-Auth-Token: fa0aeb6a19ca6813deb08b933a0cc5b3
Accept-Encoding: gzip

{"@Redfish.SettingsApplyTime":{"ApplyTime":"OnReset"},"Attributes":{"SysProfile":"Custom"}}
HTTP/1.1 202 Accepted
Connection: close
Content-Length: 0
Access-Control-Allow-Origin: *
Cache-Control: no-cache
Content-Type: application/json;odata.metadata=minimal;charset=utf-8
Date: Tue, 10 May 2022 01:23:09 GMT
Location: /redfish/v1/TaskService/Tasks/JID_521457899106
Odata-Version: 4.0
Server: Apache
Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
Www-Authenticate: Basic realm="RedfishService"
X-Frame-Options: DENY
```

Signed-off-by: Guohao Wang <wangguohao.2009@gmail.com>