### PR TITLE
Clean up TaskService testing

### DIFF
--- a/redfish/taskervice.go
+++ b/redfish/taskervice.go
@@ -33,8 +33,6 @@ type TaskService struct {
 	Status common.Status
 	// tasks points towards the tasks store endpoint
 	tasks string
-	// rawData holds the original serialized JSON so we can compare updates.
-	rawData []byte
 }
 
 // UnmarshalJSON unmarshals a TaskService object from the raw JSON.
@@ -53,7 +51,6 @@ func (taskService *TaskService) UnmarshalJSON(b []byte) error {
 	// Extract the links to other entities for later
 	*taskService = TaskService(t.temp)
 	taskService.tasks = t.Tasks.String()
-	taskService.rawData = b
 
 	return nil
 }

--- a/redfish/taskervice_test.go
+++ b/redfish/taskervice_test.go
@@ -8,8 +8,6 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
-
-	"github.com/stmcginnis/gofish/common"
 )
 
 var simpleTaskServiceBody = `{
@@ -35,22 +33,25 @@ var simpleTaskServiceBody = `{
 
 func TestTaskService(t *testing.T) {
 	var result TaskService
-	assertMessage := func(t testing.TB, got string, want string) {
-		t.Helper()
-		if got != want {
-			t.Errorf("got %s, want %s", got, want)
-		}
+	err := json.NewDecoder(strings.NewReader(simpleTaskServiceBody)).Decode(&result)
+
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
 	}
 
-	t.Run("Check default redfish fields", func(t *testing.T) {
-		c := &common.TestClient{}
-		result.Client = c
+	if result.ID != "TaskService" {
+		t.Errorf("Received invalid ID: %s", result.ID)
+	}
 
-		err := json.NewDecoder(strings.NewReader(simpleTaskServiceBody)).Decode(&result)
-		if err != nil {
-			t.Errorf("Error decoding JSON: %s", err)
-		}
-		assertMessage(t, result.tasks, "/redfish/v1/TaskService/Tasks")
-		assertMessage(t, result.CompletedTaskOverWritePolicy, "Oldest")
-	})
+	if result.Name != "Task Service" {
+		t.Errorf("Received invalid name: %s", result.Name)
+	}
+
+	if result.tasks != "/redfish/v1/TaskService/Tasks" {
+		t.Errorf("Received invalid tasks link: %s", result.tasks)
+	}
+
+	if result.CompletedTaskOverWritePolicy != "Oldest" {
+		t.Errorf("Received %s completed task overwrite policy", result.CompletedTaskOverWritePolicy)
+	}
 }


### PR DESCRIPTION
Handling was causes failures in other tests. Clean things up to the simpler format used for most other objects.

Also removes `rawData` since this object does not have any update methods, so no reason to keep that data stored in memory.