### PR TITLE
added new parameter MediaType to VirtualMediaConfig

### DIFF
--- a/redfish/virtualmedia.go
+++ b/redfish/virtualmedia.go
@@ -106,7 +106,7 @@ type VirtualMedia struct {
 	// types for this connection.
 	MediaTypes []VirtualMediaType
 	// Indicates which MediaTypes is used
-	MediaType string
+	MediaType VirtualMediaType
 	// Password shall represent the password to access the
 	// Image parameter-specified URI. The value shall be null in responses.
 	Password string
@@ -185,6 +185,7 @@ func (virtualmedia *VirtualMedia) Update() error {
 	readWriteFields := []string{
 		"Image",
 		"Inserted",
+		"MediaType",
 		"Password",
 		"TransferMethod",
 		"TransferProtocolType",
@@ -229,12 +230,13 @@ func (virtualmedia *VirtualMedia) InsertMedia(image string, inserted, writeProte
 // VirtualMediaConfig is an struct used to pass config data to build the HTTP body when inserting media
 type VirtualMediaConfig struct {
 	Image                string
-	Inserted             bool   `json:",omitempty"`
-	Password             string `json:",omitempty"`
-	TransferMethod       string `json:",omitempty"`
-	TransferProtocolType string `json:",omitempty"`
-	UserName             string `json:",omitempty"`
-	WriteProtected       bool   `json:",omitempty"`
+	Inserted             bool                 `json:",omitempty"`
+	MediaType            VirtualMediaType     `json:",omitempty"`
+	Password             string               `json:",omitempty"`
+	TransferMethod       TransferMethod       `json:",omitempty"`
+	TransferProtocolType TransferProtocolType `json:",omitempty"`
+	UserName             string               `json:",omitempty"`
+	WriteProtected       bool                 `json:",omitempty"`
 }
 
 // InsertMediaConfig sends a request to insert virtual media using the VirtualMediaConfig struct

--- a/redfish/virtualmedia_test.go
+++ b/redfish/virtualmedia_test.go
@@ -114,7 +114,6 @@ func TestVirtualMediaUpdate(t *testing.T) {
 
 	testClient := &common.TestClient{}
 	result.SetClient(testClient)
-
 	result.UserName = "Fred"
 	result.WriteProtected = false
 	err = result.Update()
@@ -206,6 +205,7 @@ func TestVirtualMediaInsertConfig(t *testing.T) {
 	virtualMediaConfig := VirtualMediaConfig{
 		Image:          "https://example.com/image",
 		Inserted:       true,
+		MediaType:      "CD",
 		Password:       "test1234",
 		UserName:       "root",
 		WriteProtected: true,
@@ -222,6 +222,9 @@ func TestVirtualMediaInsertConfig(t *testing.T) {
 		t.Errorf("Unexpected InsertMedia Image payload: %s", calls[0].Payload)
 	}
 	if !strings.Contains(calls[0].Payload, "Inserted:true") {
+		t.Errorf("Unexpected InsertMedia Inserted payload: %s", calls[0].Payload)
+	}
+	if !strings.Contains(calls[0].Payload, "MediaType:CD") {
 		t.Errorf("Unexpected InsertMedia Inserted payload: %s", calls[0].Payload)
 	}
 	if !strings.Contains(calls[0].Payload, "Password:test1234") {


### PR DESCRIPTION
we need to add a new parameter because without it an error occurs:
400: {
  "MediaType@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The property MediaType is a required property and must be included in the request.",
      "MessageArgs": [
        "MediaType"
      ],
      "MessageId": "Base.1.8.1.PropertyMissing",
      "MessageSeverity": "Warning",
      "Resolution": "Ensure that the property is in the request body and has a valid value and resubmit the request if the operation failed."
    }
  ]
}