### PR TITLE
Correct HttpBootUri JSON case

### DIFF
--- a/redfish/computersystem.go
+++ b/redfish/computersystem.go
@@ -330,7 +330,7 @@ type Boot struct {
 	// The link to a collection of certificates used for booting through HTTPS by this computer system.
 	certificates string
 	// The URI to boot from when BootSourceOverrideTarget is set to UefiHttp.
-	HTTPBootURI string `json:",omitempty"`
+	HTTPBootURI string `json:"HttpBootUri,omitempty"`
 }
 
 // UnmarshalJSON unmarshals a Boot object from the raw JSON.

--- a/redfish/computersystem_test.go
+++ b/redfish/computersystem_test.go
@@ -60,7 +60,7 @@ var computerSystemBody = `{
 				"UefiHttp"
 			],
 			"UefiTargetBootSourceOverride": "uefi device path",
-			"HttpBootURI": "http://localhost/boot.efi"
+			"HttpBootUri": "http://localhost/boot.efi"
 		},
 		"BiosVersion": "P79 v1.00 (09/20/2013)",
 		"ProcessorSummary": {


### PR DESCRIPTION
This patch corrects the JSON name for HttpBootUri to the camel case used in the spec. Turns out it has no effect on tests because (TIL) Go JSON marshaler in stdlib is by default case insensitive:

https://pkg.go.dev/encoding/json#Unmarshal

To unmarshal JSON into a struct, Unmarshal matches incoming object keys to the keys used by Marshal (either the struct field name or its tag), preferring an exact match but also accepting a case-insensitive match. By default, object keys which don't have a corresponding struct field are ignored (see Decoder.DisallowUnknownFields for an alternative).

It is worth mentioning that I haven’t tested this new feature yet on a real hardware and the Redfish specification does not tell (or at least I could not figure it out) if JSON keys are supposed to be case sensitive or not. But it is better to fix this.

Anyway, I want this to be fixed an aligned with other fields. The test actually confirms that Go behaviour, it was previously in a sort of hybrid form `HttpBootURI`.

Can you tell me more about how to implement reading of AllowableValues for this:

```
			"BootSourceOverrideTarget@Redfish.AllowableValues": [
				"None",
				"Pxe",
				"Floppy",
				"Cd",
				"Usb",
				"Hdd",
				"BiosSetup",
				"Utilities",
				"Diags",
				"UefiTarget",
				"SDCard",
				"UefiHttp"
			],
```

It looks like other code performs some sort of custom decoding. I wonder why is that, my initial idea would be to simple add a new field with custom JSON name. Shall I do the same if I want this feature? Thanks.