### PR TITLE
Make collections retrieval parallel

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -31,10 +31,6 @@ linters-settings:
     min-complexity: 25
   goimports:
     local-prefixes: github.com/stmcginnis
-  gomnd:
-    settings:
-      mnd:
-        checks: argument,case,condition,return
   govet:
     check-shadowing: true
   misspell:
@@ -59,7 +55,6 @@ linters:
     - gocyclo
     - goheader
     - goimports
-    - gomnd
     - goprintffuncname
     - gosec
     - gosimple

--- a/client.go
+++ b/client.go
@@ -417,7 +417,7 @@ func (c *APIClient) runRawRequestWithHeaders(method, url string, payloadBuffer i
 		// Set Content-Length custom headers on the request
 		// since its ignored when set using Header.Set()
 		if strings.EqualFold("Content-Length", k) {
-			req.ContentLength, err = strconv.ParseInt(v, 10, 64) //nolint:gomnd // base 10, 64 bit
+			req.ContentLength, err = strconv.ParseInt(v, 10, 64) // base 10, 64 bit
 			if err != nil {
 				return nil, common.ConstructError(0, []byte("error parsing custom Content-Length header"))
 			}

--- a/redfish/chassis.go
+++ b/redfish/chassis.go
@@ -332,20 +332,38 @@ func GetChassis(c common.Client, uri string) (*Chassis, error) {
 }
 
 // ListReferencedChassis gets the collection of Chassis from a provided reference.
-func ListReferencedChassis(c common.Client, link string) ([]*Chassis, error) {
+func ListReferencedChassis(c common.Client, link string) ([]*Chassis, error) { //nolint:dupl
 	var result []*Chassis
-	links, err := common.GetCollection(c, link)
-	if err != nil {
-		return result, err
+	if link == "" {
+		return result, nil
 	}
 
+	type GetResult struct {
+		Item  *Chassis
+		Link  string
+		Error error
+	}
+
+	ch := make(chan GetResult)
 	collectionError := common.NewCollectionError()
-	for _, chassisLink := range links.ItemLinks {
-		chassis, err := GetChassis(c, chassisLink)
+	get := func(link string) {
+		chassis, err := GetChassis(c, link)
+		ch <- GetResult{Item: chassis, Link: link, Error: err}
+	}
+
+	go func() {
+		err := common.CollectList(get, c, link)
 		if err != nil {
-			collectionError.Failures[chassisLink] = err
+			collectionError.Failures[link] = err
+		}
+		close(ch)
+	}()
+
+	for r := range ch {
+		if r.Error != nil {
+			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, chassis)
+			result = append(result, r.Item)
 		}
 	}
 
@@ -367,22 +385,40 @@ func (chassis *Chassis) Drives() ([]*Drive, error) {
 	// In version v1.2.0 of the spec, Drives were added to the Chassis.Links
 	// property. But in v1.14.0 of the spec, Chassis.Drives was added as a
 	// direct property.
+	// TODO: Update this to use the concurrent collection method
+	collectionError := common.NewCollectionError()
 	driveLinks := chassis.linkedDrives
 	if chassis.drives != "" {
 		drives, err := common.GetCollection(chassis.Client, chassis.drives)
 		if err != nil {
-			return nil, err
+			collectionError.Failures[chassis.drives] = err
+			return nil, collectionError
 		}
 		driveLinks = drives.ItemLinks
 	}
 
-	collectionError := common.NewCollectionError()
-	for _, driveLink := range driveLinks {
-		drive, err := GetDrive(chassis.Client, driveLink)
-		if err != nil {
-			collectionError.Failures[driveLink] = err
+	type GetResult struct {
+		Item  *Drive
+		Link  string
+		Error error
+	}
+
+	ch := make(chan GetResult)
+	get := func(link string) {
+		drive, err := GetDrive(chassis.Client, link)
+		ch <- GetResult{Item: drive, Link: link, Error: err}
+	}
+
+	go func() {
+		common.CollectCollection(get, chassis.Client, driveLinks)
+		close(ch)
+	}()
+
+	for r := range ch {
+		if r.Error != nil {
+			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, drive)
+			result = append(result, r.Item)
 		}
 	}
 

--- a/redfish/logservice.go
+++ b/redfish/logservice.go
@@ -165,18 +165,32 @@ func ListReferencedLogServices(c common.Client, link string) ([]*LogService, err
 		return result, nil
 	}
 
-	links, err := common.GetCollection(c, link)
-	if err != nil {
-		return result, err
+	type GetResult struct {
+		Item  *LogService
+		Link  string
+		Error error
 	}
 
+	ch := make(chan GetResult)
 	collectionError := common.NewCollectionError()
-	for _, logserviceLink := range links.ItemLinks {
-		logservice, err := GetLogService(c, logserviceLink)
+	get := func(link string) {
+		logservice, err := GetLogService(c, link)
+		ch <- GetResult{Item: logservice, Link: link, Error: err}
+	}
+
+	go func() {
+		err := common.CollectList(get, c, link)
 		if err != nil {
-			collectionError.Failures[logserviceLink] = err
+			collectionError.Failures[link] = err
+		}
+		close(ch)
+	}()
+
+	for r := range ch {
+		if r.Error != nil {
+			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, logservice)
+			result = append(result, r.Item)
 		}
 	}
 

--- a/redfish/manager.go
+++ b/redfish/manager.go
@@ -402,20 +402,38 @@ func GetManager(c common.Client, uri string) (*Manager, error) {
 }
 
 // ListReferencedManagers gets the collection of Managers
-func ListReferencedManagers(c common.Client, link string) ([]*Manager, error) {
+func ListReferencedManagers(c common.Client, link string) ([]*Manager, error) { //nolint:dupl
 	var result []*Manager
-	links, err := common.GetCollection(c, link)
-	if err != nil {
-		return result, err
+	if link == "" {
+		return result, nil
 	}
 
+	type GetResult struct {
+		Item  *Manager
+		Link  string
+		Error error
+	}
+
+	ch := make(chan GetResult)
 	collectionError := common.NewCollectionError()
-	for _, managerLink := range links.ItemLinks {
-		manager, err := GetManager(c, managerLink)
+	get := func(link string) {
+		manager, err := GetManager(c, link)
+		ch <- GetResult{Item: manager, Link: link, Error: err}
+	}
+
+	go func() {
+		err := common.CollectList(get, c, link)
 		if err != nil {
-			collectionError.Failures[managerLink] = err
+			collectionError.Failures[link] = err
+		}
+		close(ch)
+	}()
+
+	for r := range ch {
+		if r.Error != nil {
+			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, manager)
+			result = append(result, r.Item)
 		}
 	}
 

--- a/redfish/messageregistry.go
+++ b/redfish/messageregistry.go
@@ -88,21 +88,20 @@ func GetMessageRegistry(
 }
 
 // ListReferencedMessageRegistries gets the collection of MessageRegistry.
-func ListReferencedMessageRegistries(
-	c common.Client,
-	link string,
-) ([]*MessageRegistry, error) {
+func ListReferencedMessageRegistries(c common.Client, link string) ([]*MessageRegistry, error) {
 	var result []*MessageRegistry
 	links, err := common.GetCollection(c, link)
 	if err != nil {
 		return nil, err
 	}
 
+	// TODO: Look at what to do to make parallel
 	for _, sLink := range links.ItemLinks {
 		mrf, err := GetMessageRegistryFile(c, sLink)
 		if err != nil {
 			return nil, err
 		}
+
 		// get message registry from all location
 		for _, location := range mrf.Location {
 			mr, err := GetMessageRegistry(c, location.URI)
@@ -118,16 +117,13 @@ func ListReferencedMessageRegistries(
 
 // ListReferencedMessageRegistriesByLanguage gets the collection of MessageRegistry.
 // language is the RFC5646-conformant language code for the message registry.
-func ListReferencedMessageRegistriesByLanguage(
-	c common.Client,
-	link string,
-	language string,
-) ([]*MessageRegistry, error) {
+func ListReferencedMessageRegistriesByLanguage(c common.Client, link, language string) ([]*MessageRegistry, error) {
 	language = strings.TrimSpace(language)
 	if language == "" {
 		return nil, fmt.Errorf("received empty language")
 	}
 
+	// TODO: Looks at what to do to make parallel.
 	var result []*MessageRegistry
 	links, err := common.GetCollection(c, link)
 	if err != nil {
@@ -139,6 +135,7 @@ func ListReferencedMessageRegistriesByLanguage(
 		if err != nil {
 			return nil, err
 		}
+
 		// get message registry by language
 		for _, location := range mrf.Location {
 			if location.Language == language {
@@ -176,6 +173,7 @@ func GetMessageRegistryByLanguage(
 		return nil, fmt.Errorf("received empty language")
 	}
 
+	// TODO: Look at what to do to make parallel
 	links, err := common.GetCollection(c, link)
 	if err != nil {
 		return nil, err

--- a/redfish/networkadapter.go
+++ b/redfish/networkadapter.go
@@ -255,20 +255,38 @@ func GetNetworkAdapter(c common.Client, uri string) (*NetworkAdapter, error) {
 }
 
 // ListReferencedNetworkAdapter gets the collection of Chassis from a provided reference.
-func ListReferencedNetworkAdapter(c common.Client, link string) ([]*NetworkAdapter, error) {
+func ListReferencedNetworkAdapter(c common.Client, link string) ([]*NetworkAdapter, error) { //nolint:dupl
 	var result []*NetworkAdapter
-	links, err := common.GetCollection(c, link)
-	if err != nil {
-		return result, err
+	if link == "" {
+		return result, nil
 	}
 
+	type GetResult struct {
+		Item  *NetworkAdapter
+		Link  string
+		Error error
+	}
+
+	ch := make(chan GetResult)
 	collectionError := common.NewCollectionError()
-	for _, networkAdapterLink := range links.ItemLinks {
-		networkAdapter, err := GetNetworkAdapter(c, networkAdapterLink)
+	get := func(link string) {
+		networkadapter, err := GetNetworkAdapter(c, link)
+		ch <- GetResult{Item: networkadapter, Link: link, Error: err}
+	}
+
+	go func() {
+		err := common.CollectList(get, c, link)
 		if err != nil {
-			collectionError.Failures[networkAdapterLink] = err
+			collectionError.Failures[link] = err
+		}
+		close(ch)
+	}()
+
+	for r := range ch {
+		if r.Error != nil {
+			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, networkAdapter)
+			result = append(result, r.Item)
 		}
 	}
 

--- a/redfish/volume.go
+++ b/redfish/volume.go
@@ -243,18 +243,32 @@ func ListReferencedVolumes(c common.Client, link string) ([]*Volume, error) { //
 		return result, nil
 	}
 
-	links, err := common.GetCollection(c, link)
-	if err != nil {
-		return result, err
+	type GetResult struct {
+		Item  *Volume
+		Link  string
+		Error error
 	}
 
+	ch := make(chan GetResult)
 	collectionError := common.NewCollectionError()
-	for _, volumeLink := range links.ItemLinks {
-		volume, err := GetVolume(c, volumeLink)
+	get := func(link string) {
+		volume, err := GetVolume(c, link)
+		ch <- GetResult{Item: volume, Link: link, Error: err}
+	}
+
+	go func() {
+		err := common.CollectList(get, c, link)
 		if err != nil {
-			collectionError.Failures[volumeLink] = err
+			collectionError.Failures[link] = err
+		}
+		close(ch)
+	}()
+
+	for r := range ch {
+		if r.Error != nil {
+			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, volume)
+			result = append(result, r.Item)
 		}
 	}
 

--- a/swordfish/capacity.go
+++ b/swordfish/capacity.go
@@ -137,26 +137,46 @@ func GetCapacitySource(c common.Client, uri string) (*CapacitySource, error) {
 
 // ListReferencedCapacitySources gets the collection of CapacitySources from
 // a provided reference.
-func ListReferencedCapacitySources(c common.Client, link string) ([]*CapacitySource, error) {
+func ListReferencedCapacitySources(c common.Client, link string) ([]*CapacitySource, error) { //nolint:dupl
 	var result []*CapacitySource
 	if link == "" {
 		return result, nil
 	}
 
-	links, err := common.GetCollection(c, link)
-	if err != nil {
-		return result, err
+	type GetResult struct {
+		Item  *CapacitySource
+		Link  string
+		Error error
 	}
 
-	for _, capSourceLink := range links.ItemLinks {
-		capSource, err := GetCapacitySource(c, capSourceLink)
+	ch := make(chan GetResult)
+	collectionError := common.NewCollectionError()
+	get := func(link string) {
+		capacitysource, err := GetCapacitySource(c, link)
+		ch <- GetResult{Item: capacitysource, Link: link, Error: err}
+	}
+
+	go func() {
+		err := common.CollectList(get, c, link)
 		if err != nil {
-			return result, err
+			collectionError.Failures[link] = err
 		}
-		result = append(result, capSource)
+		close(ch)
+	}()
+
+	for r := range ch {
+		if r.Error != nil {
+			collectionError.Failures[r.Link] = r.Error
+		} else {
+			result = append(result, r.Item)
+		}
 	}
 
-	return result, nil
+	if collectionError.Empty() {
+		return result, nil
+	}
+
+	return result, collectionError
 }
 
 // ProvidedClassOfService gets the ClassOfService from the ProvidingDrives,

--- a/swordfish/datastoragelineofservice.go
+++ b/swordfish/datastoragelineofservice.go
@@ -94,18 +94,32 @@ func ListReferencedDataStorageLineOfServices(c common.Client, link string) ([]*D
 		return result, nil
 	}
 
-	links, err := common.GetCollection(c, link)
-	if err != nil {
-		return result, err
+	type GetResult struct {
+		Item  *DataStorageLineOfService
+		Link  string
+		Error error
 	}
 
+	ch := make(chan GetResult)
 	collectionError := common.NewCollectionError()
-	for _, datastoragelineofserviceLink := range links.ItemLinks {
-		datastoragelineofservice, err := GetDataStorageLineOfService(c, datastoragelineofserviceLink)
+	get := func(link string) {
+		datastoragelineofservice, err := GetDataStorageLineOfService(c, link)
+		ch <- GetResult{Item: datastoragelineofservice, Link: link, Error: err}
+	}
+
+	go func() {
+		err := common.CollectList(get, c, link)
 		if err != nil {
-			collectionError.Failures[datastoragelineofserviceLink] = err
+			collectionError.Failures[link] = err
+		}
+		close(ch)
+	}()
+
+	for r := range ch {
+		if r.Error != nil {
+			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, datastoragelineofservice)
+			result = append(result, r.Item)
 		}
 	}
 

--- a/swordfish/ioperformancelineofservice.go
+++ b/swordfish/ioperformancelineofservice.go
@@ -72,18 +72,32 @@ func ListReferencedIOPerformanceLineOfServices(c common.Client, link string) ([]
 		return result, nil
 	}
 
-	links, err := common.GetCollection(c, link)
-	if err != nil {
-		return result, err
+	type GetResult struct {
+		Item  *IOPerformanceLineOfService
+		Link  string
+		Error error
 	}
 
+	ch := make(chan GetResult)
 	collectionError := common.NewCollectionError()
-	for _, ioperformancelineofserviceLink := range links.ItemLinks {
-		ioperformancelineofservice, err := GetIOPerformanceLineOfService(c, ioperformancelineofserviceLink)
+	get := func(link string) {
+		ioperformancelineofservice, err := GetIOPerformanceLineOfService(c, link)
+		ch <- GetResult{Item: ioperformancelineofservice, Link: link, Error: err}
+	}
+
+	go func() {
+		err := common.CollectList(get, c, link)
 		if err != nil {
-			collectionError.Failures[ioperformancelineofserviceLink] = err
+			collectionError.Failures[link] = err
+		}
+		close(ch)
+	}()
+
+	for r := range ch {
+		if r.Error != nil {
+			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, ioperformancelineofservice)
+			result = append(result, r.Item)
 		}
 	}
 

--- a/swordfish/storagepool.go
+++ b/swordfish/storagepool.go
@@ -196,18 +196,32 @@ func ListReferencedStoragePools(c common.Client, link string) ([]*StoragePool, e
 		return result, nil
 	}
 
-	links, err := common.GetCollection(c, link)
-	if err != nil {
-		return result, err
+	type GetResult struct {
+		Item  *StoragePool
+		Link  string
+		Error error
 	}
 
+	ch := make(chan GetResult)
 	collectionError := common.NewCollectionError()
-	for _, storagepoolLink := range links.ItemLinks {
-		storagepool, err := GetStoragePool(c, storagepoolLink)
+	get := func(link string) {
+		storagepool, err := GetStoragePool(c, link)
+		ch <- GetResult{Item: storagepool, Link: link, Error: err}
+	}
+
+	go func() {
+		err := common.CollectList(get, c, link)
 		if err != nil {
-			collectionError.Failures[storagepoolLink] = err
+			collectionError.Failures[link] = err
+		}
+		close(ch)
+	}()
+
+	for r := range ch {
+		if r.Error != nil {
+			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, storagepool)
+			result = append(result, r.Item)
 		}
 	}
 

--- a/swordfish/storagereplicainfo.go
+++ b/swordfish/storagereplicainfo.go
@@ -469,18 +469,32 @@ func ListReferencedStorageReplicaInfos(c common.Client, link string) ([]*Storage
 		return result, nil
 	}
 
-	links, err := common.GetCollection(c, link)
-	if err != nil {
-		return result, err
+	type GetResult struct {
+		Item  *StorageReplicaInfo
+		Link  string
+		Error error
 	}
 
+	ch := make(chan GetResult)
 	collectionError := common.NewCollectionError()
-	for _, storagereplicainfoLink := range links.ItemLinks {
-		storagereplicainfo, err := GetStorageReplicaInfo(c, storagereplicainfoLink)
+	get := func(link string) {
+		storagereplicainfo, err := GetStorageReplicaInfo(c, link)
+		ch <- GetResult{Item: storagereplicainfo, Link: link, Error: err}
+	}
+
+	go func() {
+		err := common.CollectList(get, c, link)
 		if err != nil {
-			collectionError.Failures[storagereplicainfoLink] = err
+			collectionError.Failures[link] = err
+		}
+		close(ch)
+	}()
+
+	for r := range ch {
+		if r.Error != nil {
+			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, storagereplicainfo)
+			result = append(result, r.Item)
 		}
 	}
 

--- a/swordfish/storagesystem.go
+++ b/swordfish/storagesystem.go
@@ -35,20 +35,38 @@ func GetStorageSystem(c common.Client, uri string) (*StorageSystem, error) {
 }
 
 // ListReferencedStorageSystems gets the collection of StorageSystems.
-func ListReferencedStorageSystems(c common.Client, link string) ([]*StorageSystem, error) {
+func ListReferencedStorageSystems(c common.Client, link string) ([]*StorageSystem, error) { //nolint:dupl
 	var result []*StorageSystem
-	links, err := common.GetCollection(c, link)
-	if err != nil {
-		return result, err
+	if link == "" {
+		return result, nil
 	}
 
+	type GetResult struct {
+		Item  *StorageSystem
+		Link  string
+		Error error
+	}
+
+	ch := make(chan GetResult)
 	collectionError := common.NewCollectionError()
-	for _, storageSystemLink := range links.ItemLinks {
-		storageSystem, err := GetStorageSystem(c, storageSystemLink)
+	get := func(link string) {
+		storagesystem, err := GetStorageSystem(c, link)
+		ch <- GetResult{Item: storagesystem, Link: link, Error: err}
+	}
+
+	go func() {
+		err := common.CollectList(get, c, link)
 		if err != nil {
-			collectionError.Failures[storageSystemLink] = err
+			collectionError.Failures[link] = err
+		}
+		close(ch)
+	}()
+
+	for r := range ch {
+		if r.Error != nil {
+			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, storageSystem)
+			result = append(result, r.Item)
 		}
 	}
 

--- a/tools/source.tmpl
+++ b/tools/source.tmpl
@@ -109,30 +109,44 @@ func Get{{ class.name }}(c common.Client, uri string) (*{{ class.name }}, error)
 // a provided reference.
 func ListReferenced{{ class.name }}s(c common.Client, link string) ([]*{{ class.name }}, error) {
     var result []*{{ class.name }}
-    if link == "" {
-        return result, nil
-    }
+	if link == "" {
+		return result, nil
+	}
 
-    links, err := common.GetCollection(c, link)
-    if err != nil {
-        return result, err
-    }
+	type GetResult struct {
+		Item  *{{ class.name }}
+		Link  string
+		Error error
+	}
 
-    collectionError := common.NewCollectionError()
-    for _, {{ class.name|lower }}Link := range links.ItemLinks {
-        {{ class.name|lower }}, err := Get{{ class.name }}(c, {{ class.name|lower }}Link)
-        if err != nil {
-            collectionError.Failures[{{ class.name|lower }}Link] = err
-        } else {
-            result = append(result, {{ class.name|lower }})
-        }
-    }
+	ch := make(chan GetResult)
+	collectionError := common.NewCollectionError()
+	get := func(link string) {
+		{{ class.name|lower }}, err := Get{{ class.name }}(c, link)
+		ch <- GetResult{Item: {{ class.name|lower }}, Link: link, Error: err}
+	}
 
-    if collectionError.Empty() {
-        return result, nil
-    } else {
-        return result, collectionError
-    }
+	go func() {
+		err := common.CollectList(get, c, link)
+		if err != nil {
+			collectionError.Failures[link] = err
+		}
+		close(ch)
+	}()
+
+	for r := range ch {
+		if r.Error != nil {
+			collectionError.Failures[r.Link] = r.Error
+		} else {
+			result = append(result, r.Item)
+		}
+	}
+
+	if collectionError.Empty() {
+		return result, nil
+	}
+
+	return result, collectionError
 }
 
 {% endif %}


### PR DESCRIPTION
This makes calls to get the objects from a collection link parallel.

Some collections can contain a large number of items to retrieve. Doing this serially can have a noticable performance impact. This change allows three fetches in parallel so we don't overwhelm the Redfish service and cause a denial of service. With three concurrent operations we can be processing some responses while queuing up the more, making it a lot faster to process.