### PR TITLE
add oem to AccountService

### DIFF
--- a/redfish/accountservice.go
+++ b/redfish/accountservice.go
@@ -250,6 +250,10 @@ type AccountService struct {
 	Status common.Status
 	// rawData holds the original serialized JSON so we can compare updates.
 	rawData []byte
+	// Oem shall contain the OEM extensions. All values for properties that
+	// this object contains shall conform to the Redfish Specification
+	// described requirements.
+	Oem interface{}
 }
 
 // UnmarshalJSON unmarshals an AccountService object from the raw JSON.

--- a/redfish/accountservice_test.go
+++ b/redfish/accountservice_test.go
@@ -29,6 +29,12 @@ var accountServiceBody = `{
 			"Roles": {
 				"@odata.id": "/redfish/v1/AccountService/Roles"
 			}
+		},
+		"Oem": {
+			"VendorName": {
+				"PasswordChangeOnNextLogin": false,
+				"PasswordChangeOnFirstAccess": false
+			}
 		}
 	}`
 
@@ -64,6 +70,31 @@ func TestAccountService(t *testing.T) {
 
 	if result.roles != "/redfish/v1/AccountService/Roles" {
 		t.Errorf("Received invalid Roles: %s", result.roles)
+	}
+
+	switch oem := result.Oem.(type) {
+	case map[string]interface{}:
+		for vendor, values := range oem {
+			if vendor != "VendorName" {
+				t.Errorf("Received invalid Oem vendor: %s", vendor)
+			}
+			switch val := values.(type) {
+			case map[string]interface{}:
+				for k, v := range val {
+					if k != "PasswordChangeOnNextLogin" && k != "PasswordChangeOnFirstAccess" {
+						t.Errorf("Received invalid Oem key %s for vendor: %s", k, vendor)
+					}
+					if k == "PasswordChangeOnNextLogin" && v != false {
+						t.Errorf("Received invalid OemInfo1: %s", v)
+					}
+					if v == "PasswordChangeOnFirstAccess" && v != false {
+						t.Errorf("Received invalid OemInfoN: %s", v)
+					}
+				}
+			}
+		}
+	default:
+		t.Errorf("Received invalid Oem")
 	}
 }
 


### PR DESCRIPTION
This PR adds the `Oem` to the `AccountService`, in my case needed for setting Global Login Options for Lenovo 