### PR TITLE
Update GitHub Action versions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,11 +13,11 @@ jobs:
     steps:
 
     # Get the code
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # Setup our go environment
     - name: Setup Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: '1.18.0'
 
@@ -33,16 +33,16 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # Setup our go environment
     - name: Setup Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: '1.18.0'
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v2
+      uses: golangci/golangci-lint-action@v3
       with:
         version: v1.49.0
         args: --timeout=5m -v


### PR DESCRIPTION
This updates the `checkout`, `setup-go`, and `golangci-lint` versions to v3 to use the latest. Deprecation warnings have started to be logged for the v2 version of `golangci-lint`, so we should get up to date to avoid any issues there.
