### PR TITLE
Add etag support to ComputerSystem

### DIFF
--- a/redfish/chassis.go
+++ b/redfish/chassis.go
@@ -470,7 +470,6 @@ func (chassis *Chassis) NetworkAdapters() ([]*NetworkAdapter, error) {
 
 // Reset shall reset the chassis. This action shall not reset Systems or other
 // contained resource, although side effects may occur which affect those resources.
-//nolint:dupl
 func (chassis *Chassis) Reset(resetType ResetType) error {
 	// Make sure the requested reset type is supported by the chassis
 	valid := false


### PR DESCRIPTION
This needs to be addressed library-wide yet, but as a proof of concept
this adds eTag awareness just to the ComputerSystem object. This is used
when making updates to ensure the object has not changed underneath us
which could potentially cause problems by making updates based on stale
information.

Closes: #171 