### PR TITLE
correct processing sub processor

### DIFF
--- a/redfish/processor.go
+++ b/redfish/processor.go
@@ -321,7 +321,7 @@ type Processor struct {
 	Status common.Status
 	// SubProcessors shall be a link to a
 	// collection of type ProcessorCollection.
-	SubProcessors string
+	subProcessors string
 	// TDPWatts shall be the nominal Thermal
 	// Design Power (TDP) in watts.
 	TDPWatts int
@@ -376,6 +376,7 @@ func (processor *Processor) UnmarshalJSON(b []byte) error {
 		AccelerationFunctions common.Link
 		Assembly              common.Link
 		Metrics               common.Link
+		SubProcessors         common.Link
 		ProcessorMemory       common.Links
 		Links                 struct {
 			Chassis                  common.Link
@@ -431,6 +432,7 @@ func (processor *Processor) UnmarshalJSON(b []byte) error {
 	processor.pcieFunctions = t.Links.PCIeFunctions.ToStrings()
 	processor.PCIeFunctionsCount = t.Links.PCIeFunctionsCount
 	processor.metrics = t.Metrics.String()
+	processor.subProcessors = t.SubProcessors.String()
 
 	return nil
 }

--- a/redfish/processor_test.go
+++ b/redfish/processor_test.go
@@ -75,6 +75,9 @@ var processorBody = strings.NewReader(
 		"Metrics": {
 			"@odata.id": "/redfish/v1/Systems/1/Processors/1/ProcessorMetrics"
 		},
+		"SubProcessors": {
+			"@odata.id": "/redfish/v1/Systems/Self/Processors/CPU_1/SubProcessors"
+		},
 		"Model":"Intel(R) Xeon(R) Gold 6136 CPU @ 3.00GHz",
 		"Name":"CPU 2",
 		"Oem":{


### PR DESCRIPTION
faced with a device that is implemented according to the specification "#Processor.v1_5_1.Processor"
and the library did not properly process it

ex: 
`{
    "@odata.context": "/redfish/v1/$metadata#Processor.Processor",
    "@odata.etag": "\"1677574563\"",
    "@odata.id": "/redfish/v1/Systems/Self/Processors/CPU_1",
    "@odata.type": "#Processor.v1_5_1.Processor",
    "Id": "CPU_1",
    "Links": {
        "Chassis": {
            "@odata.id": "/redfish/v1/Chassis/Self"
        },
        "ConnectedProcessors": [
            {
                "@odata.id": "/redfish/v1/Systems/Self/Processors/CPU_1/SubProcessors/CPU_1_Core13"
            },
            {
                "@odata.id": "/redfish/v1/Systems/Self/Processors/CPU_1/SubProcessors/CPU_1_Core15"
            },
            {
                "@odata.id": "/redfish/v1/Systems/Self/Processors/CPU_1/SubProcessors/CPU_1_Core14"
            },
            {
                "@odata.id": "/redfish/v1/Systems/Self/Processors/CPU_1/SubProcessors/CPU_1_Core6"
            },
            {
                "@odata.id": "/redfish/v1/Systems/Self/Processors/CPU_1/SubProcessors/CPU_1_Core10"
            },
            {
                "@odata.id": "/redfish/v1/Systems/Self/Processors/CPU_1/SubProcessors/CPU_1_Core0"
            },
            {
                "@odata.id": "/redfish/v1/Systems/Self/Processors/CPU_1/SubProcessors/CPU_1_Core1"
            },
            {
                "@odata.id": "/redfish/v1/Systems/Self/Processors/CPU_1/SubProcessors/CPU_1_Core7"
            },
            {
                "@odata.id": "/redfish/v1/Systems/Self/Processors/CPU_1/SubProcessors/CPU_1_Core11"
            },
            {
                "@odata.id": "/redfish/v1/Systems/Self/Processors/CPU_1/SubProcessors/CPU_1_Core5"
            },
            {
                "@odata.id": "/redfish/v1/Systems/Self/Processors/CPU_1/SubProcessors/CPU_1_Core9"
            },
            {
                "@odata.id": "/redfish/v1/Systems/Self/Processors/CPU_1/SubProcessors/CPU_1_Core8"
            },
            {
                "@odata.id": "/redfish/v1/Systems/Self/Processors/CPU_1/SubProcessors/CPU_1_Core4"
            },
            {
                "@odata.id": "/redfish/v1/Systems/Self/Processors/CPU_1/SubProcessors/CPU_1_Core3"
            },
            {
                "@odata.id": "/redfish/v1/Systems/Self/Processors/CPU_1/SubProcessors/CPU_1_Core12"
            },
            {
                "@odata.id": "/redfish/v1/Systems/Self/Processors/CPU_1/SubProcessors/CPU_1_Core2"
            }
        ],
        "ConnectedProcessors@odata.count": 16
    },
    "Manufacturer": "Intel(R) Corporation",
    "MaxSpeedMHz": 4000,
    "Model": "Undefined",
    "Name": "CPU_1",
    "ProcessorArchitecture": "x86",
    "ProcessorId": {
        "EffectiveFamily": "Intel(R) Xeon(R) Gold 6226R CPU @ 2.90GHz"
    },
    "ProcessorType": "CPU",
    "Socket": "CPU1",
    "Status": {
        "Health": "OK",
        "State": "Enabled"
    },
    "SubProcessors": {
        "@odata.id": "/redfish/v1/Systems/Self/Processors/CPU_1/SubProcessors"
    },
    "TotalCores": 16,
    "TotalEnabledCores": 16,
    "TotalThreads": 32
}`