### PR TITLE
Fix lint issue with nolint:dupl no longer needed

### DIFF
--- a/redfish/memory.go
+++ b/redfish/memory.go
@@ -405,7 +405,7 @@ func GetMemory(c common.Client, uri string) (*Memory, error) {
 
 // ListReferencedMemorys gets the collection of Memory from
 // a provided reference.
-func ListReferencedMemorys(c common.Client, link string) ([]*Memory, error) { //nolint:dupl
+func ListReferencedMemorys(c common.Client, link string) ([]*Memory, error) {
 	var result []*Memory
 	if link == "" {
 		return result, nil


### PR DESCRIPTION
With the change to make memory fetch async in
0b4ea564cb6065f0caec27ee9b90a64d4f36b096 there was a `//nolint:dupl` that is no longer needed. This just drops that linter flag.