### PR TITLE
fix insurance, check that the object is still active before disconnecting

### DIFF
--- a/client.go
+++ b/client.go
@@ -573,7 +573,7 @@ func (c *APIClient) dumpResponse(resp *http.Response) error {
 // Logout will delete any active session. Useful to defer logout when creating
 // a new connection.
 func (c *APIClient) Logout() {
-	if c.Service != nil && c.auth != nil {
+	if c != nil && c.Service != nil && c.auth != nil {
 		_ = c.Service.DeleteSession(c.auth.Session)
 	}
 }


### PR DESCRIPTION
I caught a panic in a pet project on the state switch when I checked if the connection was available and if the. bmc's service was available

        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x138a3ae]

goroutine 1 [running]:
github.com/stmcginnis/gofish.(*APIClient).Logout(0x0?)
        /Users/max/Desktop/code/device-mgr/vendor/github.com/stmcginnis/gofish/client.go:576 +0xe
panic({0x13e4040?, 0x1812cf0?})