### PR TITLE
added the ability to take networkDeviceFunctions, pcieDevices and networkPorts  from Controller

### DIFF
--- a/redfish/eventdestination.go
+++ b/redfish/eventdestination.go
@@ -459,7 +459,7 @@ func sendCreateEventDestinationRequest(
 
 	resp, err := c.Post(uri, s)
 	if err != nil {
-		return
+		return err.Error(), err
 	}
 	defer resp.Body.Close()
 

--- a/redfish/networkadapter_test.go
+++ b/redfish/networkadapter_test.go
@@ -52,11 +52,7 @@ var networkAdapterBody = strings.NewReader(
 				"NetworkDeviceFunctions@odata.count": 1,
 				"NetworkPorts": [{
 						"@odata.id": "/redfish/v1/NetworkAdapters/Port-1"
-					},
-					{
-						"@odata.id": "/redfish/v1/NetworkAdapters/Port-2"
-					}
-				],
+					}],
 				"NetworkPorts@odata.count": 2,
 				"PCIeDevices": [{
 					"@odata.id": "/redfish/v1/NetworkAdapters/PCIeDevice-1"
@@ -108,21 +104,31 @@ func TestNetworkAdapter(t *testing.T) {
 		t.Errorf("Received invalid name: %s", result.Name)
 	}
 
-	if !result.Controllers[0].ControllerCapabilities.DataCenterBridging.Capable {
+	if !result.controllers[0].ControllerCapabilities.DataCenterBridging.Capable {
 		t.Error("DCB should be enabled")
 	}
 
-	if result.Controllers[0].ControllerCapabilities.NPIV.MaxDeviceLogins != 1024 {
+	if result.controllers[0].ControllerCapabilities.NPIV.MaxDeviceLogins != 1024 {
 		t.Errorf("Received incorrect Controller NPIC max device logins: %d",
-			result.Controllers[0].ControllerCapabilities.NPIV.MaxDeviceLogins)
+			result.controllers[0].ControllerCapabilities.NPIV.MaxDeviceLogins)
 	}
 
-	if result.Controllers[0].PCIeInterface.MaxPCIeType != Gen4PCIeTypes {
-		t.Errorf("Received incorrect max PCIe type: %s", result.Controllers[0].PCIeInterface.MaxPCIeType)
+	if result.controllers[0].PCIeInterface.MaxPCIeType != Gen4PCIeTypes {
+		t.Errorf("Received incorrect max PCIe type: %s", result.controllers[0].PCIeInterface.MaxPCIeType)
 	}
 
-	if result.Controllers[0].PCIeInterface.PCIeType != Gen4PCIeTypes {
-		t.Errorf("Received incorrect PCIe type: %s", result.Controllers[0].PCIeInterface.PCIeType)
+	if result.controllers[0].PCIeInterface.PCIeType != Gen4PCIeTypes {
+		t.Errorf("Received incorrect PCIe type: %s", result.controllers[0].PCIeInterface.PCIeType)
+	}
+
+	if PCIeTypes(result.controllers[0].pcieDevices[0]) != "/redfish/v1/NetworkAdapters/PCIeDevice-1" {
+		t.Errorf("Received incorrect PCIeDevice  Link: %s", "/redfish/v1/NetworkAdapters/PCIeDevice-1")
+	}
+	if PCIeTypes(result.controllers[0].networkPorts[0]) != "/redfish/v1/NetworkAdapters/Port-1" {
+		t.Errorf("Received incorrect NetworkPorts  Link: %s", "/redfish/v1/NetworkAdapters/Port-1")
+	}
+	if PCIeTypes(result.controllers[0].networkDeviceFunctions[0]) != "/redfish/v1/NetworkAdapters/DeviceFunction-1" {
+		t.Errorf("Received incorrect NetworkDeviceFunctions  Link: %s", "/redfish/v1/NetworkAdapters/DeviceFunction-1")
 	}
 
 	if result.resetSettingsToDefaultTarget != "/redfish/v1/NetworkAdapter/Actions/NetworkAdapter.ResetSettingsToDefault" {


### PR DESCRIPTION
need connect PcieDevice to a network adapter in the current implementation, this task could not be implemented so I had to rewrite the controller class

Now from the Controller we can get Network ports Network functions and PCI devices

ex:
{
    "@odata.context": "/redfish/v1/$metadata#NetworkAdapter.NetworkAdapter",
    "@odata.etag": "\"1706246633\"",
    "@odata.id": "/redfish/v1/Chassis/Self/NetworkAdapters/DevType7_NIC1",
    "@odata.type": "#NetworkAdapter.v1_3_0.NetworkAdapter",
    "Controllers": [
        {
            "FirmwarePackageVersion": "nil",
            "Links": {
                "NetworkDeviceFunctions": [
                    {
                        "@odata.id": "/redfish/v1/Chassis/Self/NetworkAdapters/DevType7_NIC1/NetworkDeviceFunctions/NetworkDeviceFunction1"
                    }
                ],
                "NetworkDeviceFunctions@odata.count": 1,
                "NetworkPorts": [
                    {
                        "@odata.id": "/redfish/v1/Chassis/Self/NetworkAdapters/DevType7_NIC1/NetworkPorts/DevType7_DMMY_Instance1_PORT1"
                    }
                ],
                "NetworkPorts@odata.count": 1,
                "PCIeDevices": [
                    {
                        "@odata.id": "/redfish/v1/Chassis/Self/PCIeDevices/00_01_00"
                    }
                ],
                "PCIeDevices@odata.count": 1
            }
        }
    ],
    "Id": "DevType7_NIC1",
    "Name": "DevType7_NIC1",
    "NetworkDeviceFunctions": {
        "@odata.id": "/redfish/v1/Chassis/Self/NetworkAdapters/DevType7_NIC1/NetworkDeviceFunctions"
    },
    "NetworkPorts": {
        "@odata.id": "/redfish/v1/Chassis/Self/NetworkAdapters/DevType7_NIC1/NetworkPorts"
    },
    "Status": {
        "Health": "OK",
        "State": "Disabled"
    }
}