### PR TITLE
Add deprecation note to Storage.StorageControllers

### DIFF
--- a/redfish/storage.go
+++ b/redfish/storage.go
@@ -140,6 +140,7 @@ type Storage struct {
 	Status common.Status
 	// StorageControllers is a collection that indicates all the storage
 	// controllers that this resource represents.
+	// This property has been deprecated in favor of Controllers to allow for storage controllers to be represented as their own resources.
 	StorageControllers []StorageController
 	// StorageControllersCount is the number of storage controllers.
 	StorageControllersCount int `json:"StorageControllers@odata.count"`


### PR DESCRIPTION
This property has been deprecated in favor of linking to a collection of objects, rather than embedding in the storage object. This adds a note to make it clear to consumers that this property may not be the right way to access this information if talking to a newer system.

Closes: #294 