### PR TITLE
bugfix: some dell machine /redfish/v1/systems without memeber@count

### DIFF
--- a/common/collection.go
+++ b/common/collection.go
@@ -35,7 +35,8 @@ func (c *Collection) UnmarshalJSON(b []byte) error {
 	c.ItemLinks = t.Links.ToStrings()
 
 	// Swordfish has them at the root
-	if len(c.ItemLinks) == 0 && t.Count > 0 {
+	if len(c.ItemLinks) == 0 &&
+		(t.Count > 0 || t.ODataCount > 0) {
 		c.ItemLinks = t.Members.ToStrings()
 	}
 

--- a/common/types.go
+++ b/common/types.go
@@ -146,8 +146,9 @@ func (l Links) ToStrings() []string {
 
 // LinksCollection contains links to other entities
 type LinksCollection struct {
-	Count   int   `json:"Members@odata.count"`
-	Members Links `json:"Members"`
+	ODataCount int   `json:"@odata.count"`
+	Count      int   `json:"Members@odata.count"`
+	Members    Links `json:"Members"`
 }
 
 // ToStrings will extract the URI for all linked entities.


### PR DESCRIPTION
some dell machine not provider the `Members@odata.count` field

```
curl https://192.168.156.212/redfish/v1/Managers/iDRAC.Embedded.1 -u username:passwd --insecure -k --ciphers DEFAULT@SECLEVEL=1 | jq|grep FirmwareVersion
...
  "FirmwareVersion": "2.30.30.30",
```

so the system info as follow

```json
{
  "@odata.context": "/redfish/v1/$metadata#Systems",
  "@odata.count": 1,
  "@odata.id": "/redfish/v1/Systems",
  "@odata.type": "#ComputerSystem.1.0.0.ComputerSystemCollection",
  "Description": "Collection of Computer Systems",
  "Members": [
    {
      "@odata.id": "/redfish/v1/Systems/System.Embedded.1"
    }
  ],
  "Name": "Computer System Collection"
}
```

and you can to compare with the stand format response( this body copy from another machine)

```json
{
  "@odata.context": "/redfish/v1/$metadata#ComputerSystemCollection.ComputerSystemCollection",
  "@odata.id": "/redfish/v1/Systems",
  "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
  "Description": "Collection of Computer Systems",
  "Members": [
    {
      "@odata.id": "/redfish/v1/Systems/System.Embedded.1"
    }
  ],
  "Members@odata.count": 1,
  "Name": "Computer System Collection"
}
```

Signed-off-by: Guohao Wang <guohao.wang@shopee.com>