### PR TITLE
Add jobservice and job types

### DIFF
--- a/redfish/job.go
+++ b/redfish/job.go
@@ -62,9 +62,9 @@ type JobPayload struct {
 	// HTTPOperation shall contain the HTTP operation that executes this Job.
 	HTTPOperation string `json:"HttpOperation"`
 	// JsonBody shall contain JSON-formatted payload for this Job.
-	JsonBody string
+	JSONBody string
 	// TargetUri shall contain link to a target location for an HTTP operation.
-	TargetUri string
+	TargetURI string
 }
 
 // Job shall contain a job in a Redfish implementation.

--- a/redfish/job.go
+++ b/redfish/job.go
@@ -1,0 +1,215 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package redfish
+
+import (
+	"encoding/json"
+
+	"github.com/stmcginnis/gofish/common"
+)
+
+// JobState indicates the state of a job.
+type JobState string
+
+const (
+	// NewJobState shall represent that this job is newly created but the
+	// operation has not yet started.
+	NewJobState JobState = "New"
+	// StartingJobState shall represent that the operation is starting.
+	StartingJobState JobState = "Starting"
+	// RunningJobState shall represent that the operation is executing.
+	RunningJobState JobState = "Running"
+	// SuspendedJobState shall represent that the operation has been
+	// suspended but is expected to restart and is therefore not complete.
+	SuspendedJobState JobState = "Suspended"
+	// InterruptedJobState shall represent that the operation has been
+	// interrupted but is expected to restart and is therefore not complete.
+	InterruptedJobState JobState = "Interrupted"
+	// PendingJobState shall represent that the operation is pending some
+	// condition and has not yet begun to execute.
+	PendingJobState JobState = "Pending"
+	// StoppingJobState shall represent that the operation is stopping but is
+	// not yet complete.
+	StoppingJobState JobState = "Stopping"
+	// CompletedJobState shall represent that the operation completed
+	// successfully or with warnings.
+	CompletedJobState JobState = "Completed"
+	// CancelledJobState shall represent that the operation completed because
+	// the job was cancelled by an operator.
+	CancelledJobState JobState = "Cancelled"
+	// ExceptionJobState shall represent that the operation completed with
+	// errors.
+	ExceptionJobState JobState = "Exception"
+	// ServiceJobState shall represent that the operation is now running as a
+	// service and expected to continue operation until stopped or killed.
+	ServiceJobState JobState = "Service"
+	// UserInterventionJobState shall represent that the operation is waiting
+	// for a user to intervene and needs to be manually continued, stopped,
+	// or cancelled.
+	UserInterventionJobState JobState = "UserIntervention"
+	// ContinueJobState shall represent that the operation has been resumed
+	// from a paused condition and should return to a Running state.
+	ContinueJobState JobState = "Continue"
+)
+
+// JobPayload shall contain information detailing the HTTP and JSON payload
+// information for executing this Job.
+type JobPayload struct {
+	// HTTPHeaders shall contain an array of HTTP headers in this Job.
+	HTTPHeaders []string
+	// HTTPOperation shall contain the HTTP operation that executes this Job.
+	HTTPOperation string `json:"HttpOperation"`
+	// JsonBody shall contain JSON-formatted payload for this Job.
+	JsonBody string
+	// TargetUri shall contain link to a target location for an HTTP operation.
+	TargetUri string
+}
+
+// Job shall contain a job in a Redfish implementation.
+type Job struct {
+	common.Entity
+
+	// ODataContext is the odata context.
+	ODataContext string `json:"@odata.context"`
+	// ODataType is the odata type.
+	ODataType string `json:"@odata.type"`
+	// CreatedBy shall contain the user name, software program name,
+	// or other identifier indicating the creator of this job.
+	CreatedBy string
+	// Description provides a description of this resource.
+	Description string
+	// EndTime shall indicate the date and time when the job was completed.
+	// This property shall not appear if the job is running or was not
+	// completed.  This property shall appear only if the JobState is
+	// Completed, Cancelled, or Exception.
+	EndTime string
+	// EstimatedDuration shall indicate the estimated total time needed to
+	// complete the job. The value is not expected to change while the job is
+	// in progress, but the service may update the value if it obtains new
+	// information that significantly changes the expected duration.
+	// Services should be conservative in the reported estimate and clients
+	// should treat this value as an estimate.
+	EstimatedDuration string
+	// HidePayload shall indicate whether the contents of the payload should
+	// be hidden from view after the job has been created. If 'true',
+	// responses shall not return the Payload property. If 'false',
+	// responses shall return the Payload property.
+	// If this property is not present when the job is created,
+	// the default is 'false'.
+	HidePayload bool
+	// JobState shall indicate the state of the job.
+	JobState JobState
+	// JobStatus shall indicate the health status of the job.
+	// This property should contain 'Critical' if one or more messages in the
+	// Messages array contains the severity 'Critical'.
+	// This property should contain 'Warning' if one or more messages in the
+	// Messages array contains the severity 'Warning' and no messages contain
+	// the severity 'Critical'.
+	// This property should contain 'OK' if all messages in the Messages
+	// array contain the severity 'OK' or the array is empty.
+	JobStatus common.Health
+	// MaxExecutionTime shall be an ISO 8601 conformant duration describing
+	// the maximum duration the job is allowed to execute before being
+	// stopped by the service.
+	MaxExecutionTime string
+	// Messages shall contain an array of messages associated with the job.
+	Messages []common.Message
+	// Payload shall contain the HTTP and JSON payload information for
+	// executing this job. This property shall not be included in the
+	// response if the HidePayload property is 'true'.
+	Payload JobPayload
+	// PercentComplete shall indicate the completion progress of the job,
+	// reported in percent of completion. If the job has not been started,
+	// the value shall be zero.
+	PercentComplete int
+	// Schedule shall contain the scheduling details for this job and the
+	// recurrence frequency for future instances of this job.
+	Schedule string
+	// StartTime shall indicate the date and time when the job was last
+	// started or is scheduled to start.
+	StartTime string
+	// StepOrder shall contain an array of IDs for the job steps in the order
+	// that they shall be executed.
+	// Each step shall be completed prior to the execution of the next step
+	// in array order. An incomplete list of steps shall be considered an
+	// invalid configuration. If this property is not present or contains an
+	// empty array it shall indicate that the step execution order is omitted
+	// and may occur in parallel or in series as determined by the service.
+	StepOrder []string
+	// Steps shall contain the link to a resource collection of type
+	// JobCollection. This property shall not be present if this resource
+	// represents a step for a job.
+	steps string
+}
+
+// UnmarshalJSON unmarshals a Job object from the raw JSON.
+func (job *Job) UnmarshalJSON(b []byte) error {
+	type temp Job
+	var t struct {
+		temp
+		Steps common.Link
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	*job = Job(t.temp)
+
+	// Extract the links to other entities for later
+	job.steps = t.Steps.String()
+	return nil
+}
+
+// GetJob will get a Job instance from the service.
+func GetJob(c common.Client, uri string) (*Job, error) {
+	var job Job
+	return &job, job.Get(c, uri, &job)
+}
+
+// ListReferencedJobs gets the collection of Job from
+// a provided reference.
+func ListReferencedJobs(c common.Client, link string) ([]*Job, error) { //nolint:dupl
+	var result []*Job
+	if link == "" {
+		return result, nil
+	}
+
+	type GetResult struct {
+		Item  *Job
+		Link  string
+		Error error
+	}
+
+	ch := make(chan GetResult)
+	collectionError := common.NewCollectionError()
+	get := func(link string) {
+		job, err := GetJob(c, link)
+		ch <- GetResult{Item: job, Link: link, Error: err}
+	}
+
+	go func() {
+		err := common.CollectList(get, c, link)
+		if err != nil {
+			collectionError.Failures[link] = err
+		}
+		close(ch)
+	}()
+
+	for r := range ch {
+		if r.Error != nil {
+			collectionError.Failures[r.Link] = r.Error
+		} else {
+			result = append(result, r.Item)
+		}
+	}
+
+	if collectionError.Empty() {
+		return result, nil
+	}
+
+	return result, collectionError
+}

--- a/redfish/job.go
+++ b/redfish/job.go
@@ -58,13 +58,13 @@ const (
 // information for executing this Job.
 type JobPayload struct {
 	// HTTPHeaders shall contain an array of HTTP headers in this Job.
-	HTTPHeaders []string
+	HTTPHeaders []string `json:"HttpHeaders"`
 	// HTTPOperation shall contain the HTTP operation that executes this Job.
 	HTTPOperation string `json:"HttpOperation"`
 	// JsonBody shall contain JSON-formatted payload for this Job.
-	JSONBody string
+	JSONBody string `json:"JsonBody"`
 	// TargetUri shall contain link to a target location for an HTTP operation.
-	TargetURI string
+	TargetURI string `json:"TargetUri"`
 }
 
 // Job shall contain a job in a Redfish implementation.

--- a/redfish/job_test.go
+++ b/redfish/job_test.go
@@ -1,0 +1,87 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package redfish
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stmcginnis/gofish/common"
+)
+
+var jobBody = strings.NewReader(
+	`{
+		"@odata.context": "/redfish/v1/$metadata#Job.Job",
+		"@odata.type": "#Job.v1_0_7.Job",
+		"@odata.id": "/redfish/v1/JobService/Jobs/Job-1",
+		"Id": "Job-1",
+		"Name": "JobOne",
+		"Description": "Job One",
+		"EndTime": "2012-03-07T14:44+06:00",
+		"HidePayload": false,
+		"Messages": [{
+            "Resolution": "None",
+            "@odata.type": "#Message.v1_1_2.Message",
+            "Message": "An update is in progress.",
+            "MessageArgs": [],
+            "MessageId": "Update.1.0.UpdateInProgress",
+            "MessageSeverity": "OK"
+        }],
+		"Payload": {
+			"HttpHeaders": ["User-Agent: Tadpole"],
+			"HttpOperation": "POST",
+			"JsonBody": "{}",
+			"TargetUri": "http://example.com/API"
+		},
+		"PercentComplete": 60,
+		"StartTime": "2012-03-07T14:04+06:00",
+		"StepOrder": [
+        	"Step-1"
+    	],		
+		"Steps": {
+			"@odata.id": "/redfish/v1/JobService/Jobs/Job-1/Steps"
+		},
+		"JobState": "Running",
+		"JobStatus": "OK"
+	}`)
+
+// TestJob tests the parsing of Job objects.
+func TestJob(t *testing.T) {
+	var result Job
+	err := json.NewDecoder(jobBody).Decode(&result)
+
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+
+	if result.ID != "Job-1" {
+		t.Errorf("Received invalid ID: %s", result.ID)
+	}
+
+	if result.Name != "JobOne" {
+		t.Errorf("Received invalid name: %s", result.Name)
+	}
+
+	if result.Payload.HTTPOperation != "POST" {
+		t.Errorf("Invalid HTTP operation: %s", result.Payload.HTTPOperation)
+	}
+
+	if result.JobState != RunningJobState {
+		t.Errorf("Invalid JobState: %s", result.JobState)
+	}
+
+	if result.JobStatus != common.OKHealth {
+		t.Errorf("Invalid JobStatus: %s", result.JobStatus)
+	}
+
+	if len(result.Messages) != 1 {
+		t.Errorf("Incorrect number of job messages: %d", len(result.Messages))
+	}
+
+	if result.steps != "/redfish/v1/JobService/Jobs/Job-1/Steps" {
+		t.Errorf("Invalid steps reference")
+	}
+}

--- a/redfish/jobservice.go
+++ b/redfish/jobservice.go
@@ -1,0 +1,92 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package redfish
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/stmcginnis/gofish/common"
+)
+
+// JobServiceCapabilities shall contain properties that describe the
+// capabilities or supported features of this implementation of a job service.
+type JobServiceCapabilities struct {
+	// MaxJobs shall contain the maximum number of jobs supported by the
+	// implementation.
+	MaxJobs int
+	// MaxSteps shall contain the maximum number of steps supported by a
+	// single job instance.
+	MaxSteps int
+	// Scheduling shall indicate whether the Schedule property within the job
+	// supports scheduling of jobs.
+	Scheduling bool
+}
+
+// JobService shall represent a job service for a Redfish implementation.
+type JobService struct {
+	common.Entity
+
+	// ODataContext is the odata context.
+	ODataContext string `json:"@odata.context"`
+	// ODataType is the odata type.
+	ODataType string `json:"@odata.type"`
+	// DateTime shall contain the current date and time setting for the job
+	// service.
+	DateTime time.Time
+	// Description provides a description of this resource.
+	Description string
+	// jobs shall contain a link to a resource collection of type JobCollection.
+	jobs string
+	// log shall contain a link to a resource of type LogService that this
+	// job service uses.
+	log string
+	// ServiceCapabilities shall contain properties that describe the
+	// capabilities or supported features of this implementation of a job
+	// service.
+	ServiceCapabilities JobServiceCapabilities
+	// ServiceEnabled shall indicate whether this service is enabled.
+	ServiceEnabled bool
+	// Status shall contain any status or health properties of the resource.
+	Status common.Status
+}
+
+// UnmarshalJSON unmarshals a JobService object from the raw JSON.
+func (jobservice *JobService) UnmarshalJSON(b []byte) error {
+	type temp JobService
+	var t struct {
+		temp
+		Jobs common.Link
+		Log  common.Link
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	*jobservice = JobService(t.temp)
+
+	// Extract the links to other entities for later
+	jobservice.jobs = t.Jobs.String()
+	jobservice.log = t.Log.String()
+	return nil
+}
+
+// GetJobService will get a JobService instance from the service.
+func GetJobService(c common.Client, uri string) (*JobService, error) {
+	var jobService JobService
+	return &jobService, jobService.Get(c, uri, &jobService)
+}
+
+// Jobs gets the collection of jobs of this job service
+func (jobservice *JobService) Jobs() ([]*Job, error) {
+	return ListReferencedJobs(jobservice.GetClient(), jobservice.jobs)
+}
+
+// Log gets the LogService instance for this job service
+func (jobservice *JobService) Log() (*LogService, error) {
+	return GetLogService(jobservice.GetClient(), jobservice.log)
+}

--- a/redfish/jobservice_test.go
+++ b/redfish/jobservice_test.go
@@ -1,0 +1,69 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package redfish
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+var simpleJobServiceBody = `{
+   "@odata.context":"/redfish/v1/$metadata#JobService.JobService",
+   "@odata.etag":"\"1614826331\"",
+   "@odata.id":"/redfish/v1/JobService",
+   "@odata.type":"#JobService.v1_0_4.JobService",
+   "DateTime":"2023-04-25T01:15:32+00:00",
+   "Description":"Job Service",
+   "Id":"JobService",
+   "Name":"Job Service",
+   "ServiceEnabled":true,
+   "ServiceCapabilities": {
+      "Scheduling": true,
+      "MaxSteps": 50,
+      "MaxJobs": 50
+   },
+   "Status":{
+      "Health":"OK",
+      "HealthRollup": "OK",
+      "State":"Enabled"
+   },
+   "Jobs":{
+      "@odata.id":"/redfish/v1/JobService/Jobs"
+   },
+   "Log":{
+      "@odata.id":"/redfish/v1/JobService/Log"
+   }
+}`
+
+func TestJobService(t *testing.T) {
+	var result JobService
+	err := json.NewDecoder(strings.NewReader(simpleJobServiceBody)).Decode(&result)
+
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+
+	if result.ID != "JobService" {
+		t.Errorf("Received invalid ID: %s", result.ID)
+	}
+
+	if result.Name != "Job Service" {
+		t.Errorf("Received invalid name: %s", result.Name)
+	}
+
+	if result.jobs != "/redfish/v1/JobService/Jobs" {
+		t.Errorf("Received invalid jobs link: %s", result.jobs)
+	}
+
+	if result.log != "/redfish/v1/JobService/Log" {
+		t.Errorf("Received invalid log link: %s", result.log)
+	}
+
+	if !result.ServiceCapabilities.Scheduling || result.ServiceCapabilities.
+		MaxJobs != 50 || result.ServiceCapabilities.MaxSteps != 50 {
+		t.Errorf("Received invalid service capabilities")
+	}
+}

--- a/serviceroot.go
+++ b/serviceroot.go
@@ -341,3 +341,8 @@ func (serviceroot *Service) CompositionService() (*redfish.CompositionService, e
 func (serviceroot *Service) UpdateService() (*redfish.UpdateService, error) {
 	return redfish.GetUpdateService(serviceroot.GetClient(), serviceroot.updateService)
 }
+
+// JobService gets the job service instance
+func (serviceroot *Service) JobService() (*redfish.JobService, error) {
+	return redfish.GetJobService(serviceroot.GetClient(), serviceroot.jobService)
+}


### PR DESCRIPTION
Alternative to #257 (abandoned?) that addresses issues noted in that PR:
* Rename `ServiceCapabilities` to `JobServiceCapabilities` (consistent with schema)
* Rename service capability `ServiceEnabled` to `Scheduling` (consistent with schema. `ServiceEnabled` is a property of `JobService` rather than a capability)
* export `ListReferencedJobs` (consistent with other gofish library services)
* Move `GetJob` and `ListReferencedJobs` from jobservice.go to job.go (consistent with other gofish library services)