### PR TITLE
feat(oem/supermicro): Add Supermicro Manager OEM functions

### DIFF
--- a/oem/hpe/thermal.go
+++ b/oem/hpe/thermal.go
@@ -17,8 +17,8 @@ type Fan struct {
 
 type FanOem struct {
 	Hpe struct {
-		OdataContext string `json:"@odata.context"`
-		OdataType    string `json:"@odata.type"`
+		ODataContext string `json:"@odata.context"`
+		ODataType    string `json:"@odata.type"`
 		Location     string `json:"Location"`
 		Redundant    bool   `json:"Redundant"`
 		HotPluggable bool   `json:"HotPluggable"`
@@ -33,8 +33,8 @@ type Thermal struct {
 
 type ThermalOem struct {
 	Hpe struct {
-		OdataContext         string `json:"@odata.context"`
-		OdataType            string `json:"@odata.type"`
+		ODataContext         string `json:"@odata.context"`
+		ODataType            string `json:"@odata.type"`
 		ThermalConfiguration string `json:"ThermalConfiguration"`
 		FanPercentMinimum    int    `json:"FanPercentMinimum"`
 	} `json:"Hpe"`

--- a/oem/supermicro/ikvm.go
+++ b/oem/supermicro/ikvm.go
@@ -1,0 +1,78 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package supermicro
+
+import (
+	"encoding/json"
+	"reflect"
+
+	"github.com/stmcginnis/gofish/common"
+)
+
+type IKVMInterface string
+
+const (
+	JavaIKVMInterface IKVMInterface = "JAVA plug-in"
+	HTMLIKVMInterface IKVMInterface = "HTML 5"
+)
+
+type IKVM struct {
+	common.Entity
+
+	OdataType        string        `json:"@odata.type"`
+	CurrentInterface IKVMInterface `json:"Current interface"`
+	URI              string        `json:"URI"`
+
+	rawData []byte
+}
+
+func (ikvm *IKVM) UnmarshalJSON(b []byte) error {
+	type temp IKVM
+
+	var rtn temp
+	err := json.Unmarshal(b, &rtn)
+	if err != nil {
+		return err
+	}
+
+	*ikvm = IKVM(rtn)
+	ikvm.rawData = b
+
+	return nil
+}
+
+func (ikvm *IKVM) Update() error {
+	original := new(IKVM)
+	err := original.UnmarshalJSON(ikvm.rawData)
+	if err != nil {
+		return err
+	}
+
+	readWriteFields := []string{
+		"Current interface",
+	}
+
+	originalElement := reflect.ValueOf(original).Elem()
+	currentElement := reflect.ValueOf(ikvm).Elem()
+
+	return ikvm.Entity.Update(originalElement, currentElement, readWriteFields)
+}
+
+func GetIKVM(c common.Client, uri string) (*IKVM, error) {
+	resp, err := c.Get(uri)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var ikvm IKVM
+	err = json.NewDecoder(resp.Body).Decode(&ikvm)
+	if err != nil {
+		return nil, err
+	}
+
+	ikvm.SetClient(c)
+	return &ikvm, nil
+}

--- a/oem/supermicro/ikvm.go
+++ b/oem/supermicro/ikvm.go
@@ -21,7 +21,7 @@ const (
 type IKVM struct {
 	common.Entity
 
-	OdataType        string        `json:"@odata.type"`
+	ODataType        string        `json:"@odata.type"`
 	CurrentInterface IKVMInterface `json:"Current interface"`
 	URI              string        `json:"URI"`
 

--- a/oem/supermicro/ikvm_test.go
+++ b/oem/supermicro/ikvm_test.go
@@ -1,0 +1,58 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package supermicro
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+var supermicroIKVMBodyHTML = `{
+    "@odata.type": "#IKVM.v1_0_1.IKVM",
+    "@odata.id": "/redfish/v1/Managers/1/Oem/Supermicro/IKVM",
+    "Id": "IKVM",
+    "Name": "IKVM",
+    "Current interface": "HTML 5",
+    "URI": "/redfish/ohkei8Quei5odeem.IKVM"
+}`
+
+var supermicroIKVMBodyJAVA = `{
+    "@odata.type": "#IKVM.v1_0_1.IKVM",
+    "@odata.id": "/redfish/v1/Managers/1/Oem/Supermicro/IKVM",
+    "Id": "IKVM",
+    "Name": "IKVM",
+    "Current interface": "JAVA plug-in"
+}`
+
+func TestSupermicroIKVM(t *testing.T) {
+	var ikvm *IKVM
+	err := json.NewDecoder(strings.NewReader(supermicroIKVMBodyJAVA)).Decode(&ikvm)
+
+	if err != nil {
+		t.Errorf("Error decoding IKVM-JAVA JSON: %v", err)
+	}
+
+	if ikvm.CurrentInterface != JavaIKVMInterface {
+		t.Errorf("Expected JAVA KVM interface, got: %s", ikvm.CurrentInterface)
+	}
+
+	if ikvm.URI != "" {
+		t.Errorf("JAVA KVM interface should have an empty URI, got %s", ikvm.URI)
+	}
+
+	err = json.NewDecoder(strings.NewReader(supermicroIKVMBodyHTML)).Decode(&ikvm)
+	if err != nil {
+		t.Errorf("Error decoding IKVM-HTML JSON: %v", err)
+	}
+
+	if ikvm.CurrentInterface != HTMLIKVMInterface {
+		t.Errorf("Expected HTML KVM interface, got %s", ikvm.CurrentInterface)
+	}
+
+	if ikvm.URI != "/redfish/ohkei8Quei5odeem.IKVM" {
+		t.Errorf("Expected HTML KVM interface URI \"/redfish/ohkei8Quei5odeem.IKVM\", got %s", ikvm.URI)
+	}
+}

--- a/oem/supermicro/manager.go
+++ b/oem/supermicro/manager.go
@@ -40,13 +40,13 @@ func FromManager(manager *redfish.Manager) (Manager, error) {
 }
 
 func (manager *Manager) NTP() (*NTP, error) {
-	return GetNTP(manager.Client, string(manager.Oem.Supermicro.NTP))
+	return GetNTP(manager.GetClient(), string(manager.Oem.Supermicro.NTP))
 }
 
 func (manager *Manager) Syslog() (*Syslog, error) {
-	return GetSyslog(manager.Client, string(manager.Oem.Supermicro.Syslog))
+	return GetSyslog(manager.GetClient(), string(manager.Oem.Supermicro.Syslog))
 }
 
 func (manager *Manager) IKVM() (*IKVM, error) {
-	return GetIKVM(manager.Client, string(manager.Oem.Supermicro.IKVM))
+	return GetIKVM(manager.GetClient(), string(manager.Oem.Supermicro.IKVM))
 }

--- a/oem/supermicro/manager.go
+++ b/oem/supermicro/manager.go
@@ -1,0 +1,53 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package supermicro
+
+import (
+	"encoding/json"
+
+	"github.com/stmcginnis/gofish/common"
+	"github.com/stmcginnis/gofish/redfish"
+)
+
+type Manager struct {
+	redfish.Manager
+	Oem ManagerOem
+}
+
+type ManagerOem struct {
+	Supermicro ManagerOemSupermicro
+}
+
+type ManagerOemSupermicro struct {
+	OdataType string `json:"@odata.type"`
+	NTP       common.Link
+	Syslog    common.Link
+	IKVM      common.Link
+	m         *redfish.Manager
+}
+
+func FromManager(manager *redfish.Manager) (Manager, error) {
+	var oem ManagerOem
+	_ = json.Unmarshal(manager.Oem, &oem)
+
+	oem.Supermicro.m = manager
+
+	return Manager{
+		Manager: *manager,
+		Oem:     oem,
+	}, nil
+}
+
+func (manager *ManagerOemSupermicro) NTPs() (*NTP, error) {
+	return GetNTP(manager.m.Client, string(manager.NTP))
+}
+
+func (manager *ManagerOemSupermicro) Syslogs() (*Syslog, error) {
+	return GetSyslog(manager.m.Client, string(manager.Syslog))
+}
+
+func (manager *ManagerOemSupermicro) IKVMs() (*IKVM, error) {
+	return GetIKVM(manager.m.Client, string(manager.IKVM))
+}

--- a/oem/supermicro/manager.go
+++ b/oem/supermicro/manager.go
@@ -19,7 +19,7 @@ type Manager struct {
 
 type ManagerOem struct {
 	Supermicro struct {
-		OdataType string `json:"@odata.type"`
+		ODataType string `json:"@odata.type"`
 		NTP       common.Link
 		Syslog    common.Link
 		IKVM      common.Link

--- a/oem/supermicro/manager_test.go
+++ b/oem/supermicro/manager_test.go
@@ -1,0 +1,162 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package supermicro
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stmcginnis/gofish/redfish"
+)
+
+const managerBody = `{
+    "@odata.type": "#Manager.v1_5_2.Manager",
+    "@odata.id": "/redfish/v1/Managers/1",
+    "Id": "1",
+    "Name": "Manager",
+    "Description": "BMC",
+    "ManagerType": "BMC",
+    "UUID": "00000000-0000-0000-0000-AC1F6B3FF75A",
+    "Model": "ASPEED",
+    "FirmwareVersion": "01.00.17",
+    "DateTime": "2022-10-19T14:29:05Z",
+    "DateTimeLocalOffset": "+00:00",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "GraphicalConsole": {
+        "ServiceEnabled": true,
+        "MaxConcurrentSessions": 4,
+        "ConnectTypesSupported": [
+            "KVMIP"
+        ]
+    },
+    "SerialConsole": {
+        "ServiceEnabled": true,
+        "MaxConcurrentSessions": 1,
+        "ConnectTypesSupported": [
+            "SSH",
+            "IPMI"
+        ]
+    },
+    "CommandShell": {
+        "ServiceEnabled": true,
+        "MaxConcurrentSessions": 0,
+        "ConnectTypesSupported": [
+            "SSH"
+        ]
+    },
+    "EthernetInterfaces": {
+        "@odata.id": "/redfish/v1/Managers/1/EthernetInterfaces"
+    },
+    "HostInterfaces": {
+        "@odata.id": "/redfish/v1/Managers/1/HostInterfaces"
+    },
+    "SerialInterfaces": {
+        "@odata.id": "/redfish/v1/Managers/1/SerialInterfaces"
+    },
+    "NetworkProtocol": {
+        "@odata.id": "/redfish/v1/Managers/1/NetworkProtocol"
+    },
+    "LogServices": {
+        "@odata.id": "/redfish/v1/Managers/1/LogServices"
+    },
+    "VirtualMedia": {
+        "@odata.id": "/redfish/v1/Managers/1/VirtualMedia"
+    },
+    "Links": {
+        "ManagerForServers": [
+            {
+                "@odata.id": "/redfish/v1/Systems/1"
+            }
+        ],
+        "ManagerForChassis": [
+            {
+                "@odata.id": "/redfish/v1/Chassis/1"
+            }
+        ],
+        "Oem": {}
+    },
+    "Actions": {
+        "Oem": {
+            "#SmcManagerConfig.Reset": {
+                "target": "/redfish/v1/Managers/1/Actions/Oem/SmcManagerConfig.Reset",
+                "@Redfish.ActionInfo": "/redfish/v1/Managers/1/Oem/Supermicro/ResetActionInfo"
+            }
+        },
+        "#Manager.Reset": {
+            "target": "/redfish/v1/Managers/1/Actions/Manager.Reset"
+        }
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcManagerExtensions.v1_0_0.Manager",
+            "SMTP": {
+                "@odata.id": "/redfish/v1/Managers/1/Oem/Supermicro/SMTP"
+            },
+            "RADIUS": {
+                "@odata.id": "/redfish/v1/Managers/1/Oem/Supermicro/RADIUS"
+            },
+            "MouseMode": {
+                "@odata.id": "/redfish/v1/Managers/1/Oem/Supermicro/MouseMode"
+            },
+            "NTP": {
+                "@odata.id": "/redfish/v1/Managers/1/Oem/Supermicro/NTP"
+            },
+            "IPAccessControl": {
+                "@odata.id": "/redfish/v1/Managers/1/Oem/Supermicro/IPAccessControl"
+            },
+            "SMCRAKP": {
+                "@odata.id": "/redfish/v1/Managers/1/Oem/Supermicro/SMCRAKP"
+            },
+            "SNMP": {
+                "@odata.id": "/redfish/v1/Managers/1/Oem/Supermicro/SNMP"
+            },
+            "Syslog": {
+                "@odata.id": "/redfish/v1/Managers/1/Oem/Supermicro/Syslog"
+            },
+            "SysLockdown": {
+                "@odata.id": "/redfish/v1/Managers/1/Oem/Supermicro/SysLockdown"
+            },
+            "Snooping": {
+                "@odata.id": "/redfish/v1/Managers/1/Oem/Supermicro/Snooping"
+            },
+            "FanMode": {
+                "@odata.id": "/redfish/v1/Managers/1/Oem/Supermicro/FanMode"
+            },
+            "IKVM": {
+                "@odata.id": "/redfish/v1/Managers/1/Oem/Supermicro/IKVM"
+            },
+            "KCSInterface": {
+                "@odata.id": "/redfish/v1/Managers/1/Oem/Supermicro/KCSInterface"
+            },
+            "LicenseManager": {
+                "@odata.id": "/redfish/v1/Managers/1/LicenseManager"
+            }
+        }
+    }
+}`
+
+func TestManager(t *testing.T) {
+	var manager *redfish.Manager
+	err := json.NewDecoder((strings.NewReader(managerBody))).Decode(&manager)
+
+	if err != nil {
+		t.Errorf("Error decoding JSON: %v", err)
+	}
+
+	supermicroManager, err := FromManager(manager)
+	if err != nil {
+		t.Errorf("Convert manager failed: %v", err)
+		return
+	}
+
+	var emptyManager ManagerOem
+	if supermicroManager.Oem == emptyManager {
+		t.Errorf("Manager is empty")
+	}
+}

--- a/oem/supermicro/ntp.go
+++ b/oem/supermicro/ntp.go
@@ -1,0 +1,77 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package supermicro
+
+import (
+	"encoding/json"
+	"reflect"
+
+	"github.com/stmcginnis/gofish/common"
+)
+
+type NTP struct {
+	common.Entity
+
+	OdataType          string `json:"@odata.type"`
+	NTPEnable          bool   `json:"NTPEnable"`
+	PrimaryNTPServer   string `json:"PrimaryNTPServer"`
+	SecondaryNTPServer string `json:"SecondaryNTPServer"`
+	DaylightSavingTime bool   `json:"DaylightSavingTime"`
+
+	rawData []byte
+}
+
+func (ntp *NTP) UnmarshalJSON(b []byte) error {
+	type temp NTP
+
+	var rtn temp
+	err := json.Unmarshal(b, &rtn)
+	if err != nil {
+		return err
+	}
+
+	*ntp = NTP(rtn)
+
+	ntp.rawData = b
+
+	return nil
+}
+
+func (ntp *NTP) Update() error {
+	original := new(NTP)
+	err := original.UnmarshalJSON(ntp.rawData)
+	if err != nil {
+		return err
+	}
+
+	readWriteFields := []string{
+		"NTPEnable",
+		"PrimaryNTPServer",
+		"SecondaryNTPServer",
+		"DaylightSavingTime",
+	}
+
+	originalElement := reflect.ValueOf(original).Elem()
+	currentElement := reflect.ValueOf(ntp).Elem()
+
+	return ntp.Entity.Update(originalElement, currentElement, readWriteFields)
+}
+
+func GetNTP(c common.Client, uri string) (*NTP, error) {
+	resp, err := c.Get(uri)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var ntp NTP
+	err = json.NewDecoder(resp.Body).Decode(&ntp)
+	if err != nil {
+		return nil, err
+	}
+
+	ntp.SetClient(c)
+	return &ntp, nil
+}

--- a/oem/supermicro/ntp.go
+++ b/oem/supermicro/ntp.go
@@ -14,7 +14,7 @@ import (
 type NTP struct {
 	common.Entity
 
-	OdataType          string `json:"@odata.type"`
+	ODataType          string `json:"@odata.type"`
 	NTPEnable          bool   `json:"NTPEnable"`
 	PrimaryNTPServer   string `json:"PrimaryNTPServer"`
 	SecondaryNTPServer string `json:"SecondaryNTPServer"`

--- a/oem/supermicro/ntp_test.go
+++ b/oem/supermicro/ntp_test.go
@@ -1,0 +1,47 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package supermicro
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+var supermicroNTPBody = `{
+    "@odata.type": "#NTP.v1_0_1.NTP",
+    "@odata.id": "/redfish/v1/Managers/1/Oem/Supermicro/NTP",
+    "Id": "NTP",
+    "Name": "NTP Service",
+    "NTPEnable": true,
+    "PrimaryNTPServer": "192.168.0.1",
+    "SecondaryNTPServer": "192.168.1.1",
+    "DaylightSavingTime": false
+}`
+
+func TestSupermicroNTPOem(t *testing.T) {
+	var ntp *NTP
+	err := json.NewDecoder(strings.NewReader(supermicroNTPBody)).Decode(&ntp)
+
+	if err != nil {
+		t.Errorf("Error decoding JSON: %v", err)
+	}
+
+	if !ntp.NTPEnable {
+		t.Errorf("NTPEnable should be true")
+	}
+
+	if ntp.PrimaryNTPServer != "192.168.0.1" {
+		t.Errorf("Expected primary NTP server at 192.168.0.1, got %s", ntp.PrimaryNTPServer)
+	}
+
+	if ntp.SecondaryNTPServer != "192.168.1.1" {
+		t.Errorf("Expected secondary NTP server at 192.168.1.1, got %s", ntp.SecondaryNTPServer)
+	}
+
+	if ntp.DaylightSavingTime {
+		t.Errorf("DaylightSavingTime should be false")
+	}
+}

--- a/oem/supermicro/syslog.go
+++ b/oem/supermicro/syslog.go
@@ -1,0 +1,74 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package supermicro
+
+import (
+	"encoding/json"
+	"reflect"
+
+	"github.com/stmcginnis/gofish/common"
+)
+
+type Syslog struct {
+	common.Entity
+
+	OdataType        string `json:"@odata.type"`
+	EnableSyslog     bool   `json:"EnableSyslog"`
+	SyslogServer     string `json:"SyslogServer"`
+	SyslogPortNumber int    `json:"SyslogPortNumber"`
+
+	rawData []byte
+}
+
+func (syslog *Syslog) UnmarshalJSON(b []byte) error {
+	type temp Syslog
+
+	var rtn temp
+	err := json.Unmarshal(b, &rtn)
+	if err != nil {
+		return err
+	}
+
+	*syslog = Syslog(rtn)
+	syslog.rawData = b
+
+	return nil
+}
+
+func (syslog *Syslog) Update() error {
+	original := new(Syslog)
+	err := original.UnmarshalJSON(syslog.rawData)
+	if err != nil {
+		return err
+	}
+
+	readWriteFields := []string{
+		"EnableSyslog",
+		"SyslogServer",
+		"SyslogPortNumber",
+	}
+
+	originalElement := reflect.ValueOf(original).Elem()
+	currentElement := reflect.ValueOf(syslog).Elem()
+
+	return syslog.Entity.Update(originalElement, currentElement, readWriteFields)
+}
+
+func GetSyslog(c common.Client, uri string) (*Syslog, error) {
+	resp, err := c.Get(uri)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var syslog Syslog
+	err = json.NewDecoder(resp.Body).Decode(&syslog)
+	if err != nil {
+		return nil, err
+	}
+
+	syslog.SetClient(c)
+	return &syslog, nil
+}

--- a/oem/supermicro/syslog.go
+++ b/oem/supermicro/syslog.go
@@ -14,7 +14,7 @@ import (
 type Syslog struct {
 	common.Entity
 
-	OdataType        string `json:"@odata.type"`
+	ODataType        string `json:"@odata.type"`
 	EnableSyslog     bool   `json:"EnableSyslog"`
 	SyslogServer     string `json:"SyslogServer"`
 	SyslogPortNumber int    `json:"SyslogPortNumber"`

--- a/oem/supermicro/syslog_test.go
+++ b/oem/supermicro/syslog_test.go
@@ -1,0 +1,42 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package supermicro
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+var supermicroSyslogBody = `{
+    "@odata.type": "#Syslog.v1_0_1.Syslog",
+    "@odata.id": "/redfish/v1/Managers/1/Oem/Supermicro/Syslog",
+    "Id": "Syslog",
+    "Name": "Syslog",
+    "EnableSyslog": true,
+    "SyslogServer": "192.168.0.1",
+    "SyslogPortNumber": 514
+}`
+
+func TestSupermicroSyslogOem(t *testing.T) {
+	var syslog *Syslog
+	err := json.NewDecoder(strings.NewReader(supermicroSyslogBody)).Decode(&syslog)
+
+	if err != nil {
+		t.Errorf("Error decoding JSON: %v", err)
+	}
+
+	if !syslog.EnableSyslog {
+		t.Errorf("EnableSyslog should be true")
+	}
+
+	if syslog.SyslogServer != "192.168.0.1" {
+		t.Errorf("Expected syslog server at 192.168.0.1, got %s", syslog.SyslogServer)
+	}
+
+	if syslog.SyslogPortNumber != 514 {
+		t.Errorf("Expected syslog server port 514, got %d", syslog.SyslogPortNumber)
+	}
+}


### PR DESCRIPTION
This PR includes functions for:
* IKVM (Java/HTML5)
* NTP (Enabled/Servers/DST)
* Syslog (Enabled/Server)

I'd appreciate any hints regarding the `supermicro.Manager`-structure and how custom manager extensions should be integrated - while it does work accessing the syslog configuration using `smm.supermicroManager.Oem.Supermicro.Syslogs()` seems to be rather awkward.