### PR TITLE
make getting Chassis collection work with DPU BMCs

### DIFF
--- a/redfish/chassis.go
+++ b/redfish/chassis.go
@@ -504,6 +504,7 @@ func (chassis *Chassis) UnmarshalJSON(b []byte) error {
 	// Extract the links to other entities for later
 	chassis.assembly = t.Assembly.String()
 	chassis.certificates = t.Certificates.String()
+	chassis.controls = t.Controls.String()
 	chassis.drives = t.Drives.String()
 	chassis.environmentMetrics = t.EnvironmentMetrics.String()
 	chassis.fabricAdapters = t.FabricAdapters.String()

--- a/redfish/chassis_test.go
+++ b/redfish/chassis_test.go
@@ -39,6 +39,9 @@ var chassisBody = `{
 		"Assembly": {
 			"@odata.id": "/redfish/v1/Chassis/Chassis-1/Assembly"
 		},
+		"Controls": {
+			"@odata.id": "/redfish/v1/Chassis/Chassis-1/Controls"
+		},
 		"Drives": {
 			"@odata.id": "/redfish/v1/Chassis/Chassis-1/Drives"
 		},
@@ -153,6 +156,10 @@ func TestChassis(t *testing.T) {
 
 	if result.assembly != "/redfish/v1/Chassis/Chassis-1/Assembly" {
 		t.Errorf("Received invalid assembly reference: %s", result.assembly)
+	}
+
+	if result.controls != "/redfish/v1/Chassis/Chassis-1/Controls" {
+		t.Errorf("Received invalid controls reference: %s", result.controls)
 	}
 
 	if result.drives != "/redfish/v1/Chassis/Chassis-1/Drives" {


### PR DESCRIPTION
This fixes the issue where we cannot get the Chassis collection for DPU BMCs. 

Per Redfish docs, Controls should be a `Link` singular

```
Controls (v1.17+) { object The link to the collection of controls located in this chassis.
Contains a link to a resource.
@odata.id string read-only Link to Collection of Control. See the Control schema for
details.
}
```

Closes: #322

