### PR TITLE
Update event subscription for Redfish v.1.5+

### DIFF
--- a/redfish/eventdestination.go
+++ b/redfish/eventdestination.go
@@ -272,20 +272,50 @@ func GetEventDestination(c common.Client, uri string) (*EventDestination, error)
 
 // subscriptionPayload is the payload to create the event subscription
 type subscriptionPayload struct {
-	Destination string                   `json:"Destination"`
-	EventTypes  []EventType              `json:"EventTypes"`
-	HTTPHeaders map[string]string        `json:"HttpHeaders,omitempty"`
-	Oem         interface{}              `json:"Oem,omitempty"`
-	Protocol    EventDestinationProtocol `json:"Protocol,omitempty"`
-	Context     string                   `json:"Context,omitempty"`
+	Destination         string                   `json:"Destination,omitempty"`
+	EventTypes          []EventType              `json:"EventTypes,omitempty"`
+	RegistryPrefixes    []string                 `json:"RegistryPrefixes,omitempty"`
+	ResourceTypes       []string                 `json:"ResourceTypes,omitempty"`
+	DeliveryRetryPolicy DeliveryRetryPolicy      `json:"DeliveryRetryPolicy,omitempty"`
+	HTTPHeaders         map[string]string        `json:"HttpHeaders,omitempty"`
+	Oem                 interface{}              `json:"Oem,omitempty"`
+	Protocol            EventDestinationProtocol `json:"Protocol,omitempty"`
+	Context             string                   `json:"Context,omitempty"`
 }
 
 // validateCreateEventDestinationParams will validate
 // CreateEventDestination parameters
