### PR TITLE
redfish/task: Adds the Oem field as json.RawMessage

### DIFF
--- a/redfish/task.go
+++ b/redfish/task.go
@@ -128,6 +128,8 @@ type Task struct {
 	// Status section of the Redfish specification and shall not be set until
 	// the task has completed.
 	TaskStatus common.Health
+	// Oem property contains OEM specific task information
+	Oem json.RawMessage `json:"Oem,omitempty"`
 }
 
 // UnmarshalJSON unmarshals a Task object from the raw JSON.

--- a/redfish/task_test.go
+++ b/redfish/task_test.go
@@ -36,6 +36,24 @@ var taskBody = strings.NewReader(
 			"JsonBody": "{}",
 			"TargetUri": "http://example.com/API"
 		},
+		"Oem": {
+			"Dell": {
+			  "@odata.type": "#DellJob.v1_4_0.DellJob",
+			  "CompletionTime": null,
+			  "Description": "Job Instance",
+			  "EndTime": "TIME_NA",
+			  "Id": "JID_005950769310",
+			  "JobState": "Scheduled",
+			  "JobType": "FirmwareUpdate",
+			  "Message": "Task successfully scheduled.",
+			  "MessageArgs": [],
+			  "MessageId": "IDRAC.2.8.JCP001",
+			  "Name": "Firmware Update: BIOS",
+			  "PercentComplete": 0,
+			  "StartTime": "TIME_NOW",
+			  "TargetSettingsURI": null
+			}
+		 },
 		"PercentComplete": 60,
 		"StartTime": "2012-03-07T14:04+06:00",
 		"TaskMonitor": "http://example.com/API/Tasks/1",
@@ -74,5 +92,9 @@ func TestTask(t *testing.T) {
 
 	if len(result.Messages) != 1 {
 		t.Errorf("Incorrect number of task messages: %d", len(result.Messages))
+	}
+
+	if len(result.Oem) == 0 {
+		t.Error("Expected Oem object with properties, got none")
 	}
 }


### PR DESCRIPTION
This exposes the Task `Oem` field to the caller, its upto the caller to unmarshal its contents.

@stmcginnis  Let me know if this should go into `common.Entity` or if it should be done differently.
