### PR TITLE
make concurrency configurable

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"sync"
 	"testing"
 	"time"
 
@@ -190,7 +189,7 @@ func TestConnectDefaultContextCancel(t *testing.T) {
 }
 
 func TestClientRunRawRequestNoURL(t *testing.T) {
-	client := APIClient{mu: &sync.Mutex{}}
+	client := APIClient{sem: make(chan bool, 1)}
 
 	_, err := client.runRawRequest("", "", nil, "") //nolint:bodyclose
 	if err == nil {

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/stmcginnis/gofish
 
 go 1.16
-
-require golang.org/x/sync v0.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/stmcginnis/gofish
 
 go 1.16
+
+require golang.org/x/sync v0.3.0 // indirect


### PR DESCRIPTION
This allows the concurrency of HTTP client to be configured (it is 1 by default in order to maintain the existing behaviour). This also has the added benefit that a context cancellation will abort the lock acquisition