### PR TITLE
client.go: fixes a panic when the client.auth is nil

### DIFF
--- a/client.go
+++ b/client.go
@@ -251,7 +251,7 @@ func (c *APIClient) CloneWithSession() (*APIClient, error) {
 // GetSession retrieves the session data from an initialized APIClient. An error
 // is returned if the client is not authenticated.
 func (c *APIClient) GetSession() (*Session, error) {
-	if c.auth.Session == "" {
+	if c.auth == nil || c.auth.Session == "" {
 		return nil, fmt.Errorf("client not authenticated")
 	}
 	return &Session{


### PR DESCRIPTION
The panic occurs if a caller of APIClient attempts to run GetSession() when APIClient.auth has not yet been set.