### PR TITLE
feature: support huawei machine set bootorder

### DIFF
--- a/redfish/bios.go
+++ b/redfish/bios.go
@@ -257,7 +257,8 @@ func (bios *Bios) UpdateBiosAttributesApplyAt(attrs BiosAttributes, applyTime co
 	}
 
 	for key := range attrs {
-		if original.Attributes[key] != attrs[key] {
+		if strings.HasPrefix(key, "BootTypeOrder") ||
+			original.Attributes[key] != attrs[key] {
 			payload[key] = attrs[key]
 		}
 	}


### PR DESCRIPTION
the user can update the huawei machine boot order by set the arrt of bios.

```json
PATCH /redfish/v1/Systems/1/Bios/Settings HTTP/1.1
Host: 192.168.142.53
User-Agent: gofish/1.0
Connection: close
Content-Length: 129
Accept: application/json
Content-Type: application/json
Cookie: sessionKey=xxx
If-Match: W/"8052ea0b"
X-Auth-Token: xx
Accept-Encoding: gzip

{"Attributes":{"BootTypeOrder0":"Others","BootTypeOrder1":"PXE","BootTypeOrder2":"DVDROMDrive","BootTypeOrder3":"HardDiskDrive"}}

HTTP/1.1 200 OK
Connection: close
Content-Length: 624
Cache-Control: max-age=0, no-cache, no-store, must-revalidate
Content-Security-Policy: default-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' wss://*:*; img-src 'self' data:; frame-src 'self'; font-src 'self' data:; object-src 'self'; style-src 'self' 'unsafe-inline'
Content-Type: application/json;charset=utf-8
Date: Tue, 24 May 2022 07:11:55 GMT
Etag: W/"8052ea0b"
Expires: 0
Odata-Version: 4.0
Referrer-Policy: no-referrer
Strict-Transport-Security: max-age=31536000; includeSubDomains
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Frame-Options: SAMEORIGIN
X-Xss-Protection: 1; mode=block
```


Signed-off-by: Guohao Wang <wangguohao.2009@gmail.com>