### PR TITLE
Services.Tasks(): fix no Task objects being returned

### DIFF
--- a/serviceroot.go
+++ b/serviceroot.go
@@ -250,7 +250,12 @@ func (serviceroot *Service) StorageServices() ([]*swordfish.StorageService, erro
 
 // Tasks gets the system's tasks
 func (serviceroot *Service) Tasks() ([]*redfish.Task, error) {
-	return redfish.ListReferencedTasks(serviceroot.GetClient(), serviceroot.tasks)
+	ts, err := redfish.GetTaskService(serviceroot.GetClient(), serviceroot.tasks)
+	if err != nil {
+		return nil, err
+	}
+
+	return ts.Tasks()
 }
 
 // TaskService gets the task service instance


### PR DESCRIPTION
Use the `redfish.GetTaskService()` method to retrieve linked Task objects instead - since they cannot be unmarshaled by common.Client.