### PR TITLE
Decode task messages

### DIFF
--- a/redfish/task.go
+++ b/redfish/task.go
@@ -86,9 +86,8 @@ type Task struct {
 	// returned normally. If this property is not specified when the Task is
 	// created, the default value shall be False.
 	HidePayload bool
-	// messages shall be an array of messages associated with the task.
-	// TODO: Add processing of messages.
-	messages []string
+	// Messages shall be an array of messages associated with the task.
+	Messages []common.Message
 	// Payload shall contain information detailing the HTTP and JSON payload
 	// information for executing this task. This object shall not be included in
 	// the response if the HidePayload property is set to True.
@@ -136,7 +135,6 @@ func (task *Task) UnmarshalJSON(b []byte) error {
 	type temp Task
 	var t struct {
 		temp
-		Messages common.Links
 	}
 
 	err := json.Unmarshal(b, &t)
@@ -146,7 +144,6 @@ func (task *Task) UnmarshalJSON(b []byte) error {
 
 	// Extract the links to other entities for later
 	*task = Task(t.temp)
-	task.messages = t.Messages.ToStrings()
 
 	return nil
 }

--- a/redfish/task_test.go
+++ b/redfish/task_test.go
@@ -22,7 +22,14 @@ var taskBody = strings.NewReader(
 		"Description": "Task One",
 		"EndTime": "2012-03-07T14:44+06:00",
 		"HidePayload": false,
-		"Messages": [],
+		"Messages": [{
+            "Resolution": "None",
+            "@odata.type": "#Message.v1_1_2.Message",
+            "Message": "An update is in progress.",
+            "MessageArgs": [],
+            "MessageId": "Update.1.0.UpdateInProgress",
+            "MessageSeverity": "OK"
+        }],
 		"Payload": {
 			"HttpHeaders": ["User-Agent: Tadpole"],
 			"HttpOperation": "POST",
@@ -63,5 +70,9 @@ func TestTask(t *testing.T) {
 
 	if result.TaskStatus != common.OKHealth {
 		t.Errorf("Invalid TaskStatus: %s", result.TaskStatus)
+	}
+
+	if len(result.Messages) != 1 {
+		t.Errorf("Incorrect number of task messages: %d", len(result.Messages))
 	}
 }


### PR DESCRIPTION
According to the [Redfish Firmware Update White Paper](https://www.dmtf.org/sites/default/files/standards/documents/DSP2062_1.0.0.pdf) (section 6.3), tasks can transition to a job, and the job URI is provided via the task message args. So we need to be able to fully decode task messages.