### PR TITLE
Pin golangci-lint to avoid go conflicts

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,13 +19,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.16.0'
-
-    # Install extra dependencies
-    - name: Install dependencies
-      run: |
-        go version
-        go get -u golang.org/x/lint/golint
+        go-version: '1.18.0'
 
     # Build the code
     - name: Run build
@@ -45,10 +39,10 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.16.0'
+        go-version: '1.18.0'
 
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.45.2
+        version: v1.48.0
         args: --timeout=5m -v

--- a/client.go
+++ b/client.go
@@ -184,12 +184,12 @@ func (c *APIClient) setupClientAuth(config *ClientConfig) error {
 }
 
 // Connect creates a new client connection to a Redfish service.
-func Connect(config ClientConfig) (c *APIClient, err error) { // nolint:gocritic
+func Connect(config ClientConfig) (c *APIClient, err error) { //nolint:gocritic
 	return ConnectContext(context.Background(), config)
 }
 
 // ConnectContext is the same as Connect, but sets the ctx.
-func ConnectContext(ctx context.Context, config ClientConfig) (c *APIClient, err error) { // nolint:gocritic
+func ConnectContext(ctx context.Context, config ClientConfig) (c *APIClient, err error) { //nolint:gocritic
 	client, err := setupClientWithConfig(ctx, &config)
 	if err != nil {
 		return c, err
@@ -417,7 +417,7 @@ func (c *APIClient) runRawRequestWithHeaders(method, url string, payloadBuffer i
 		// Set Content-Length custom headers on the request
 		// since its ignored when set using Header.Set()
 		if strings.EqualFold("Content-Length", k) {
-			req.ContentLength, err = strconv.ParseInt(v, 10, 64) // nolint:gomnd // base 10, 64 bit
+			req.ContentLength, err = strconv.ParseInt(v, 10, 64) //nolint:gomnd // base 10, 64 bit
 			if err != nil {
 				return nil, common.ConstructError(0, []byte("error parsing custom Content-Length header"))
 			}

--- a/client_test.go
+++ b/client_test.go
@@ -49,7 +49,7 @@ const (
 func testError(code int, t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(code)
-		w.Write([]byte(expectErrorStatus)) // nolint
+		w.Write([]byte(expectErrorStatus)) //nolint
 	}))
 	defer ts.Close()
 
@@ -87,7 +87,7 @@ func TestError404(t *testing.T) {
 func TestErrorOther(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)
-		w.Write([]byte(nonErrorStructErrorStatus)) // nolint
+		w.Write([]byte(nonErrorStructErrorStatus)) //nolint
 	}))
 	defer ts.Close()
 
@@ -191,7 +191,7 @@ func TestConnectDefaultContextCancel(t *testing.T) {
 func TestClientRunRawRequestNoURL(t *testing.T) {
 	client := APIClient{}
 
-	_, err := client.runRawRequest("", "", nil, "") // nolint:bodyclose
+	_, err := client.runRawRequest("", "", nil, "") //nolint:bodyclose
 	if err == nil {
 		t.Error("Request without relative path should have failed")
 	}

--- a/common/types.go
+++ b/common/types.go
@@ -101,7 +101,7 @@ func (e *Entity) Update(originalEntity, currentEntity reflect.Value, allowedUpda
 	// If there are any allowed updates, try to send updates to the system and
 	// return the result.
 	if len(payload) > 0 {
-		_, err := e.Client.Patch(e.ODataID, payload) // nolint:bodyclose
+		_, err := e.Client.Patch(e.ODataID, payload) //nolint:bodyclose
 		if err != nil {
 			return err
 		}

--- a/oem/dell/eventservice_test.go
+++ b/oem/dell/eventservice_test.go
@@ -214,12 +214,12 @@ func TestDellSubmitTestEvent(t *testing.T) {
 			rw.WriteHeader(http.StatusOK)
 			rw.Header().Set("Content-Type", "application/json")
 
-			rw.Write([]byte(serviceRootBody)) // nolint:errcheck
+			rw.Write([]byte(serviceRootBody)) //nolint:errcheck
 		} else if req.Method == http.MethodGet && // Get event service
 			req.URL.String() == "/redfish/v1/EventService" &&
 			requestCounter == 2 {
 			requestCounter++
-			rw.Write([]byte(eventServiceBody)) // nolint:errcheck
+			rw.Write([]byte(eventServiceBody)) //nolint:errcheck
 		} else if req.Method == http.MethodPost && // SubmitTestEvent
 			req.URL.String() == "/redfish/v1/EventService/Actions/EventService.SubmitTestEvent" &&
 			requestCounter == 3 {

--- a/oem/zt/eventservice_test.go
+++ b/oem/zt/eventservice_test.go
@@ -186,7 +186,7 @@ func TestSubscribeZT(t *testing.T) {
 			rw.WriteHeader(http.StatusOK)
 			rw.Header().Set("Content-Type", "application/json")
 
-			rw.Write([]byte(serviceRootBody)) // nolint:errcheck
+			rw.Write([]byte(serviceRootBody)) //nolint:errcheck
 		} else if req.Method == http.MethodGet && // Get event service
 			req.URL.String() == "/redfish/v1/EventService" &&
 			requestCounter == 2 {
@@ -194,7 +194,7 @@ func TestSubscribeZT(t *testing.T) {
 
 			requestCounter++
 
-			rw.Write([]byte(eventServiceBody)) // nolint:errcheck
+			rw.Write([]byte(eventServiceBody)) //nolint:errcheck
 		} else if req.Method == http.MethodPost && // Subscribe
 			req.URL.String() == "/redfish/v1/EventService/Subscriptions" &&
 			requestCounter == 3 {
@@ -202,7 +202,7 @@ func TestSubscribeZT(t *testing.T) {
 
 			requestCounter++
 
-			rw.Write([]byte(subscribeResponseBody)) // nolint:errcheck
+			rw.Write([]byte(subscribeResponseBody)) //nolint:errcheck
 		} else {
 			t.Errorf("mock got unexpected %v request to path %v while request counter is %v",
 				req.Method, req.URL.String(), requestCounter)

--- a/redfish/chassis_test.go
+++ b/redfish/chassis_test.go
@@ -195,6 +195,7 @@ func TestChassis(t *testing.T) {
 //
 // The required properties according to the spec are:
 // "required": [
+//
 //	"ChassisType",
 //	"@odata.id",
 //	"@odata.type",
@@ -296,8 +297,8 @@ func TestChassisDrives(t *testing.T) {
 	testClient := &common.TestClient{
 		CustomReturnForActions: map[string][]interface{}{
 			http.MethodGet: {
-				getCall(driveCollection), // nolint
-				getCall(driveBody),       // nolint
+				getCall(driveCollection), //nolint
+				getCall(driveBody),       //nolint
 			},
 		},
 	}
@@ -331,10 +332,10 @@ func TestChassisLinkedDrives(t *testing.T) {
 	testClient := &common.TestClient{
 		CustomReturnForActions: map[string][]interface{}{
 			http.MethodGet: {
-				getCall(driveBody), // nolint
-				getCall(driveBody), // nolint
-				getCall(driveBody), // nolint
-				getCall(driveBody), // nolint
+				getCall(driveBody), //nolint
+				getCall(driveBody), //nolint
+				getCall(driveBody), //nolint
+				getCall(driveBody), //nolint
 			},
 		},
 	}

--- a/redfish/computersystem.go
+++ b/redfish/computersystem.go
@@ -812,7 +812,7 @@ func (computersystem *ComputerSystem) SecureBoot() (*SecureBoot, error) {
 }
 
 // SetBoot set a boot object based on a payload request
-func (computersystem *ComputerSystem) SetBoot(b Boot) error { // nolint
+func (computersystem *ComputerSystem) SetBoot(b Boot) error { //nolint
 	type temp struct {
 		Boot Boot
 	}
@@ -881,7 +881,7 @@ func (computersystem *ComputerSystem) Reset(resetType ResetType) error {
 func (computersystem *ComputerSystem) SetDefaultBootOrder() error {
 	// This action wasn't added until 1.5.0, make sure this is supported.
 	if computersystem.setDefaultBootOrderTarget == "" {
-		return fmt.Errorf("SetDefaultBootOrder is not supported by this system") // nolint:golint
+		return fmt.Errorf("SetDefaultBootOrder is not supported by this system") //nolint:golint
 	}
 
 	var header = make(map[string]string)

--- a/redfish/computersystem_test.go
+++ b/redfish/computersystem_test.go
@@ -129,7 +129,7 @@ var computerSystemBody = `{
 	}`
 
 // TestComputerSystem tests the parsing of ComputerSystem objects.
-func TestComputerSystem(t *testing.T) { // nolint
+func TestComputerSystem(t *testing.T) { //nolint
 	var result ComputerSystem
 	err := json.NewDecoder(strings.NewReader(computerSystemBody)).Decode(&result)
 

--- a/redfish/eventservice_test.go
+++ b/redfish/eventservice_test.go
@@ -443,7 +443,7 @@ func TestEventServiceCreateEventSubscriptionWithoutOptionalParameters(t *testing
 
 // TestEventServiceCreateEventSubscriptionInputParametersValidation
 // tests the validation of input parameters for CreateEventSubscription.
-func TestEventServiceCreateEventSubscriptionInputParametersValidation(t *testing.T) { // nolint
+func TestEventServiceCreateEventSubscriptionInputParametersValidation(t *testing.T) { //nolint
 	var result EventService
 	err := json.NewDecoder(strings.NewReader(eventServiceBody)).Decode(&result)
 	if err != nil {

--- a/redfish/logservice_test.go
+++ b/redfish/logservice_test.go
@@ -81,7 +81,7 @@ func TestLogService(t *testing.T) {
 }
 
 // TestLogServiceUpdate tests the Update call.
-func TestLogServiceUpdate(t *testing.T) { // nolint:dupl
+func TestLogServiceUpdate(t *testing.T) { //nolint:dupl
 	var result LogService
 	err := json.NewDecoder(strings.NewReader(logServiceBody)).Decode(&result)
 

--- a/redfish/memory_test.go
+++ b/redfish/memory_test.go
@@ -129,7 +129,7 @@ func TestMemory(t *testing.T) {
 }
 
 // TestMemoryUpdate tests the Update call.
-func TestMemoryUpdate(t *testing.T) { // nolint:dupl
+func TestMemoryUpdate(t *testing.T) { //nolint:dupl
 	var result Memory
 	err := json.NewDecoder(strings.NewReader(memoryBody)).Decode(&result)
 

--- a/redfish/messageregistry.go
+++ b/redfish/messageregistry.go
@@ -204,10 +204,11 @@ func GetMessageRegistryByLanguage(
 // from the informed messageID.
 // messageID is the key used to find the registry, version and message:
 // Example of messageID: Alert.1.0.LanDisconnect
-//  - The segment before the 1st period is the Registry Name (Registry Prefix): Alert
-//  - The segment between the 1st and 2nd period is the major version: 1
-//  - The segment between the 2nd and 3rd period is the minor version: 0
-//  - The segment after the 3rd period is the Message Identifier in the Registry: LanDisconnect
+//   - The segment before the 1st period is the Registry Name (Registry Prefix): Alert
+//   - The segment between the 1st and 2nd period is the major version: 1
+//   - The segment between the 2nd and 3rd period is the minor version: 0
+//   - The segment after the 3rd period is the Message Identifier in the Registry: LanDisconnect
+//
 // language is the RFC5646-conformant language code for the message registry.
 // Example of language: en
 func GetMessageFromMessageRegistryByLanguage(

--- a/redfish/messageregistry_test.go
+++ b/redfish/messageregistry_test.go
@@ -67,7 +67,7 @@ var messageRegistryBody = `{
 	}`
 
 // TestMessageRegistry tests the parsing of MessageRegistry objects.
-func TestMessageRegistry(t *testing.T) { // nolint:funlen,gocyclo
+func TestMessageRegistry(t *testing.T) { //nolint:funlen,gocyclo
 	var result MessageRegistry
 	err := json.NewDecoder(strings.NewReader(messageRegistryBody)).Decode(&result)
 

--- a/redfish/networkdevicefunction_test.go
+++ b/redfish/networkdevicefunction_test.go
@@ -118,7 +118,7 @@ func TestNetworkDeviceFunction(t *testing.T) {
 }
 
 // TestNetworkDeviceFunctionUpdate tests the Update call.
-func TestNetworkDeviceFunctionUpdate(t *testing.T) { // nolint:dupl
+func TestNetworkDeviceFunctionUpdate(t *testing.T) { //nolint:dupl
 	var result NetworkDeviceFunction
 	err := json.NewDecoder(strings.NewReader(networkDeviceFunctionBody)).Decode(&result)
 

--- a/redfish/pciedevice_test.go
+++ b/redfish/pciedevice_test.go
@@ -87,7 +87,7 @@ func TestPCIeDevice(t *testing.T) {
 }
 
 // TestPCIeDeviceUpdate tests the Update call.
-func TestPCIeDeviceUpdate(t *testing.T) { // nolint:dupl
+func TestPCIeDeviceUpdate(t *testing.T) { //nolint:dupl
 	var result PCIeDevice
 	err := json.NewDecoder(strings.NewReader(pcieDeviceBody)).Decode(&result)
 

--- a/redfish/power.go
+++ b/redfish/power.go
@@ -233,7 +233,7 @@ type PowerControl struct {
 }
 
 // UnmarshalJSON unmarshals a PowerControl object from the raw JSON.
-func (powercontrol *PowerControl) UnmarshalJSON(b []byte) error { // nolint:dupl
+func (powercontrol *PowerControl) UnmarshalJSON(b []byte) error { //nolint:dupl
 	type temp PowerControl
 	type t1 struct {
 		temp
@@ -493,7 +493,7 @@ type Voltage struct {
 }
 
 // UnmarshalJSON unmarshals a Voltage object from the raw JSON.
-func (voltage *Voltage) UnmarshalJSON(b []byte) error { // nolint:dupl
+func (voltage *Voltage) UnmarshalJSON(b []byte) error { //nolint:dupl
 	type temp Voltage
 	type t1 struct {
 		temp

--- a/redfish/redundancy_test.go
+++ b/redfish/redundancy_test.go
@@ -59,7 +59,7 @@ func TestRedundancy(t *testing.T) {
 }
 
 // TestRedundancyUpdate tests the Update call.
-func TestRedundancyUpdate(t *testing.T) { // nolint:dupl
+func TestRedundancyUpdate(t *testing.T) { //nolint:dupl
 	var result Redundancy
 	err := json.NewDecoder(strings.NewReader(redundancyBody)).Decode(&result)
 

--- a/redfish/secureboot_test.go
+++ b/redfish/secureboot_test.go
@@ -64,7 +64,7 @@ func TestSecureBoot(t *testing.T) {
 }
 
 // TestSecureBootUpdate tests the Update call.
-func TestSecureBootUpdate(t *testing.T) { // nolint:dupl
+func TestSecureBootUpdate(t *testing.T) { //nolint:dupl
 	var result SecureBoot
 	err := json.NewDecoder(strings.NewReader(secureBootBody)).Decode(&result)
 

--- a/redfish/vlannetworkinterface_test.go
+++ b/redfish/vlannetworkinterface_test.go
@@ -50,7 +50,7 @@ func TestVlanNetworkInterface(t *testing.T) {
 }
 
 // TestVlanNetworkInterfaceUpdate tests the Update call.
-func TestVlanNetworkInterfaceUpdate(t *testing.T) { // nolint:dupl
+func TestVlanNetworkInterfaceUpdate(t *testing.T) { //nolint:dupl
 	var result VLanNetworkInterface
 	err := json.NewDecoder(strings.NewReader(vlanNetworkInterfaceBody)).Decode(&result)
 

--- a/serviceroot.go
+++ b/serviceroot.go
@@ -313,10 +313,11 @@ func (serviceroot *Service) MessageRegistryByLanguage(registry, language string)
 
 // MessageByLanguage tries to find and get the message in the correct language from the informed messageID.
 // messageID is the key used to find the registry, version and message, for example: "Alert.1.0.LanDisconnect"
-//  - The segment before the 1st period is the Registry Name (Registry Prefix): Alert
-//  - The segment between the 1st and 2nd period is the major version: 1
-//  - The segment between the 2nd and 3rd period is the minor version: 0
-//  - The segment after the 3rd period is the Message Identifier in the Registry: LanDisconnect
+//   - The segment before the 1st period is the Registry Name (Registry Prefix): Alert
+//   - The segment between the 1st and 2nd period is the major version: 1
+//   - The segment between the 2nd and 3rd period is the minor version: 0
+//   - The segment after the 3rd period is the Message Identifier in the Registry: LanDisconnect
+//
 // language is the RFC5646-conformant language code for the message registry, for example: "en".
 func (serviceroot *Service) MessageByLanguage(messageID, language string) (*redfish.MessageRegistryMessage, error) {
 	return redfish.GetMessageFromMessageRegistryByLanguage(serviceroot.Client, serviceroot.registries, messageID, language)

--- a/swordfish/endpointgroup_test.go
+++ b/swordfish/endpointgroup_test.go
@@ -67,7 +67,7 @@ func TestEndpointGroup(t *testing.T) {
 }
 
 // TestEndpointGroupUpdate tests the Update call.
-func TestEndpointGroupUpdate(t *testing.T) { // nolint:dupl
+func TestEndpointGroupUpdate(t *testing.T) { //nolint:dupl
 	var result EndpointGroup
 	err := json.NewDecoder(strings.NewReader(endpointGroupBody)).Decode(&result)
 

--- a/swordfish/ioperformanceloscapabilities_test.go
+++ b/swordfish/ioperformanceloscapabilities_test.go
@@ -122,7 +122,7 @@ func TestIOPerformanceLoSCapabilities(t *testing.T) {
 }
 
 // TestIOPerformanceLoSCapabilitiesUpdate tests the Update call.
-func TestIOPerformanceLoSCapabilitiesUpdate(t *testing.T) { // nolint:dupl
+func TestIOPerformanceLoSCapabilitiesUpdate(t *testing.T) { //nolint:dupl
 	var result IOPerformanceLoSCapabilities
 	err := json.NewDecoder(strings.NewReader(ioPerformanceLoSCapabilitiesBody)).Decode(&result)
 

--- a/swordfish/spareresourceset_test.go
+++ b/swordfish/spareresourceset_test.go
@@ -106,7 +106,7 @@ func TestSpareResourceSet(t *testing.T) {
 }
 
 // TestSpareResourceSetUpdate tests the Update call.
-func TestSpareResourceSetUpdate(t *testing.T) { // nolint:dupl
+func TestSpareResourceSetUpdate(t *testing.T) { //nolint:dupl
 	var result SpareResourceSet
 	err := json.NewDecoder(strings.NewReader(spareResourceSetBody)).Decode(&result)
 

--- a/swordfish/storagepool_test.go
+++ b/swordfish/storagepool_test.go
@@ -119,7 +119,7 @@ func TestStoragePool(t *testing.T) {
 }
 
 // TestStoragePoolUpdate tests the Update call.
-func TestStoragePoolUpdate(t *testing.T) { // nolint:dupl
+func TestStoragePoolUpdate(t *testing.T) { //nolint:dupl
 	var result StoragePool
 	err := json.NewDecoder(strings.NewReader(storagePoolBody)).Decode(&result)
 


### PR DESCRIPTION
The newer releases of golangci-lint have had issues as they try to work
through changes in go 1.19 while keeping backward compatibility. In the
meantime, this pins to an older version and bumps up the version of go
used in CI.

Also some minor cleanup on nolint tags.