### PR TITLE
bugfix: fix SpeedGbps type with float32

### DIFF
--- a/redfish/storage.go
+++ b/redfish/storage.go
@@ -263,7 +263,7 @@ type StorageController struct {
 	// interface (in Gigabits per second). The interface specified connects the
 	// controller to the storage devices, not the controller to a host (e.g. SAS
 	// bus, not PCIe host bus).
-	SpeedGbps int
+	SpeedGbps float32
 	// Status shall contain any status or health properties of the resource.
 	Status common.Status
 	// SupportedControllerProtocols shall be the set of protocols this storage


### PR DESCRIPTION
update the data type of SpeedGbps

```json
{
  "@odata.context": "/redfish/v1/$metadata#Systems/Members/1/Storages/Members/$entity",
  "@odata.id": "/redfish/v1/Systems/1/Storages/RAIDStorage0",
  "@odata.type": "#Storage.v1_7_0.Storage",
  "Id": "RAIDStorage0",
  "Name": "RAIDStorage0",
  "StorageControllers@odata.count": 1,
  "StorageControllers": [
    {
      "MemberId": "0",
      "@odata.id": "/redfish/v1/Systems/1/Storages/RAIDStorage0#/StorageControllers/0",
      "@odata.type": "#Storage.v1_7_0.StorageController",
      "Name": "RAID Card1 Controller",
      "Description": "RAID Controller",
      "Status": {
        "State": "Enabled",
        "Oem": {
          "Huawei": {
            "FaultDetails": null
          }
        },
        "Health": "OK"
      },
      "SpeedGbps": 12.0,
      "FirmwareVersion": "5.030.00-1512",
      "SupportedDeviceProtocols": [
        "SAS"
      ],
      "SerialNumber": "024JMY6TJB005180",
      "Manufacturer": "Broadcom",
      "Model": "SAS3508",
      "CacheSummary": {
        "TotalCacheSizeMiB": 2048
      },
      "SupportedRAIDTypes": [
        "RAID0",
        "RAID1",
        "RAID5",
        "RAID6",
        "RAID10",
        "RAID50",
        "RAID60"
      ],
      "Oem": {
        "Huawei": {
          "SupportedRAIDLevels": [
            "RAID0",
            "RAID1",
            "RAID5",
            "RAID6",
            "RAID10",
            "RAID50",
            "RAID60"
          ],
          "SupportedModes": [
            "RAID"
          ],
          "VolumeSupported": true,
          "ReadPolicy": {
            "Configurable": true,
            "SupportedPolicy": [
              "NoReadAhead",
              "ReadAhead"
            ]
          },
          "WritePolicy": {
            "Configurable": true,
            "SupportedPolicy": [
              "WriteThrough",
              "WriteBackWithBBU",
              "WriteBack"
            ]
          },
          "CachePolicy": {
            "Configurable": true,
            "SupportedPolicy": [
              "CachedIO",
              "DirectIO"
            ]
          },
          "AccessPolicy": {
            "Configurable": true,
            "SupportedPolicy": [
              "ReadWrite",
              "ReadOnly",
              "Blocked"
            ]
          },
          "DriveCachePolicy": {
            "Configurable": true,
            "SupportedPolicy": [
              "Unchanged",
              "Enabled",
              "Disabled"
            ]
          },
          "AssociatedCard": {
            "@odata.id": "/redfish/v1/Chassis/1/Boards/mainboardRAIDCard1"
          },
          "Mode": "RAID",
          "CachePinnedState": false,
          "Type": "SAS3508",
          "SASAddress": "5f063f9efd3d3000",
          "ConfigurationVersion": "5.0300.03-0043",
          "MemorySizeMiB": 2048,
          "MaintainPDFailHistory": true,
          "CopyBackState": true,
          "SmarterCopyBackState": true,
          "JBODState": false,
          "OOBSupport": true,
          "CapacitanceName": "CVPM02",
          "CapacitanceStatus": {
            "State": "Enabled",
            "Severity": "Informational",
            "Health": "OK",
            "FaultDetails": null
          },
          "DriverInfo": {
            "DriverName": null,
            "DriverVersion": null
          },
          "DDRECCCount": 0,
          "MinStripeSizeBytes": 65536,
          "MaxStripeSizeBytes": 1048576,
          "PHYStatus": [
            {
              "PHYId": 0,
              "InvalidDwordCount": 0,
              "LossDwordSyncCount": 0,
              "PHYResetProblemCount": 0,
              "RunningDisparityErrorCount": 0
            },
            {
              "PHYId": 1,
              "InvalidDwordCount": 0,
              "LossDwordSyncCount": 0,
              "PHYResetProblemCount": 0,
              "RunningDisparityErrorCount": 0
            },
            {
              "PHYId": 2,
              "InvalidDwordCount": 0,
              "LossDwordSyncCount": 0,
              "PHYResetProblemCount": 0,
              "RunningDisparityErrorCount": 0
            },
            {
              "PHYId": 3,
              "InvalidDwordCount": 0,
              "LossDwordSyncCount": 0,
              "PHYResetProblemCount": 0,
              "RunningDisparityErrorCount": 0
            },
            {
              "PHYId": 4,
              "InvalidDwordCount": 0,
              "LossDwordSyncCount": 0,
              "PHYResetProblemCount": 0,
              "RunningDisparityErrorCount": 0
            },
            {
              "PHYId": 5,
              "InvalidDwordCount": 0,
              "LossDwordSyncCount": 0,
              "PHYResetProblemCount": 0,
              "RunningDisparityErrorCount": 0
            },
            {
              "PHYId": 6,
              "InvalidDwordCount": 0,
              "LossDwordSyncCount": 0,
              "PHYResetProblemCount": 0,
              "RunningDisparityErrorCount": 0
            },
            {
              "PHYId": 7,
              "InvalidDwordCount": 0,
              "LossDwordSyncCount": 0,
              "PHYResetProblemCount": 0,
              "RunningDisparityErrorCount": 0
            }
          ],
          "BDF": "0000:17:02.0"
        }
      }
    }
  ],
  "Drives@odata.count": 2,
  "Drives": [
    {
      "@odata.id": "/redfish/v1/Chassis/1/Drives/HDDPlaneDisk0",
      "Id": "HDDPlaneDisk0",
      "Name": "Disk0",
      "MediaType": "HDD",
      "CapacityBytes": 1198999470080,
      "Oem": {
        "Huawei": {
          "DriveID": 0,
          "FirmwareStatus": "Online",
          "IsEPD": false,
          "RelatedArrayInfo": {
            "Members": [
              "Disk0",
              "Disk1"
            ],
            "FreeSpaceMiBPerDrive": 0,
            "TotalFreeSpaceMiB": 0,
            "FreeBlocksSpaceMiB": [

            ],
            "NumDrivePerSpan": 2,
            "VolumeRaidLevel": "RAID1"
          }
        }
      }
    },
    {
      "@odata.id": "/redfish/v1/Chassis/1/Drives/HDDPlaneDisk1",
      "Id": "HDDPlaneDisk1",
      "Name": "Disk1",
      "MediaType": "HDD",
      "CapacityBytes": 1198999470080,
      "Oem": {
        "Huawei": {
          "DriveID": 1,
          "FirmwareStatus": "Online",
          "IsEPD": false,
          "RelatedArrayInfo": {
            "Members": [
              "Disk0",
              "Disk1"
            ],
            "FreeSpaceMiBPerDrive": 0,
            "TotalFreeSpaceMiB": 0,
            "FreeBlocksSpaceMiB": [

            ],
            "NumDrivePerSpan": 2,
            "VolumeRaidLevel": "RAID1"
          }
        }
      }
    }
  ],
  "Volumes": {
    "@odata.id": "/redfish/v1/Systems/1/Storages/RAIDStorage0/Volumes"
  },
  "Actions": {
    "Oem": {
      "Huawei": {
        "#Storage.RestoreStorageControllerDefaultSettings": {
          "target": "/redfish/v1/Systems/1/Storages/RAIDStorage0/Actions/Oem/Huawei/Storage.RestoreStorageControllerDefaultSettings",
          "@Redfish.ActionInfo": "/redfish/v1/Systems/1/Storages/RAIDStorage0/RestoreStorageControllerDefaultSettingsActionInfo"
        },
        "#Storage.ImportForeignConfig": {
          "target": "/redfish/v1/Systems/1/Storages/RAIDStorage0/Actions/Oem/Huawei/Storage.ImportForeignConfig",
          "@Redfish.ActionInfo": "/redfish/v1/Systems/1/Storages/RAIDStorage0/ImportForeignConfigActionInfo"
        }
      }
    }
  }
}
```

Signed-off-by: Guohao Wang <guohao.wang@shopee.com>