### PR TITLE
Add HttpBootUri into Boot

### DIFF
--- a/redfish/computersystem.go
+++ b/redfish/computersystem.go
@@ -328,6 +328,8 @@ type Boot struct {
 	UefiTargetBootSourceOverride string `json:",omitempty"`
 	// The link to a collection of certificates used for booting through HTTPS by this computer system.
 	certificates string
+	// The URI to boot from when BootSourceOverrideTarget is set to UefiHttp.
+	HTTPBootURI string `json:",omitempty"`
 }
 
 // UnmarshalJSON unmarshals a Boot object from the raw JSON.

--- a/redfish/computersystem_test.go
+++ b/redfish/computersystem_test.go
@@ -59,7 +59,8 @@ var computerSystemBody = `{
 				"SDCard",
 				"UefiHttp"
 			],
-			"UefiTargetBootSourceOverride": "uefi device path"
+			"UefiTargetBootSourceOverride": "uefi device path",
+			"HttpBootURI": "http://localhost/boot.efi"
 		},
 		"BiosVersion": "P79 v1.00 (09/20/2013)",
 		"ProcessorSummary": {
@@ -196,6 +197,10 @@ func TestComputerSystem(t *testing.T) { //nolint
 
 	if result.Boot.UefiTargetBootSourceOverride != "uefi device path" {
 		t.Errorf("Received invalid uefi target boot source: %s", result.Boot.UefiTargetBootSourceOverride)
+	}
+
+	if result.Boot.HTTPBootURI != "http://localhost/boot.efi" {
+		t.Errorf("Received invalid http boot uri: %s", result.Boot.HTTPBootURI)
 	}
 
 	if result.ProcessorSummary.Status.State != common.EnabledState {


### PR DESCRIPTION
This flag allows to override UEFI HTTP Boot URI, only works when BootSourceOverrideTarget is set to UefiHttp.

I could not find any unit test for updating boot structure, let me know if I missed it. Thanks!