### PR TITLE
Raise gollangci-lint cyclometric complexity

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -28,7 +28,7 @@ linters-settings:
       - whyNoLint
       - wrapperFunc
   gocyclo:
-    min-complexity: 25
+    min-complexity: 30
   goimports:
     local-prefixes: github.com/stmcginnis
   govet:


### PR DESCRIPTION
This linter setting is really too low for some things. Raise it up higher so it doesn't cause unnecessary work refactoring methods.