+
+// Deprecated: (v1.5) EventType-based eventing is DEPRECATED in the Redfish schema
+// in favor of using RegistryPrefix and ResourceTypes
 func validateCreateEventDestinationParams(
 	uri string,
 	destination string,
+	protocol EventDestinationProtocol,
+	context string,
 	eventTypes []EventType,
+) error {
+	// validate event types
+	if len(eventTypes) == 0 {
+		return fmt.Errorf("at least one event type for subscription should be defined")
+	}
+
+	for _, et := range eventTypes {
+		if !et.IsValidEventType() {
+			return fmt.Errorf("invalid event type")
+		}
+	}
+
+	return validateCreateEventDestinationMandatoryParams(uri, destination, protocol, context)
+}
+
+// validateCreateEventDestinationMandatoryParams will validate
+// mandatory parameters for CreateEventDestination HTTP POST request
+func validateCreateEventDestinationMandatoryParams(
+	uri string,
+	destination string,
+	protocol EventDestinationProtocol,
+	context string,
 ) error {
 	// validate uri
 	if strings.TrimSpace(uri) == "" {
@@ -297,19 +327,23 @@ func validateCreateEventDestinationParams(
 		return fmt.Errorf("empty destination is not valid")
 	}
 
-	if !strings.HasPrefix(destination, "http") {
+	u, err := url.ParseRequestURI(destination)
+	if err != nil {
+		return err
+	}
+
+	if !strings.HasPrefix(u.Scheme, "http") {
 		return fmt.Errorf("destination should start with http")
 	}
 
-	// validate event types
-	if len(eventTypes) == 0 {
-		return fmt.Errorf("at least one event type for subscription should be defined")
+	// validate protocol
+	if strings.TrimSpace(string(protocol)) == "" {
+		return fmt.Errorf("the required property protocol should be defined")
 	}
 
-	for _, et := range eventTypes {
-		if !et.IsValidEventType() {
-			return fmt.Errorf("invalid event type")
-		}
+	// validate context
+	if strings.TrimSpace(context) == "" {
+		return fmt.Errorf("the required property context should be defined")
 	}
 
 	return nil
@@ -327,6 +361,9 @@ func validateCreateEventDestinationParams(
 // it should contain the vendor specific struct that goes inside the Oem session.
 // It returns the new subscription URI if the event subscription is created
 // with success or any error encountered.
+
+// Deprecated: (v1.5) EventType-based eventing is DEPRECATED in the Redfish schema
+// in favor of using RegistryPrefix and ResourceTypes
 func CreateEventDestination(
 	c common.Client,
 	uri string,
@@ -337,24 +374,78 @@ func CreateEventDestination(
 	context string,
 	oem interface{},
 ) (string, error) {
-	// validate input parameters
-	err := validateCreateEventDestinationParams(
-		uri,
-		destination,
-		eventTypes,
-	)
-
-	if err != nil {
+	// validate mandatory input parameters
+	if err := validateCreateEventDestinationParams(uri, destination, protocol, context, eventTypes); err != nil {
 		return "", err
 	}
 
 	// create subscription payload
 	s := &subscriptionPayload{
-		Destination: destination,
-		EventTypes:  eventTypes,
-		Protocol:    protocol,
-		Context:     context,
+		EventTypes: eventTypes,
 	}
+
+	return sendCreateEventDestinationRequest(c, s, uri, destination, httpHeaders, protocol, context, oem)
+}
+
+// For Redfish v1.5+
+// CreateEventDestination will create a EventDestination instance.
+// URI should contain the address of the collection for Event Subscriptions.
+// Destination should contain the URL of the destination for events to be sent.
+// RegistryPrefixes is the list of the prefixes for the Message Registries
+// that contain the MessageIds that are sent to this event destination.
+// If RegistryPrefixes is empty on subscription, the client is subscribing to all Message Registries.
+// ResourceTypes is the list of Resource Type values (Schema names) that correspond to the OriginOfCondition,
+// the version and full namespace should not be specified.
+// If ResourceTypes is empty on subscription, the client is subscribing to receive events regardless of ResourceType.
+// HttpHeaders is optional and gives the opportunity to specify any arbitrary
+// HTTP headers required for the event POST operation.
+// Protocol should be the communication protocol of the event endpoint, usually RedfishEventDestinationProtocol.
+// Context is a required client-supplied string that is sent with the event notifications.
+// DeliveryRetryPolicy is optional, it should contain the subscription delivery retry policy for events,
+// where the subscription type is RedfishEvent.
+// Oem is optional and gives the opportunity to specify any OEM specific properties,
+// it should contain the vendor specific struct that goes inside the Oem session.
+// Returns the new subscription URI if the event subscription is created with success or any error encountered.
+func CreateEventDestinationInstance(
+	c common.Client,
+	uri string,
+	destination string,
+	registryPrefixes []string,
+	resourceTypes []string,
+	httpHeaders map[string]string,
+	protocol EventDestinationProtocol,
+	context string,
+	deliveryRetryPolicy DeliveryRetryPolicy,
+	oem interface{},
+) (string, error) {
+	// validate mandatory input parameters
+	if err := validateCreateEventDestinationMandatoryParams(uri, destination, protocol, context); err != nil {
+		return "", err
+	}
+
+	// create subscription payload
+	s := &subscriptionPayload{
+		RegistryPrefixes:    registryPrefixes,
+		ResourceTypes:       resourceTypes,
+		DeliveryRetryPolicy: deliveryRetryPolicy,
+	}
+
+	return sendCreateEventDestinationRequest(c, s, uri, destination, httpHeaders, protocol, context, oem)
+}
+
+func sendCreateEventDestinationRequest(
+	c common.Client,
+	s *subscriptionPayload,
+	uri string,
+	destination string,
+	httpHeaders map[string]string,
+	protocol EventDestinationProtocol,
+	context string,
+	oem interface{},
+) (subscriptionLink string, err error) {
+	s.Destination = destination
+	s.Protocol = protocol
+	s.Context = context
 
 	// HTTP headers
 	if len(httpHeaders) > 0 {
@@ -368,17 +459,18 @@ func CreateEventDestination(
 
 	resp, err := c.Post(uri, s)
 	if err != nil {
-		return "", err
+		return
 	}
 	defer resp.Body.Close()
 
 	// return subscription link from returned location
-	subscriptionLink := resp.Header.Get("Location")
-	if urlParser, err := url.ParseRequestURI(subscriptionLink); err == nil {
+	subscriptionLink = resp.Header.Get("Location")
+	urlParser, err := url.ParseRequestURI(subscriptionLink)
+	if err == nil {
 		subscriptionLink = urlParser.RequestURI()
 	}
 
-	return subscriptionLink, nil
+	return subscriptionLink, err
 }
 
 // DeleteEventDestination will delete a EventDestination.


### PR DESCRIPTION
I'd like to suggest some changes for EventService subscriptions

According to [Redfish documentation](https://www.dmtf.org/sites/default/files/standards/documents/DSP2046_2022.2.pdf) p.6.34.3

> For the possible property values, see EventTypes in Property details. Deprecated in v1.5 and later. This property has been deprecated. Starting with Redfish Specification v1.6 (Event v1.3), subscriptions are based on the RegistryPrefix and ResourceType properties and not on the EventType property.

Now there's the following error when subscribing to events (Redfish v.1.5+, here: Redfish v.1.15.1):
`400: {"error":{"@Message.ExtendedInfo":[{"@odata.type":"#Message.v1_0_8.Message","Message":"The property EventTypes is not in the list of valid properties for the resource.","MessageArgs":["EventTypes"],"MessageId":"Base.1.12.PropertyUnknown","RelatedProperties":["/EventTypes"],"Resolution":"Remove the unknown property from the request body and resubmit the request if the operation failed.","Severity":"Warning"}],"code":"Base.1.12.PropertyUnknown","message":"The property EventTypes is not in the list of valid properties for the resource."}}`

The changes I've made are backward-compatible