### PR TITLE
Bump golangci-lint to 1.49.0

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -44,5 +44,5 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.48.0
+        version: v1.49.0
         args: --timeout=5m -v

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -49,7 +49,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -73,13 +72,11 @@ linters:
     - revive
     - rowserrcheck
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
 
   # don't enable:

--- a/redfish/messageregistry.go
+++ b/redfish/messageregistry.go
@@ -204,6 +204,7 @@ func GetMessageRegistryByLanguage(
 // from the informed messageID.
 // messageID is the key used to find the registry, version and message:
 // Example of messageID: Alert.1.0.LanDisconnect
+//
 //   - The segment before the 1st period is the Registry Name (Registry Prefix): Alert
 //   - The segment between the 1st and 2nd period is the major version: 1
 //   - The segment between the 2nd and 3rd period is the minor version: 0

--- a/serviceroot.go
+++ b/serviceroot.go
@@ -313,6 +313,7 @@ func (serviceroot *Service) MessageRegistryByLanguage(registry, language string)
 
 // MessageByLanguage tries to find and get the message in the correct language from the informed messageID.
 // messageID is the key used to find the registry, version and message, for example: "Alert.1.0.LanDisconnect"
+//
 //   - The segment before the 1st period is the Registry Name (Registry Prefix): Alert
 //   - The segment between the 1st and 2nd period is the major version: 1
 //   - The segment between the 2nd and 3rd period is the minor version: 0


### PR DESCRIPTION
This version pulls in some updated linters with better checks and
version support.