### PR TITLE
feat: Add task service support

### DIFF
--- a/redfish/taskervice.go
+++ b/redfish/taskervice.go
@@ -1,0 +1,80 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package redfish
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/stmcginnis/gofish/common"
+)
+
+// TaskService is used to represent the task service offered by the redfish API
+type TaskService struct {
+	common.Entity
+
+	// ODataContext is the odata context.
+	ODataContext string `json:"@odata.context"`
+	// ODataType is the odata type.
+	ODataType string `json:"@odata.type"`
+	// Description provides a description of this resource.
+	Description string
+	// CompletedTaskOverWritePolicy how to handle the completed tasks.
+	CompletedTaskOverWritePolicy string
+	// DateTime system time.
+	DateTime time.Time
+	// LifeCycleEventOnTaskStateChange whether an event is reported when the task status is changed.
+	LifeCycleEventOnTaskStateChange bool
+	// ServiceEnabled indicates whether this service isenabled.
+	ServiceEnabled bool
+	// Status describes the status and health of a resource and its children.
+	Status common.Status
+	// tasks points towards the tasks store endpoint
+	tasks string
+	// rawData holds the original serialized JSON so we can compare updates.
+	rawData []byte
+}
+
+// UnmarshalJSON unmarshals a TaskService object from the raw JSON.
+func (taskService *TaskService) UnmarshalJSON(b []byte) error {
+	type temp TaskService
+	var t struct {
+		temp
+		Tasks common.Link
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	// Extract the links to other entities for later
+	*taskService = TaskService(t.temp)
+	taskService.tasks = t.Tasks.String()
+	taskService.rawData = b
+
+	return nil
+}
+
+// GetTaskService will get a TaskService instance from the service.
+func GetTaskService(c common.Client, uri string) (*TaskService, error) {
+	resp, err := c.Get(uri)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var taskService TaskService
+	err = json.NewDecoder(resp.Body).Decode(&taskService)
+	if err != nil {
+		return nil, err
+	}
+	taskService.SetClient(c)
+	return &taskService, nil
+}
+
+// Tasks gets the collection of tasks of this task service
+func (taskService *TaskService) Tasks() ([]*Task, error) {
+	return ListReferencedTasks(taskService.Client, taskService.tasks)
+}

--- a/redfish/taskervice_test.go
+++ b/redfish/taskervice_test.go
@@ -1,0 +1,56 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package redfish
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stmcginnis/gofish/common"
+)
+
+var simpleTaskServiceBody = `{
+   "@odata.context":"/redfish/v1/$metadata#TaskService.TaskService",
+   "@odata.etag":"\"1614826331\"",
+   "@odata.id":"/redfish/v1/TaskService",
+   "@odata.type":"#TaskService.v1_1_4.TaskService",
+   "CompletedTaskOverWritePolicy":"Oldest",
+   "DateTime":"2022-10-10T00:04:51-05:00",
+   "Description":"Task Service",
+   "Id":"TaskService",
+   "LifeCycleEventOnTaskStateChange":true,
+   "Name":"Task Service",
+   "ServiceEnabled":true,
+   "Status":{
+      "Health":"OK",
+      "State":"Enabled"
+   },
+   "Tasks":{
+      "@odata.id":"/redfish/v1/TaskService/Tasks"
+   }
+}`
+
+func TestTaskService(t *testing.T) {
+	var result TaskService
+	assertMessage := func(t testing.TB, got string, want string) {
+		t.Helper()
+		if got != want {
+			t.Errorf("got %s, want %s", got, want)
+		}
+	}
+
+	t.Run("Check default redfish fields", func(t *testing.T) {
+		c := &common.TestClient{}
+		result.Client = c
+
+		err := json.NewDecoder(strings.NewReader(simpleTaskServiceBody)).Decode(&result)
+		if err != nil {
+			t.Errorf("Error decoding JSON: %s", err)
+		}
+		assertMessage(t, result.tasks, "/redfish/v1/TaskService/Tasks")
+		assertMessage(t, result.CompletedTaskOverWritePolicy, "Oldest")
+	})
+}

--- a/serviceroot.go
+++ b/serviceroot.go
@@ -253,6 +253,11 @@ func (serviceroot *Service) Tasks() ([]*redfish.Task, error) {
 	return redfish.ListReferencedTasks(serviceroot.Client, serviceroot.tasks)
 }
 
+// TaskService gets the task service instance
+func (serviceroot *Service) TaskService() (*redfish.TaskService, error) {
+	return redfish.GetTaskService(serviceroot.Client, serviceroot.tasks)
+}
+
 // CreateSession creates a new session and returns the token and id
 func (serviceroot *Service) CreateSession(username, password string) (*redfish.AuthToken, error) {
 	return redfish.CreateSession(serviceroot.Client, serviceroot.sessions, username, password)


### PR DESCRIPTION
```
"Product": "AMI Redfish Server"

"Tasks": {
    "@odata.id": "[/redfish/v1/TaskService](https://ip/redfish/v1/TaskService)"
},

{
   "@odata.context":"/redfish/v1/$metadata#TaskService.TaskService",
   "@odata.etag":"\"1614826331\"",
   "@odata.id":"/redfish/v1/TaskService",
   "@odata.type":"#TaskService.v1_1_4.TaskService",
   "CompletedTaskOverWritePolicy":"Oldest",
   "DateTime":"2022-10-10T00:04:51-05:00",
   "Description":"Task Service",
   "Id":"TaskService",
   "LifeCycleEventOnTaskStateChange":true,
   "Name":"Task Service",
   "ServiceEnabled":true,
   "Status":{
      "Health":"OK",
      "State":"Enabled"
   },
   "Tasks":{
      "@odata.id":"/redfish/v1/TaskService/Tasks"
   }
}
```