### PR TITLE
fix: add mutex to http client

### DIFF
--- a/client.go
+++ b/client.go
@@ -416,9 +416,6 @@ func (c *APIClient) RunRawRequestWithHeaders(method, url string, payloadBuffer i
 
 // runRawRequestWithHeaders actually performs the REST calls but allowing custom headers
 func (c *APIClient) runRawRequestWithHeaders(method, url string, payloadBuffer io.ReadSeeker, contentType string, customHeaders map[string]string) (*http.Response, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	if url == "" {
 		return nil, common.ConstructError(0, []byte("unable to execute request, no target provided"))
 	}
@@ -475,8 +472,9 @@ func (c *APIClient) runRawRequestWithHeaders(method, url string, payloadBuffer i
 			return nil, err
 		}
 	}
-
+	c.mu.Lock()
 	resp, err := c.HTTPClient.Do(req)
+	c.mu.Unlock()
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -478,12 +478,14 @@ func (c *APIClient) runRawRequestWithHeaders(method, url string, payloadBuffer i
 		}
 	}
 
+	var resp *http.Response
+
 	if c.mu != nil {
 		c.mu.Lock()
-	}
-	resp, err := c.HTTPClient.Do(req)
-	if c.mu != nil {
+		resp, err = c.HTTPClient.Do(req)
 		c.mu.Unlock()
+	} else {
+		resp, err = c.HTTPClient.Do(req)
 	}
 	if err != nil {
 		return nil, err

--- a/client.go
+++ b/client.go
@@ -50,7 +50,7 @@ type APIClient struct {
 	auth *redfish.AuthToken
 
 	// mu used to lock requests
-	mu sync.Mutex
+	mu *sync.Mutex
 
 	// dumpWriter will receive HTTP dumps if non-nil.
 	dumpWriter io.Writer
@@ -105,6 +105,7 @@ func setupClientWithConfig(ctx context.Context, config *ClientConfig) (c *APICli
 		endpoint:   config.Endpoint,
 		dumpWriter: config.DumpWriter,
 		ctx:        ctx,
+		mu:         &sync.Mutex{},
 	}
 
 	if config.TLSHandshakeTimeout == 0 {
@@ -147,6 +148,7 @@ func setupClientWithEndpoint(ctx context.Context, endpoint string) (c *APIClient
 	client := &APIClient{
 		endpoint: endpoint,
 		ctx:      ctx,
+		mu:       &sync.Mutex{},
 	}
 	client.HTTPClient = &http.Client{}
 

--- a/client_test.go
+++ b/client_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -189,7 +190,7 @@ func TestConnectDefaultContextCancel(t *testing.T) {
 }
 
 func TestClientRunRawRequestNoURL(t *testing.T) {
-	client := APIClient{}
+	client := APIClient{mu: &sync.Mutex{}}
 
 	_, err := client.runRawRequest("", "", nil, "") //nolint:bodyclose
 	if err == nil {


### PR DESCRIPTION
Our test bmc have problem with parallel requests

random uri with error
`failed to retrieve some items: [{"link":"/redfish/v1/Systems/Self/EthernetInterfaces/EthernetInterface0","error":"403: \u003c?xml version=\"1.0\" encoding=\"iso-8859-1\"?\u003e\n\u003c!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\"\n         \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\"\u003e\n\u003chtml xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\"\u003e\n \u003chead\u003e\n  \u003ctitle\u003e403 - Forbidden\u003c/title\u003e\n \u003c/head\u003e\n \u003cbody\u003e\n  \u003ch1\u003e403 - Forbidden\u003c/h1\u003e\n \u003c/body\u003e\n\u003c/html\u003e\n"},{"link":"/redfish/v1/Systems/Self/EthernetInterfaces/EthernetInterface1","error":"403: \u003c?xml version=\"1.0\" encoding=\"iso-8859-1\"?\u003e\n\u003c!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\"\n         \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\"\u003e\n\u003chtml xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\"\u003e\n \u003chead\u003e\n  \u003ctitle\u003e403 - Forbidden\u003c/title\u003e\n \u003c/head\u003e\n \u003cbody\u003e\n  \u003ch1\u003e403 - Forbidden\u003c/h1\u003e\n \u003c/body\u003e\n\u003c/html\u003e\n"}]`
