### PR TITLE
fix manager reset action when no allowed values for reset type are provided

### DIFF
--- a/redfish/manager.go
+++ b/redfish/manager.go
@@ -438,10 +438,7 @@ func ListReferencedManagers(c common.Client, link string) ([]*Manager, error) { 
 func (manager *Manager) Reset(resetType ResetType) error {
 	if len(manager.SupportedResetTypes) == 0 {
 		// reset directly without reset type. HPE server has the behavior
-		t := struct {
-			Action string
-		}{Action: "Manager.Reset"}
-		return manager.Post(manager.resetTarget, t)
+		return manager.Post(manager.resetTarget, struct{}{})
 	}
 	// Make sure the requested reset type is supported by the manager.
 	valid := false


### PR DESCRIPTION
Sometimes Manager.Reset action doesn't provide AllowableValues for ResetTypes, like that:
```
  "Actions": {
    "#Manager.Reset": {
      "target": "/redfish/v1/Managers/1/Actions/Manager.Reset/"
    }
  }
```
In this case current implementation provides a payload `{"Action": "Manager.Reset"}` which doesn't work at least for HP gen9 (iLO4) that I can test on. I get `Base.0.10.ActionNotSupported` error.

According to the [specification](https://redfish.dmtf.org/schemas/v1/Manager.v1_18_0.yaml):
```
    Manager_v1_18_0_ResetRequestBody:
        ....
        ResetType:
          ...
          x-longDescription: This parameter shall contain the type of reset.  The
            service can accept a request without the parameter and perform an implementation
            specific default reset.  Services should include the @Redfish.AllowableValues
            annotation for this parameter to ensure compatibility with clients, even
            when ActionInfo has been implemented.
         ...
```
it seems like an empty payload should be sent in this case.

I've tested an empty payload on HP gen9 and it works as expected.

Please, consider the fix for this case.