### PR TITLE
Capture Bios etag for later updates

### DIFF
--- a/redfish/bios_test.go
+++ b/redfish/bios_test.go
@@ -206,15 +206,15 @@ func TestUpdateBiosAttributes(t *testing.T) {
 
 	calls := testClient.CapturedCalls()
 
-	if len(calls) != 2 {
+	if len(calls) != 1 {
 		t.Errorf("Expected one call to be made, captured: %v", calls)
 	}
 
-	if !strings.Contains(calls[1].Payload, "AssetTag") {
+	if !strings.Contains(calls[0].Payload, "AssetTag") {
 		t.Errorf("Unexpected update payload: %s", calls[0].Payload)
 	}
 
-	if strings.Contains(calls[1].Payload, "@Redfish.SettingsApplyTime") {
+	if strings.Contains(calls[0].Payload, "@Redfish.SettingsApplyTime") {
 		t.Error("Expected 'SettingsApplyTime' to not be present")
 	}
 }
@@ -240,15 +240,15 @@ func TestUpdateBiosAttributesApplyAt(t *testing.T) {
 
 	calls := testClient.CapturedCalls()
 
-	if len(calls) != 2 {
+	if len(calls) != 1 {
 		t.Errorf("Expected one call to be made, captured: %v", calls)
 	}
 
-	if !strings.Contains(calls[1].Payload, "AssetTag") {
+	if !strings.Contains(calls[0].Payload, "AssetTag") {
 		t.Errorf("Unexpected update payload: %s", calls[0].Payload)
 	}
 
-	if !strings.Contains(calls[1].Payload, "@Redfish.SettingsApplyTime") {
+	if !strings.Contains(calls[0].Payload, "@Redfish.SettingsApplyTime") {
 		t.Error("Expected 'SettingsApplyTime' to be present")
 	}
 }


### PR DESCRIPTION
This updates our handling of an instances etag so we capture it on
initial retrieval of the object. Then this value can be used later for
any update calls to enforce that the object we are trying to update has
not been modified since our local version of it was retrieved.

Slight tweak to what was done in e12f17e73767125a26629df7ed4f0459ab5ca16b so we don't just grab the
current object that is unlikely to change before we update it.