### PR TITLE
Update golangci-lint and go versions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.18.0'
+        go-version: '1.20.0'
 
     # Build the code
     - name: Run build
@@ -39,10 +39,10 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.18.0'
+        go-version: '1.20.0'
 
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.49.0
+        version: v1.52.2
         args: --timeout=5m -v

--- a/common/collection.go
+++ b/common/collection.go
@@ -108,7 +108,7 @@ func CollectList(get func(string), c Client, link string) error {
 		return err
 	}
 
-	CollectCollection(get, c, collection.ItemLinks)
+	CollectCollection(get, collection.ItemLinks)
 	if collection.MembersNextLink != "" {
 		err := CollectList(get, c, collection.MembersNextLink)
 		if err != nil {
@@ -120,7 +120,7 @@ func CollectList(get func(string), c Client, link string) error {
 
 // CollectCollection will retrieve a collection of entitied from the Redfish service
 // when you already have the set of individual links in the collection.
-func CollectCollection(get func(string), c Client, links []string) {
+func CollectCollection(get func(string), links []string) {
 	// Only allow three concurrent requests to avoid overwhelming the service
 	limiter := make(chan struct{}, 3)
 	var wg sync.WaitGroup

--- a/redfish/chassis.go
+++ b/redfish/chassis.go
@@ -405,7 +405,7 @@ func (chassis *Chassis) Drives() ([]*Drive, error) {
 	}
 
 	go func() {
-		common.CollectCollection(get, chassis.GetClient(), driveLinks)
+		common.CollectCollection(get, driveLinks)
 		close(ch)
 	}()
 


### PR DESCRIPTION
This update golangci-lint to the current latest version and updates Go to 1.20.2 when used in the GitHub Action workflow.