### PR TITLE
Clean up and testing for UpdateBiosAttributesApplyAt

### DIFF
--- a/redfish/bios.go
+++ b/redfish/bios.go
@@ -281,34 +281,7 @@ func (bios *Bios) UpdateBiosAttributesApplyAt(attrs BiosAttributes, applyTime co
 
 // UpdateBiosAttributes is used to update attribute values.
 func (bios *Bios) UpdateBiosAttributes(attrs BiosAttributes) error {
-	payload := make(map[string]interface{})
-
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Bios)
-	err := original.UnmarshalJSON(bios.rawData)
-	if err != nil {
-		return err
-	}
-
-	for key := range attrs {
-		if original.Attributes[key] != attrs[key] {
-			payload[key] = attrs[key]
-		}
-	}
-
-	// If there are any allowed updates, try to send updates to the system and
-	// return the result.
-	if len(payload) > 0 {
-		data := map[string]interface{}{"Attributes": payload}
-		resp, err := bios.Client.Patch(bios.settingsTarget, data)
-		if err != nil {
-			return err
-		}
-		defer resp.Body.Close()
-	}
-
-	return nil
+	return bios.UpdateBiosAttributesApplyAt(attrs, "")
 }
 
 // GetActiveSoftwareImage gets the SoftwareInventory which represents the

--- a/redfish/bios_test.go
+++ b/redfish/bios_test.go
@@ -213,4 +213,42 @@ func TestUpdateBiosAttributes(t *testing.T) {
 	if !strings.Contains(calls[0].Payload, "AssetTag") {
 		t.Errorf("Unexpected update payload: %s", calls[0].Payload)
 	}
+
+	if strings.Contains(calls[0].Payload, "@Redfish.SettingsApplyTime") {
+		t.Error("Expected 'SettingsApplyTime' to not be present")
+	}
+}
+
+// TestUpdateBiosAttributesApplyAt tests the TestUpdateBiosAttributesApplyAt call.
+func TestUpdateBiosAttributesApplyAt(t *testing.T) {
+	var result Bios
+	err := json.NewDecoder(strings.NewReader(biosBody)).Decode(&result)
+
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+
+	testClient := &common.TestClient{}
+	result.SetClient(testClient)
+
+	update := BiosAttributes{"AssetTag": "test"}
+	err = result.UpdateBiosAttributesApplyAt(update, common.AtMaintenanceWindowStartApplyTime)
+
+	if err != nil {
+		t.Errorf("Error making UpdateBiosAttributesApplyAt call: %s", err)
+	}
+
+	calls := testClient.CapturedCalls()
+
+	if len(calls) != 1 {
+		t.Errorf("Expected one call to be made, captured: %v", calls)
+	}
+
+	if !strings.Contains(calls[0].Payload, "AssetTag") {
+		t.Errorf("Unexpected update payload: %s", calls[0].Payload)
+	}
+
+	if !strings.Contains(calls[0].Payload, "@Redfish.SettingsApplyTime") {
+		t.Error("Expected 'SettingsApplyTime' to be present")
+	}
 }


### PR DESCRIPTION
This refactors the code slightly to reduce duplication and adds a basic
unit test to cover the case of providing an apply time to the BIOS
update.