### PR TITLE
Fix Chassis controls link definition

### DIFF
--- a/redfish/chassis.go
+++ b/redfish/chassis.go
@@ -473,7 +473,7 @@ func (chassis *Chassis) UnmarshalJSON(b []byte) error {
 		temp
 		Assembly           common.Link
 		Certificates       common.Link
-		Controls           common.Links
+		Controls           common.Link
 		Drives             common.Link
 		EnvironmentMetrics common.Link
 		FabricAdapters     common.Link
@@ -504,6 +504,7 @@ func (chassis *Chassis) UnmarshalJSON(b []byte) error {
 	// Extract the links to other entities for later
 	chassis.assembly = t.Assembly.String()
 	chassis.certificates = t.Certificates.String()
+	chassis.controls = t.Controls.String()
 	chassis.drives = t.Drives.String()
 	chassis.environmentMetrics = t.EnvironmentMetrics.String()
 	chassis.fabricAdapters = t.FabricAdapters.String()

--- a/redfish/chassis_test.go
+++ b/redfish/chassis_test.go
@@ -39,6 +39,9 @@ var chassisBody = `{
 		"Assembly": {
 			"@odata.id": "/redfish/v1/Chassis/Chassis-1/Assembly"
 		},
+		"Controls": {
+			"@odata.id": "/redfish/v1/Chassis/Chassis-1/Controls"
+		},
 		"Drives": {
 			"@odata.id": "/redfish/v1/Chassis/Chassis-1/Drives"
 		},
@@ -153,6 +156,10 @@ func TestChassis(t *testing.T) {
 
 	if result.assembly != "/redfish/v1/Chassis/Chassis-1/Assembly" {
 		t.Errorf("Received invalid assembly reference: %s", result.assembly)
+	}
+
+	if result.controls != "/redfish/v1/Chassis/Chassis-1/Controls" {
+		t.Errorf("Received invalid controls reference: %s", result.controls)
 	}
 
 	if result.drives != "/redfish/v1/Chassis/Chassis-1/Drives" {


### PR DESCRIPTION
The Controls property of the Chassis object was incorrectly defined as a `common.Links` type, but it is actually a link to a collection, so it should be a `common.Link` (singular). This changes it to the Link type to avoid a JSON marshalling error on systems that populate this property.

This also uncovered that the link that is used later to retrieve these controls was never actually being set. Both issues are now fixed.

Fixes: #322