### PR TITLE
according to the 1.4 PCIeFunctions standard has been moved

### DIFF
--- a/common/collection.go
+++ b/common/collection.go
@@ -37,7 +37,7 @@ func (c *Collection) UnmarshalJSON(b []byte) error {
 
 	// Swordfish has them at the root
 	if len(c.ItemLinks) == 0 &&
-		(t.Count > 0 || t.ODataCount > 0) {
+		(t.Count > 0 || t.ODataCount > 0 || len(t.Members) > 0) {
 		c.ItemLinks = t.Members.ToStrings()
 	}
 

--- a/redfish/pciedevice_test.go
+++ b/redfish/pciedevice_test.go
@@ -29,18 +29,13 @@ var pcieDeviceBody = `{
 			"Chassis": [{
 				"@odata.id": "/redfish/v1/Chassis/Chassis-1"
 			}],
-			"Chassis@odata.count": 1,
-			"PCIeFunctions": [{
-					"@odata.id": "/redfish/v1/Functions/1"
-				},
-				{
-					"@odata.id": "/redfish/v1/Functions/2"
-				}
-			],
-			"PCIeFunctions@odata.count": 1
+			"Chassis@odata.count": 1
 		},
 		"Manufacturer": "Acme Inc",
 		"Model": "A1",
+		"PCIeFunctions": {
+			"@odata.id": "/redfish/v1/Systems/system/PCIeDevices/AAABBCC/PCIeFunctions"
+		},
 		"PCIeInterface": {
 			"LanesInUse": 32,
 			"MaxLanes": 32,


### PR DESCRIPTION
standard : https://www.dmtf.org/sites/default/files/standards/documents/DSP2046_2019.2.pdf

example:
**{
    "@odata.id": "/redfish/v1/Systems/system/PCIeDevices/S0B101D0",
    "@odata.type": "#PCIeDevice.v1_4_0.PCIeDevice",
    "DeviceType": "MultiFunction",
    "Id": "S0B101D0",
    "Manufacturer": "QLogic Corp.",
    "Model": "ISP2722-based 16/32Gb Fibre Channel to PCIe Adapter (QLE2742 Dual Port 32Gb Fibre Channel to PCIe Adapter)",
    "Name": "PCIe Device",
    "PCIeFunctions": {
        "@odata.id": "/redfish/v1/Systems/system/PCIeDevices/S0B101D0/PCIeFunctions"
    }
}**