### PR TITLE
Fix VirtualMediaConfig for Supermicro

### DIFF
--- a/redfish/virtualmedia.go
+++ b/redfish/virtualmedia.go
@@ -236,12 +236,12 @@ func (virtualmedia *VirtualMedia) InsertMedia(image string, inserted, writeProte
 // VirtualMediaConfig is an struct used to pass config data to build the HTTP body when inserting media
 type VirtualMediaConfig struct {
 	Image                string
-	Inserted             bool
+	Inserted             bool   `json:",omitempty"`
 	Password             string `json:",omitempty"`
 	TransferMethod       string `json:",omitempty"`
 	TransferProtocolType string `json:",omitempty"`
 	UserName             string `json:",omitempty"`
-	WriteProtected       bool
+	WriteProtected       bool   `json:",omitempty"`
 }
 
 // InsertMediaConfig sends a request to insert virtual media using the VirtualMediaConfig struct


### PR DESCRIPTION
The redfish implementation of Supermicro doesn't seem to like `Inserted` or `WriteProtected` as additional properties for the InsertMedia action target and rejects requests which include them:
```
{
  "error": {
    "code": "Base.v1_4_0.GeneralError",
    "Message": "A general error has occurred. See ExtendedInfo for more information.",
    "@Message.ExtendedInfo": [
      {
        "MessageId": "Base.1.4.PropertyUnknown",
        "Severity": "Warning",
        "Resolution": "Remove the unknown property from the request body and resubmit the request if the operation failed.",
        "Message": "The property Inserted is not in the list of valid properties for the resource.",
        "MessageArgs": [
          "Inserted"
        ],
        "RelatedProperties": [
          "Inserted"
        ]
      },
      {
        "MessageId": "Base.1.4.PropertyUnknown",
        "Severity": "Warning",
        "Resolution": "Remove the unknown property from the request body and resubmit the request if the operation failed.",
        "Message": "The property WriteProtected is not in the list of valid properties for the resource.",
        "MessageArgs": [
          "WriteProtected"
        ],
        "RelatedProperties": [
          "WriteProtected"
        ]
      }
    ]
  }
}
```

This PR adds an `omitempty` attribute to the `redfish.VirtualMediaConfig` struct, so at least `VirtualMedia.InsertMediaConfig()` can be used for Supermicro systems. The same problem exists in the `VirtualMedia.InsertMedia()` function, but I didn't want to change the functions interface and am not sure if there is a good alternative.