### PR TITLE
ComputerSystemReset: Refactor Task and Post

### DIFF
--- a/common/collection.go
+++ b/common/collection.go
@@ -118,7 +118,7 @@ func CollectList(get func(string), c Client, link string) error {
 	return nil
 }
 
-// CollectCollection will retrieve a collection of entitied from the Redfish service
+// CollectCollection will retrieve a collection of entities from the Redfish service
 // when you already have the set of individual links in the collection.
 func CollectCollection(get func(string), links []string) {
 	// Only allow three concurrent requests to avoid overwhelming the service

--- a/common/entity.go
+++ b/common/entity.go
@@ -7,6 +7,7 @@ package common
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"reflect"
 )
 
@@ -101,17 +102,17 @@ func (e *Entity) Patch(uri string, payload interface{}) error {
 }
 
 // Post performs a Post request against the Redfish service with etag
-func (e *Entity) Post(uri string, payload interface{}) error {
+func (e *Entity) Post(uri string, payload interface{}) (*http.Response, error) {
 	header := make(map[string]string)
 	if e.etag != "" {
 		header["If-Match"] = e.etag
 	}
 
 	resp, err := e.client.PostWithHeaders(uri, payload, header)
-	if err == nil {
-		return resp.Body.Close()
+	if err != nil {
+		return nil, err
 	}
-	return err
+	return resp, nil
 }
 
 type Filter string

--- a/common/task.go
+++ b/common/task.go
@@ -2,12 +2,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-package redfish
+package common
 
 import (
 	"encoding/json"
-
-	"github.com/stmcginnis/gofish/common"
 )
 
 // TaskState indicates the state of a task.
@@ -71,7 +69,7 @@ type Payload struct {
 
 // Task is used to represent a Task for a Redfish implementation.
 type Task struct {
-	common.Entity
+	Entity
 
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
@@ -128,7 +126,7 @@ type Task struct {
 	// TaskStatus shall be the completion status of the task, as defined in the
 	// Status section of the Redfish specification and shall not be set until
 	// the task has completed.
-	TaskStatus common.Health
+	TaskStatus Health
 }
 
 // UnmarshalJSON unmarshals a Task object from the raw JSON.
@@ -136,7 +134,7 @@ func (task *Task) UnmarshalJSON(b []byte) error {
 	type temp Task
 	var t struct {
 		temp
-		Messages common.Links
+		Messages Links
 	}
 
 	err := json.Unmarshal(b, &t)
@@ -152,14 +150,14 @@ func (task *Task) UnmarshalJSON(b []byte) error {
 }
 
 // GetTask will get a Task instance from the service.
-func GetTask(c common.Client, uri string) (*Task, error) {
+func GetTask(c Client, uri string) (*Task, error) {
 	var task Task
 	return &task, task.Get(c, uri, &task)
 }
 
 // ListReferencedTasks gets the collection of Task from
 // a provided reference.
-func ListReferencedTasks(c common.Client, link string) ([]*Task, error) { //nolint:dupl
+func ListReferencedTasks(c Client, link string) ([]*Task, error) { //nolint:dupl
 	var result []*Task
 	if link == "" {
 		return result, nil
@@ -172,14 +170,14 @@ func ListReferencedTasks(c common.Client, link string) ([]*Task, error) { //noli
 	}
 
 	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
+	collectionError := NewCollectionError()
 	get := func(link string) {
 		task, err := GetTask(c, link)
 		ch <- GetResult{Item: task, Link: link, Error: err}
 	}
 
 	go func() {
-		err := common.CollectList(get, c, link)
+		err := CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}

--- a/common/task_test.go
+++ b/common/task_test.go
@@ -2,14 +2,12 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-package redfish
+package common
 
 import (
 	"encoding/json"
 	"strings"
 	"testing"
-
-	"github.com/stmcginnis/gofish/common"
 )
 
 var taskBody = strings.NewReader(
@@ -61,7 +59,7 @@ func TestTask(t *testing.T) {
 		t.Errorf("Invalid TaskState: %s", result.TaskState)
 	}
 
-	if result.TaskStatus != common.OKHealth {
+	if result.TaskStatus != OKHealth {
 		t.Errorf("Invalid TaskStatus: %s", result.TaskStatus)
 	}
 }

--- a/redfish/bios.go
+++ b/redfish/bios.go
@@ -7,6 +7,7 @@ package redfish
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/stmcginnis/gofish/common"
@@ -151,15 +152,15 @@ func ListReferencedBioss(c common.Client, link string) ([]*Bios, error) { //noli
 }
 
 // ChangePassword shall change the selected BIOS password.
-func (bios *Bios) ChangePassword(passwordName, oldPassword, newPassword string) error {
+func (bios *Bios) ChangePassword(passwordName, oldPassword, newPassword string) (*http.Response, error) {
 	if passwordName == "" {
-		return fmt.Errorf("password name must be supplied")
+		return nil, fmt.Errorf("password name must be supplied")
 	}
 	if oldPassword == "" {
-		return fmt.Errorf("existing password must be supplied")
+		return nil, fmt.Errorf("existing password must be supplied")
 	}
 	if newPassword == "" {
-		return fmt.Errorf("new password must be supplied")
+		return nil, fmt.Errorf("new password must be supplied")
 	}
 
 	t := struct {
@@ -177,7 +178,7 @@ func (bios *Bios) ChangePassword(passwordName, oldPassword, newPassword string) 
 // ResetBios shall perform a reset of the BIOS attributes to their default values.
 // A system reset may be required for the default values to be applied. This
 // action may impact other resources.
-func (bios *Bios) ResetBios() error {
+func (bios *Bios) ResetBios() (*http.Response, error) {
 	return bios.Post(bios.resetBiosTarget, nil)
 }
 

--- a/redfish/chassis.go
+++ b/redfish/chassis.go
@@ -7,6 +7,7 @@ package redfish
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
@@ -503,7 +504,7 @@ func (chassis *Chassis) Assembly() (*Assembly, error) {
 
 // Reset shall reset the chassis. This action shall not reset Systems or other
 // contained resource, although side effects may occur which affect those resources.
-func (chassis *Chassis) Reset(resetType ResetType) error {
+func (chassis *Chassis) Reset(resetType ResetType) (*http.Response, error) {
 	// Make sure the requested reset type is supported by the chassis
 	valid := false
 	if len(chassis.SupportedResetTypes) > 0 {
@@ -519,7 +520,7 @@ func (chassis *Chassis) Reset(resetType ResetType) error {
 	}
 
 	if !valid {
-		return fmt.Errorf("reset type '%s' is not supported by this chassis",
+		return nil, fmt.Errorf("reset type '%s' is not supported by this chassis",
 			resetType)
 	}
 

--- a/redfish/computersystem.go
+++ b/redfish/computersystem.go
@@ -951,10 +951,12 @@ func (computersystem *ComputerSystem) SetDefaultBootOrder() error {
 		return fmt.Errorf("SetDefaultBootOrder is not supported by this system") //nolint:golint
 	}
 
-	_, err := computersystem.Post(computersystem.setDefaultBootOrderTarget, nil)
+	resp, err := computersystem.Post(computersystem.setDefaultBootOrderTarget, nil)
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
 	return nil
 }
 

--- a/redfish/drive.go
+++ b/redfish/drive.go
@@ -6,6 +6,7 @@ package redfish
 
 import (
 	"encoding/json"
+	"net/http"
 	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
@@ -458,6 +459,6 @@ func (drive *Drive) PCIeFunctions() ([]*PCIeFunction, error) {
 // }
 
 // SecureErase shall perform a secure erase of the drive.
-func (drive *Drive) SecureErase() error {
+func (drive *Drive) SecureErase() (*http.Response, error) {
 	return drive.Post(drive.secureEraseTarget, nil)
 }

--- a/redfish/eventservice.go
+++ b/redfish/eventservice.go
@@ -7,6 +7,7 @@ package redfish
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"reflect"
 	"strings"
 	"time"
@@ -384,7 +385,7 @@ func (eventservice *EventService) DeleteEventSubscription(uri string) error {
 // SubmitTestEvent shall add a test event to the event service with the event
 // data specified in the action parameters. This message should then be sent to
 // any appropriate ListenerDestination targets.
-func (eventservice *EventService) SubmitTestEvent(message string) error {
+func (eventservice *EventService) SubmitTestEvent(message string) (*http.Response, error) {
 	type temp struct {
 		EventGroupID      string `json:"EventGroupId"`
 		EventID           string `json:"EventId"`

--- a/redfish/logservice.go
+++ b/redfish/logservice.go
@@ -7,6 +7,7 @@ package redfish
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
@@ -204,7 +205,7 @@ func (logservice *LogService) FilteredEntries(options ...common.FilterOption) ([
 
 // ClearLog shall delete all entries found in the Entries collection for this
 // Log Service.
-func (logservice *LogService) ClearLog() error {
+func (logservice *LogService) ClearLog() (*http.Response, error) {
 	t := struct {
 		Action string
 	}{

--- a/redfish/manager.go
+++ b/redfish/manager.go
@@ -7,6 +7,7 @@ package redfish
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
@@ -435,7 +436,7 @@ func ListReferencedManagers(c common.Client, link string) ([]*Manager, error) { 
 }
 
 // Reset shall perform a reset of the manager.
-func (manager *Manager) Reset(resetType ResetType) error {
+func (manager *Manager) Reset(resetType ResetType) (*http.Response, error) {
 	if len(manager.SupportedResetTypes) == 0 {
 		// reset directly without reset type. HPE server has the behavior
 		t := struct {
@@ -453,7 +454,7 @@ func (manager *Manager) Reset(resetType ResetType) error {
 	}
 
 	if !valid {
-		return fmt.Errorf("reset type '%s' is not supported by this manager",
+		return nil, fmt.Errorf("reset type '%s' is not supported by this manager",
 			resetType)
 	}
 

--- a/redfish/networkadapter.go
+++ b/redfish/networkadapter.go
@@ -6,6 +6,7 @@ package redfish
 
 import (
 	"encoding/json"
+	"net/http"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -305,6 +306,6 @@ func (networkadapter *NetworkAdapter) NetworkPorts() ([]*NetworkPort, error) {
 
 // ResetSettingsToDefault shall perform a reset of all active and pending
 // settings back to factory default settings upon reset of the network adapter.
-func (networkadapter *NetworkAdapter) ResetSettingsToDefault() error {
+func (networkadapter *NetworkAdapter) ResetSettingsToDefault() (*http.Response, error) {
 	return networkadapter.Post(networkadapter.resetSettingsToDefaultTarget, nil)
 }

--- a/redfish/secureboot.go
+++ b/redfish/secureboot.go
@@ -6,6 +6,7 @@ package redfish
 
 import (
 	"encoding/json"
+	"net/http"
 	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
@@ -181,7 +182,7 @@ func ListReferencedSecureBoots(c common.Client, link string) ([]*SecureBoot, err
 // their default values. The DeleteAllKeys value shall delete the content of the
 // UEFI Secure Boot key databases. The DeletePK value shall delete the content
 // of the PK Secure boot key.
-func (secureboot *SecureBoot) ResetKeys(resetType ResetKeysType) error {
+func (secureboot *SecureBoot) ResetKeys(resetType ResetKeysType) (*http.Response, error) {
 	t := struct {
 		ResetKeysType ResetKeysType
 	}{ResetKeysType: resetType}

--- a/redfish/storage.go
+++ b/redfish/storage.go
@@ -6,6 +6,7 @@ package redfish
 
 import (
 	"encoding/json"
+	"net/http"
 	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
@@ -201,7 +202,7 @@ func (storage *Storage) Volumes() ([]*Volume, error) {
 }
 
 // SetEncryptionKey shall set the encryption key for the storage subsystem.
-func (storage *Storage) SetEncryptionKey(key string) error {
+func (storage *Storage) SetEncryptionKey(key string) (*http.Response, error) {
 	t := struct {
 		EncryptionKey string
 	}{EncryptionKey: key}

--- a/redfish/taskervice.go
+++ b/redfish/taskervice.go
@@ -62,6 +62,6 @@ func GetTaskService(c common.Client, uri string) (*TaskService, error) {
 }
 
 // Tasks gets the collection of tasks of this task service
-func (taskService *TaskService) Tasks() ([]*Task, error) {
-	return ListReferencedTasks(taskService.GetClient(), taskService.tasks)
+func (taskService *TaskService) Tasks() ([]*common.Task, error) {
+	return common.ListReferencedTasks(taskService.GetClient(), taskService.tasks)
 }

--- a/redfish/virtualmedia.go
+++ b/redfish/virtualmedia.go
@@ -7,6 +7,7 @@ package redfish
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
 	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
@@ -197,18 +198,18 @@ func (virtualmedia *VirtualMedia) Update() error {
 }
 
 // EjectMedia sends a request to eject the media.
-func (virtualmedia *VirtualMedia) EjectMedia() error {
+func (virtualmedia *VirtualMedia) EjectMedia() (*http.Response, error) {
 	if !virtualmedia.SupportsMediaEject {
-		return errors.New("redfish service does not support VirtualMedia.EjectMedia calls")
+		return nil, errors.New("redfish service does not support VirtualMedia.EjectMedia calls")
 	}
 
 	return virtualmedia.Post(virtualmedia.ejectMediaTarget, struct{}{})
 }
 
 // InsertMedia sends a request to insert virtual media.
-func (virtualmedia *VirtualMedia) InsertMedia(image string, inserted, writeProtected bool) error {
+func (virtualmedia *VirtualMedia) InsertMedia(image string, inserted, writeProtected bool) (*http.Response, error) {
 	if !virtualmedia.SupportsMediaInsert {
-		return errors.New("redfish service does not support VirtualMedia.InsertMedia calls")
+		return nil, errors.New("redfish service does not support VirtualMedia.InsertMedia calls")
 	}
 
 	t := struct {
@@ -236,9 +237,9 @@ type VirtualMediaConfig struct {
 }
 
 // InsertMediaConfig sends a request to insert virtual media using the VirtualMediaConfig struct
-func (virtualmedia *VirtualMedia) InsertMediaConfig(config VirtualMediaConfig) error { //nolint
+func (virtualmedia *VirtualMedia) InsertMediaConfig(config VirtualMediaConfig) (*http.Response, error) { //nolint
 	if !virtualmedia.SupportsMediaInsert {
-		return errors.New("redfish service does not support VirtualMedia.InsertMedia calls")
+		return nil, errors.New("redfish service does not support VirtualMedia.InsertMedia calls")
 	}
 
 	return virtualmedia.Post(virtualmedia.insertMediaTarget, config)

--- a/redfish/virtualmedia_test.go
+++ b/redfish/virtualmedia_test.go
@@ -142,7 +142,7 @@ func TestVirtualMediaEject(t *testing.T) {
 	testClient := &common.TestClient{}
 	result.SetClient(testClient)
 
-	err = result.EjectMedia()
+	_, err = result.EjectMedia()
 
 	if err != nil {
 		t.Errorf("Error making EjectMedia call: %s", err)
@@ -167,7 +167,7 @@ func TestVirtualMediaInsert(t *testing.T) {
 	testClient := &common.TestClient{}
 	result.SetClient(testClient)
 
-	err = result.InsertMedia("https://example.com/image", false, true)
+	_, err = result.InsertMedia("https://example.com/image", false, true)
 
 	if err != nil {
 		t.Errorf("Error making InsertMedia call: %s", err)
@@ -207,7 +207,7 @@ func TestVirtualMediaInsertConfig(t *testing.T) {
 		WriteProtected: true,
 	}
 
-	err = result.InsertMediaConfig(virtualMediaConfig)
+	_, err = result.InsertMediaConfig(virtualMediaConfig)
 	if err != nil {
 		t.Errorf("Error making InsertMediaConfig call: %s", err)
 	}

--- a/redfish/virtualmedia_test.go
+++ b/redfish/virtualmedia_test.go
@@ -142,11 +142,12 @@ func TestVirtualMediaEject(t *testing.T) {
 	testClient := &common.TestClient{}
 	result.SetClient(testClient)
 
-	_, err = result.EjectMedia()
+	resp, err := result.EjectMedia()
 
 	if err != nil {
 		t.Errorf("Error making EjectMedia call: %s", err)
 	}
+	defer resp.Body.Close()
 
 	calls := testClient.CapturedCalls()
 
@@ -167,11 +168,12 @@ func TestVirtualMediaInsert(t *testing.T) {
 	testClient := &common.TestClient{}
 	result.SetClient(testClient)
 
-	_, err = result.InsertMedia("https://example.com/image", false, true)
+	resp, err := result.InsertMedia("https://example.com/image", false, true)
 
 	if err != nil {
 		t.Errorf("Error making InsertMedia call: %s", err)
 	}
+	defer resp.Body.Close()
 
 	calls := testClient.CapturedCalls()
 
@@ -207,10 +209,11 @@ func TestVirtualMediaInsertConfig(t *testing.T) {
 		WriteProtected: true,
 	}
 
-	_, err = result.InsertMediaConfig(virtualMediaConfig)
+	resp, err := result.InsertMediaConfig(virtualMediaConfig)
 	if err != nil {
 		t.Errorf("Error making InsertMediaConfig call: %s", err)
 	}
+	defer resp.Body.Close()
 
 	calls := testClient.CapturedCalls()
 

--- a/serviceroot.go
+++ b/serviceroot.go
@@ -250,7 +250,11 @@ func (serviceroot *Service) StorageServices() ([]*swordfish.StorageService, erro
 
 // Tasks gets the system's tasks
 func (serviceroot *Service) Tasks() ([]*common.Task, error) {
-	return common.ListReferencedTasks(serviceroot.GetClient(), serviceroot.tasks)
+	taskService, err := redfish.GetTaskService(serviceroot.GetClient(), serviceroot.tasks)
+	if err != nil {
+		return nil, err
+	}
+	return taskService.Tasks()
 }
 
 // TaskService gets the task service instance

--- a/serviceroot.go
+++ b/serviceroot.go
@@ -249,8 +249,8 @@ func (serviceroot *Service) StorageServices() ([]*swordfish.StorageService, erro
 }
 
 // Tasks gets the system's tasks
-func (serviceroot *Service) Tasks() ([]*redfish.Task, error) {
-	return redfish.ListReferencedTasks(serviceroot.GetClient(), serviceroot.tasks)
+func (serviceroot *Service) Tasks() ([]*common.Task, error) {
+	return common.ListReferencedTasks(serviceroot.GetClient(), serviceroot.tasks)
 }
 
 // TaskService gets the task service instance

--- a/swordfish/storagegroup.go
+++ b/swordfish/storagegroup.go
@@ -321,8 +321,9 @@ type MappedVolume struct {
 // ClientEndpointGroups.  The property VolumesAreExposed shall be set to true
 // when this action is completed.
 func (storagegroup *StorageGroup) ExposeVolumes() (*http.Response, error) {
-	_, err := storagegroup.Post(storagegroup.exposeVolumesTarget, nil)
+	resp, err := storagegroup.Post(storagegroup.exposeVolumesTarget, nil)
 	if err == nil {
+		defer resp.Body.Close()
 		// Only set to exposed if no error. Calling expose when already exposed
 		// could fail so we don't want to indicate they are not exposed.
 		storagegroup.VolumesAreExposed = true
@@ -334,8 +335,9 @@ func (storagegroup *StorageGroup) ExposeVolumes() (*http.Response, error) {
 // named in the ClientEndpointGroups. The property VolumesAreExposed shall be
 // set to false when this action is completed.
 func (storagegroup *StorageGroup) HideVolumes() (*http.Response, error) {
-	_, err := storagegroup.Post(storagegroup.hideVolumesTarget, nil)
+	resp, err := storagegroup.Post(storagegroup.hideVolumesTarget, nil)
 	if err == nil {
+		defer resp.Body.Close()
 		storagegroup.VolumesAreExposed = false
 	}
 	return nil, err

--- a/swordfish/storagegroup.go
+++ b/swordfish/storagegroup.go
@@ -6,6 +6,7 @@ package swordfish
 
 import (
 	"encoding/json"
+	"net/http"
 	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
@@ -319,23 +320,23 @@ type MappedVolume struct {
 // named in the ServerEndpointGroups to the initiator endpoints named in the
 // ClientEndpointGroups.  The property VolumesAreExposed shall be set to true
 // when this action is completed.
-func (storagegroup *StorageGroup) ExposeVolumes() error {
-	err := storagegroup.Post(storagegroup.exposeVolumesTarget, nil)
+func (storagegroup *StorageGroup) ExposeVolumes() (*http.Response, error) {
+	_, err := storagegroup.Post(storagegroup.exposeVolumesTarget, nil)
 	if err == nil {
 		// Only set to exposed if no error. Calling expose when already exposed
 		// could fail so we don't want to indicate they are not exposed.
 		storagegroup.VolumesAreExposed = true
 	}
-	return err
+	return nil, err
 }
 
 // HideVolumes hides the storage of this group from the initiator endpoints
 // named in the ClientEndpointGroups. The property VolumesAreExposed shall be
 // set to false when this action is completed.
-func (storagegroup *StorageGroup) HideVolumes() error {
-	err := storagegroup.Post(storagegroup.hideVolumesTarget, nil)
+func (storagegroup *StorageGroup) HideVolumes() (*http.Response, error) {
+	_, err := storagegroup.Post(storagegroup.hideVolumesTarget, nil)
 	if err == nil {
 		storagegroup.VolumesAreExposed = false
 	}
-	return err
+	return nil, err
 }

--- a/swordfish/storageservice.go
+++ b/swordfish/storageservice.go
@@ -6,6 +6,7 @@ package swordfish
 
 import (
 	"encoding/json"
+	"net/http"
 
 	"github.com/stmcginnis/gofish/common"
 	"github.com/stmcginnis/gofish/redfish"
@@ -356,7 +357,7 @@ func (storageservice *StorageService) Volumes() ([]*Volume, error) {
 }
 
 // SetEncryptionKey shall set the encryption key for the storage subsystem.
-func (storageservice *StorageService) SetEncryptionKey(key string) error {
+func (storageservice *StorageService) SetEncryptionKey(key string) (*http.Response, error) {
 	t := struct {
 		EncryptionKey string
 	}{EncryptionKey: key}

--- a/swordfish/volume.go
+++ b/swordfish/volume.go
@@ -7,6 +7,7 @@ package swordfish
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
@@ -702,10 +703,10 @@ func (volume *Volume) StoragePools() ([]*StoragePool, error) {
 // AssignReplicaTarget is used to establish a replication relationship by
 // assigning an existing volume to serve as a target replica for an existing
 // source volume.
-func (volume *Volume) AssignReplicaTarget(replicaType ReplicaType, updateMode ReplicaUpdateMode, targetVolumeODataID string) error {
+func (volume *Volume) AssignReplicaTarget(replicaType ReplicaType, updateMode ReplicaUpdateMode, targetVolumeODataID string) (*http.Response, error) {
 	// This action wasn't added until later revisions
 	if volume.assignReplicaTargetTarget == "" {
-		return fmt.Errorf("AssignReplicaTarget action is not supported by this system")
+		return nil, fmt.Errorf("AssignReplicaTarget action is not supported by this system")
 	}
 
 	// Define this action's parameters
@@ -725,18 +726,18 @@ func (volume *Volume) AssignReplicaTarget(replicaType ReplicaType, updateMode Re
 
 // CheckConsistency is used to force a check of the Volume's parity or redundant
 // data to ensure it matches calculated values.
-func (volume *Volume) CheckConsistency() error {
+func (volume *Volume) CheckConsistency() (*http.Response, error) {
 	if volume.checkConsistencyTarget == "" {
-		return fmt.Errorf("CheckConsistency action is not supported by this system")
+		return nil, fmt.Errorf("CheckConsistency action is not supported by this system")
 	}
 
 	return volume.Post(volume.checkConsistencyTarget, nil)
 }
 
 // Initialize is used to prepare the contents of the volume for use by the system.
-func (volume *Volume) Initialize(initType InitializeType) error {
+func (volume *Volume) Initialize(initType InitializeType) (*http.Response, error) {
 	if volume.initializeTarget == "" {
-		return fmt.Errorf("initialize action is not supported by this system")
+		return nil, fmt.Errorf("initialize action is not supported by this system")
 	}
 
 	// Define this action's parameters
@@ -751,10 +752,10 @@ func (volume *Volume) Initialize(initType InitializeType) error {
 // RemoveReplicaRelationship is used to disable data synchronization between a
 // source and target volume, remove the replication relationship, and optionally
 // delete the target volume.
-func (volume *Volume) RemoveReplicaRelationship(deleteTarget bool, targetVolumeODataID string) error {
+func (volume *Volume) RemoveReplicaRelationship(deleteTarget bool, targetVolumeODataID string) (*http.Response, error) {
 	// This action wasn't added until later revisions
 	if volume.removeReplicaRelationshipTarget == "" {
-		return fmt.Errorf("RemoveReplicaRelationship action is not supported by this system")
+		return nil, fmt.Errorf("RemoveReplicaRelationship action is not supported by this system")
 	}
 
 	// Define this action's parameters
@@ -773,10 +774,10 @@ func (volume *Volume) RemoveReplicaRelationship(deleteTarget bool, targetVolumeO
 // ResumeReplication is used to resume the active data synchronization between a
 // source and target volume, without otherwise altering the replication
 // relationship.
-func (volume *Volume) ResumeReplication(targetVolumeODataID string) error {
+func (volume *Volume) ResumeReplication(targetVolumeODataID string) (*http.Response, error) {
 	// This action wasn't added until later revisions
 	if volume.resumeReplicationTarget == "" {
-		return fmt.Errorf("ResumeReplication action is not supported by this system")
+		return nil, fmt.Errorf("ResumeReplication action is not supported by this system")
 	}
 
 	// Define this action's parameters
@@ -790,10 +791,10 @@ func (volume *Volume) ResumeReplication(targetVolumeODataID string) error {
 
 // ReverseReplicationRelationship is used to reverse the replication
 // relationship between a source and target volume.
-func (volume *Volume) ReverseReplicationRelationship(targetVolumeODataID string) error {
+func (volume *Volume) ReverseReplicationRelationship(targetVolumeODataID string) (*http.Response, error) {
 	// This action wasn't added until later revisions
 	if volume.reverseReplicationRelationshipTarget == "" {
-		return fmt.Errorf("ReverseReplicationRelationship action is not supported by this system")
+		return nil, fmt.Errorf("ReverseReplicationRelationship action is not supported by this system")
 	}
 
 	// Define this action's parameters
@@ -807,10 +808,10 @@ func (volume *Volume) ReverseReplicationRelationship(targetVolumeODataID string)
 
 // SplitReplication is used to split the replication relationship and suspend
 // data synchronization between a source and target volume.
-func (volume *Volume) SplitReplication(targetVolumeODataID string) error {
+func (volume *Volume) SplitReplication(targetVolumeODataID string) (*http.Response, error) {
 	// This action wasn't added until later revisions
 	if volume.splitReplicationTarget == "" {
-		return fmt.Errorf("SplitReplication action is not supported by this system")
+		return nil, fmt.Errorf("SplitReplication action is not supported by this system")
 	}
 
 	// Define this action's parameters
@@ -825,10 +826,10 @@ func (volume *Volume) SplitReplication(targetVolumeODataID string) error {
 // SuspendReplication is used to suspend active data synchronization between a
 // source and target volume, without otherwise altering the replication
 // relationship.
-func (volume *Volume) SuspendReplication(targetVolumeODataID string) error {
+func (volume *Volume) SuspendReplication(targetVolumeODataID string) (*http.Response, error) {
 	// This action wasn't added until later revisions
 	if volume.suspendReplicationTarget == "" {
-		return fmt.Errorf("SuspendReplication action is not supported by this system")
+		return nil, fmt.Errorf("SuspendReplication action is not supported by this system")
 	}
 
 	// Define this action's parameters


### PR DESCRIPTION
Possible direction for: https://github.com/stmcginnis/gofish/issues/246

- Moves Task into common package
- Change ComputerSystem.Reset() to return a *common.Task struct
- Change ComputerSystem.Post() to return an *http.Response (which is one level additional from PostWithHeaders)
- Updated method calls in other locations to accommodate new signatures.