### PR TITLE
Fix marshalling error with Thermal objects

### DIFF
--- a/redfish/thermal.go
+++ b/redfish/thermal.go
@@ -78,7 +78,7 @@ type ThermalFan struct {
 	// RedundancyCount is the number of Redundancy items.
 	RedundancyCount int `json:"Redundancy@odata.count"`
 	// RelatedItem shall contain an array of links to resources or objects that this fan services.
-	RelatedItem []string
+	relatedItem []string
 	// RelatedItem@odataCount is the number of related items.
 	RelatedItemCount int `json:"RelatedItem@odata.count"`
 	// SensorNumber shall contain a numerical identifier for this fan speed sensor that is unique within this resource.
@@ -108,8 +108,9 @@ func (fan *ThermalFan) UnmarshalJSON(b []byte) error {
 	type temp ThermalFan
 	var t struct {
 		temp
-		Assembly   common.Link
-		Redundancy common.Links
+		Assembly    common.Link
+		Redundancy  common.Links
+		RelatedItem common.Links
 	}
 
 	err := json.Unmarshal(b, &t)
@@ -122,6 +123,7 @@ func (fan *ThermalFan) UnmarshalJSON(b []byte) error {
 	// Extract the links to other entities for later
 	fan.assembly = t.Assembly.String()
 	fan.redundancy = t.Redundancy.ToStrings()
+	fan.relatedItem = t.RelatedItem.ToStrings()
 
 	// This is a read/write object, so we need to save the raw object data for later
 	fan.rawData = b
@@ -216,7 +218,7 @@ type Temperature struct {
 	ReadingCelsius float32
 	// RelatedItem shall contain an array of links to resources or objects that represent areas or devices to which
 	// this temperature applies.
-	RelatedItem []string
+	relatedItem []string
 	// RelatedItemCount is the number of related items.
 	RelatedItemCount int `json:"RelatedItem@odata.count"`
 	// SensorNumber shall be a numerical identifier for this temperature sensor
@@ -252,6 +254,7 @@ func (temperature *Temperature) UnmarshalJSON(b []byte) error {
 	type temp Temperature
 	var t struct {
 		temp
+		RelatedItem common.Links
 	}
 
 	err := json.Unmarshal(b, &t)
@@ -262,6 +265,7 @@ func (temperature *Temperature) UnmarshalJSON(b []byte) error {
 	*temperature = Temperature(t.temp)
 
 	// Extract the links to other entities for later
+	temperature.relatedItem = t.RelatedItem.ToStrings()
 
 	// This is a read/write object, so we need to save the raw object data for later
 	temperature.rawData = b

--- a/redfish/thermal_test.go
+++ b/redfish/thermal_test.go
@@ -11,86 +11,558 @@ import (
 )
 
 var thermalBody = `{
-		"@odata.context": "/redfish/v1/$metadata#Thermal.Thermal",
-		"@odata.type": "#Thermal.v1_0_0.Thermal",
-		"@odata.id": "/redfish/v1/Thermal",
-		"Id": "Thermal-1",
-		"Name": "ThermalOne",
-		"Description": "Thermal One",
-		"Fans": [{
-			"Id": "Fan1",
-			"FanName": "Fan One",
-			"Assembly": {
-				"@odata.id": "/redfish/v1/Assemblies/1"
-			},
-			"HotPluggable": true,
-			"IndicatorLED": "Lit",
-			"LowerThresholdCritical": 10,
-			"LowerThresholdFatal": 0,
-			"LowerThresholdNonCritical": 11,
-			"Manufacturer": "Acme Fans",
-			"MaxReadingRange": 100,
-			"MemberId": "Fan1",
-			"MinReadingRange": 10,
-			"Model": "Fan2000",
-			"Name": "Charlie",
-			"PartNumber": "F123",
-			"PhysicalContext": "Exhaust",
-			"Reading": 1000,
-			"ReadingUnits": "RPM",
-			"Redundancy": [],
-			"Redundancy@odata.count": 0,
-			"RelatedItem": [],
-			"RelatedItem@odata.count": 0,
-			"SensorNumber": 1,
-			"SerialNumber": "12345",
-			"SparePartNumber": "F120",
-			"Status": {
-				"State": "Enabled",
-				"Health": "OK"
-			},
-			"UpperThresholdCritical": 9999,
-			"UpperThresholdFatal": 10000,
-			"UpperThresholdNonCritical": 9998
-		}],
-		"Fan@odata.count": 1,
-		"Redundancy": [],
-		"Redundancy@odata.count": 0,
+	"@odata.type": "#Thermal.v1_6_0.Thermal",
+	"@odata.id": "/redfish/v1/Chassis/1/Thermal",
+	"Id": "Thermal-1",
+	"Name": "Thermal",
+	"Temperatures": [
+	  {
+		"@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/0",
+		"@odata.type": "#Thermal.v1_6_0.Temperature",
+		"MemberId": "0",
+		"Name": "CPU Temp",
+		"SensorNumber": 1,
 		"Status": {
-			"State": "Enabled",
-			"Health": "OK"
+		  "State": "Enabled",
+		  "Health": "OK"
 		},
-		"Temperatures": [{
-			"@odata.id": "/redfish/v1/Temp",
-			"Id": "Temp1",
-			"AdjustedMaxAllowableOperatingValue": 60,
-			"AdjustedMinAllowableOperatingValue": 1,
-			"DeltaPhysicalContext": "Exhaust",
-			"DeltaReadingCelsius": 35,
-			"LowerThresholdCritical": 1,
-			"LowerThresholdFatal": 0,
-			"LowerThresholdNonCritical": 2,
-			"MaxAllowableOperatingValue": 45,
-			"MaxReadingRangeTemp": 45,
-			"MemberId": "Thermal1",
-			"MinAllowableOperatingValue": -5,
-			"MinReadingRangeTemp": -12,
-			"Name": "Thermal Temp One",
-			"PhysicalContext": "Exhaust",
-			"ReadingCelsius": 32,
-			"RelatedItem": [],
-			"RelatedItem@odata.count": 0,
-			"SensorNumber": 1,
-			"Status": {
-				"State": "Enabled",
-				"Health": "OK"
-			},
-			"UpperThresholdCritical": 9999,
-			"UpperThresholdFatal": 10000,
-			"UpperThresholdNonCritical": 9998
-		}],
-		"Temperatures@odata.count": 1
-	}`
+		"ReadingCelsius": 63,
+		"UpperThresholdCritical": 100,
+		"UpperThresholdFatal": 100,
+		"LowerThresholdCritical": 5,
+		"LowerThresholdFatal": 5,
+		"MinReadingRangeTemp": 3,
+		"MaxReadingRangeTemp": 102,
+		"PhysicalContext": "CPU",
+		"RelatedItem": [
+		  {
+			"@odata.id": "/redfish/v1/Systems/1/Processors/1"
+		  }
+		]
+	  },
+	  {
+		"@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/1",
+		"@odata.type": "#Thermal.v1_6_0.Temperature",
+		"MemberId": "1",
+		"Name": "Inlet Temp",
+		"SensorNumber": 9,
+		"Status": {
+		  "State": "Absent"
+		},
+		"ReadingCelsius": 0,
+		"UpperThresholdCritical": 0,
+		"UpperThresholdFatal": 0,
+		"LowerThresholdCritical": 0,
+		"LowerThresholdFatal": 0,
+		"MinReadingRangeTemp": 0,
+		"MaxReadingRangeTemp": 0,
+		"PhysicalContext": "SystemBoard",
+		"RelatedItem": [
+		  {
+			"@odata.id": "/redfish/v1/Chassis/1"
+		  },
+		  {
+			"@odata.id": "/redfish/v1/Systems/1"
+		  }
+		]
+	  },
+	  {
+		"@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/2",
+		"@odata.type": "#Thermal.v1_6_0.Temperature",
+		"MemberId": "2",
+		"Name": "System Temp",
+		"SensorNumber": 11,
+		"Status": {
+		  "State": "Enabled",
+		  "Health": "OK"
+		},
+		"ReadingCelsius": 30,
+		"UpperThresholdCritical": 85,
+		"UpperThresholdFatal": 90,
+		"LowerThresholdCritical": 5,
+		"LowerThresholdFatal": 5,
+		"MinReadingRangeTemp": 3,
+		"MaxReadingRangeTemp": 92,
+		"PhysicalContext": "SystemBoard",
+		"RelatedItem": [
+		  {
+			"@odata.id": "/redfish/v1/Chassis/1"
+		  },
+		  {
+			"@odata.id": "/redfish/v1/Systems/1"
+		  }
+		]
+	  },
+	  {
+		"@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/3",
+		"@odata.type": "#Thermal.v1_6_0.Temperature",
+		"MemberId": "3",
+		"Name": "Peripheral Temp",
+		"SensorNumber": 12,
+		"Status": {
+		  "State": "Enabled",
+		  "Health": "OK"
+		},
+		"ReadingCelsius": 44,
+		"UpperThresholdCritical": 85,
+		"UpperThresholdFatal": 90,
+		"LowerThresholdCritical": 5,
+		"LowerThresholdFatal": 5,
+		"MinReadingRangeTemp": 3,
+		"MaxReadingRangeTemp": 92,
+		"PhysicalContext": "SystemBoard",
+		"RelatedItem": [
+		  {
+			"@odata.id": "/redfish/v1/Chassis/1"
+		  },
+		  {
+			"@odata.id": "/redfish/v1/Systems/1"
+		  }
+		]
+	  },
+	  {
+		"@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/4",
+		"@odata.type": "#Thermal.v1_6_0.Temperature",
+		"MemberId": "4",
+		"Name": "CPU_VRM Temp",
+		"SensorNumber": 16,
+		"Status": {
+		  "State": "Enabled",
+		  "Health": "OK"
+		},
+		"ReadingCelsius": 41,
+		"UpperThresholdCritical": 100,
+		"UpperThresholdFatal": 105,
+		"LowerThresholdCritical": 5,
+		"LowerThresholdFatal": 5,
+		"MinReadingRangeTemp": 3,
+		"MaxReadingRangeTemp": 107,
+		"PhysicalContext": "CPU",
+		"RelatedItem": [
+		  {
+			"@odata.id": "/redfish/v1/Systems/1/Processors/1"
+		  }
+		]
+	  },
+	  {
+		"@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/5",
+		"@odata.type": "#Thermal.v1_6_0.Temperature",
+		"MemberId": "5",
+		"Name": "SOC_VRM Temp",
+		"SensorNumber": 18,
+		"Status": {
+		  "State": "Enabled",
+		  "Health": "OK"
+		},
+		"ReadingCelsius": 57,
+		"UpperThresholdCritical": 100,
+		"UpperThresholdFatal": 105,
+		"LowerThresholdCritical": 5,
+		"LowerThresholdFatal": 5,
+		"MinReadingRangeTemp": 3,
+		"MaxReadingRangeTemp": 107,
+		"PhysicalContext": "SystemBoard",
+		"RelatedItem": [
+		  {
+			"@odata.id": "/redfish/v1/Systems/1/Processors/1"
+		  }
+		]
+	  },
+	  {
+		"@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/6",
+		"@odata.type": "#Thermal.v1_6_0.Temperature",
+		"MemberId": "6",
+		"Name": "VRMABCD Temp",
+		"SensorNumber": 20,
+		"Status": {
+		  "State": "Enabled",
+		  "Health": "OK"
+		},
+		"ReadingCelsius": 52,
+		"UpperThresholdCritical": 100,
+		"UpperThresholdFatal": 105,
+		"LowerThresholdCritical": 5,
+		"LowerThresholdFatal": 5,
+		"MinReadingRangeTemp": 3,
+		"MaxReadingRangeTemp": 107,
+		"PhysicalContext": "SystemBoard",
+		"RelatedItem": [
+		  {
+			"@odata.id": "/redfish/v1/Systems/1/Processors/1"
+		  }
+		]
+	  },
+	  {
+		"@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/7",
+		"@odata.type": "#Thermal.v1_6_0.Temperature",
+		"MemberId": "7",
+		"Name": "VRMEFGH Temp",
+		"SensorNumber": 22,
+		"Status": {
+		  "State": "Enabled",
+		  "Health": "OK"
+		},
+		"ReadingCelsius": 51,
+		"UpperThresholdCritical": 100,
+		"UpperThresholdFatal": 105,
+		"LowerThresholdCritical": 5,
+		"LowerThresholdFatal": 5,
+		"MinReadingRangeTemp": 3,
+		"MaxReadingRangeTemp": 107,
+		"PhysicalContext": "SystemBoard",
+		"RelatedItem": [
+		  {
+			"@odata.id": "/redfish/v1/Systems/1/Processors/1"
+		  }
+		]
+	  },
+	  {
+		"@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/8",
+		"@odata.type": "#Thermal.v1_6_0.Temperature",
+		"MemberId": "8",
+		"Name": "DIMMABCD Temp",
+		"SensorNumber": 176,
+		"Status": {
+		  "State": "Enabled",
+		  "Health": "OK"
+		},
+		"ReadingCelsius": 39,
+		"UpperThresholdCritical": 85,
+		"UpperThresholdFatal": 90,
+		"LowerThresholdCritical": 5,
+		"LowerThresholdFatal": 5,
+		"MinReadingRangeTemp": 3,
+		"MaxReadingRangeTemp": 92,
+		"PhysicalContext": "Memory",
+		"RelatedItem": [
+		  {
+			"@odata.id": "/redfish/v1/Systems/1/Processors/1"
+		  }
+		]
+	  },
+	  {
+		"@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/9",
+		"@odata.type": "#Thermal.v1_6_0.Temperature",
+		"MemberId": "9",
+		"Name": "DIMMEFGH Temp",
+		"SensorNumber": 177,
+		"Status": {
+		  "State": "Enabled",
+		  "Health": "OK"
+		},
+		"ReadingCelsius": 38,
+		"UpperThresholdCritical": 85,
+		"UpperThresholdFatal": 90,
+		"LowerThresholdCritical": 5,
+		"LowerThresholdFatal": 5,
+		"MinReadingRangeTemp": 3,
+		"MaxReadingRangeTemp": 92,
+		"PhysicalContext": "Memory",
+		"RelatedItem": [
+		  {
+			"@odata.id": "/redfish/v1/Systems/1/Processors/1"
+		  }
+		]
+	  },
+	  {
+		"@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/10",
+		"@odata.type": "#Thermal.v1_6_0.Temperature",
+		"MemberId": "10",
+		"Name": "M2_SSD1 Temp",
+		"SensorNumber": 140,
+		"Status": {
+		  "State": "Enabled",
+		  "Health": "OK"
+		},
+		"ReadingCelsius": 37,
+		"UpperThresholdCritical": 70,
+		"UpperThresholdFatal": 75,
+		"LowerThresholdCritical": 5,
+		"LowerThresholdFatal": 5,
+		"MinReadingRangeTemp": 3,
+		"MaxReadingRangeTemp": 77,
+		"PhysicalContext": "StorageDevice",
+		"RelatedItem": [
+		  {
+			"@odata.id": "/redfish/v1/Chassis/1"
+		  },
+		  {
+			"@odata.id": "/redfish/v1/Systems/1"
+		  }
+		]
+	  },
+	  {
+		"@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/11",
+		"@odata.type": "#Thermal.v1_6_0.Temperature",
+		"MemberId": "11",
+		"Name": "M2_SSD2 Temp",
+		"SensorNumber": 141,
+		"Status": {
+		  "State": "Enabled",
+		  "Health": "OK"
+		},
+		"ReadingCelsius": 46,
+		"UpperThresholdCritical": 70,
+		"UpperThresholdFatal": 75,
+		"LowerThresholdCritical": 5,
+		"LowerThresholdFatal": 5,
+		"MinReadingRangeTemp": 3,
+		"MaxReadingRangeTemp": 77,
+		"PhysicalContext": "StorageDevice",
+		"RelatedItem": [
+		  {
+			"@odata.id": "/redfish/v1/Chassis/1"
+		  },
+		  {
+			"@odata.id": "/redfish/v1/Systems/1"
+		  }
+		]
+	  },
+	  {
+		"@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/12",
+		"@odata.type": "#Thermal.v1_6_0.Temperature",
+		"MemberId": "12",
+		"Name": "AIOM_NIC1 Temp",
+		"SensorNumber": 160,
+		"Status": {
+		  "State": "Enabled",
+		  "Health": "OK"
+		},
+		"ReadingCelsius": 47,
+		"UpperThresholdCritical": 100,
+		"UpperThresholdFatal": 105,
+		"LowerThresholdCritical": 5,
+		"LowerThresholdFatal": 5,
+		"MinReadingRangeTemp": 3,
+		"MaxReadingRangeTemp": 107,
+		"PhysicalContext": "ASIC",
+		"RelatedItem": [
+		  {
+			"@odata.id": "/redfish/v1/Chassis/1/NetworkAdapters/1"
+		  }
+		]
+	  },
+	  {
+		"@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/13",
+		"@odata.type": "#Thermal.v1_6_0.Temperature",
+		"MemberId": "13",
+		"Name": "AOC_NIC1 Temp",
+		"SensorNumber": 161,
+		"Status": {
+		  "State": "Enabled",
+		  "Health": "OK"
+		},
+		"ReadingCelsius": 71,
+		"UpperThresholdCritical": 100,
+		"UpperThresholdFatal": 105,
+		"LowerThresholdCritical": 5,
+		"LowerThresholdFatal": 5,
+		"MinReadingRangeTemp": 3,
+		"MaxReadingRangeTemp": 107,
+		"PhysicalContext": "ASIC",
+		"RelatedItem": [
+		  {
+			"@odata.id": "/redfish/v1/Chassis/1/NetworkAdapters/2"
+		  }
+		]
+	  },
+	  {
+		"@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/14",
+		"@odata.type": "#Thermal.v1_6_0.Temperature",
+		"MemberId": "14",
+		"Name": "AOC_NIC2 Temp",
+		"SensorNumber": 162,
+		"Status": {
+		  "State": "Enabled",
+		  "Health": "OK"
+		},
+		"ReadingCelsius": 61,
+		"UpperThresholdCritical": 100,
+		"UpperThresholdFatal": 105,
+		"LowerThresholdCritical": 5,
+		"LowerThresholdFatal": 5,
+		"MinReadingRangeTemp": 3,
+		"MaxReadingRangeTemp": 107,
+		"PhysicalContext": "ASIC",
+		"RelatedItem": [
+		  {
+			"@odata.id": "/redfish/v1/Chassis/1/NetworkAdapters/3"
+		  }
+		]
+	  }
+	],
+	"Fans": [
+	  {
+		"@odata.id": "/redfish/v1/Chassis/1/Thermal#/Fans/0",
+		"@odata.type": "#Thermal.v1_6_0.Fan",
+		"MemberId": "0",
+		"Name": "FAN1",
+		"SensorNumber": 65,
+		"PhysicalContext": "Fan",
+		"Status": {
+		  "State": "Enabled",
+		  "Health": "OK"
+		},
+		"ReadingUnits": "RPM",
+		"Reading": 10780,
+		"UpperThresholdCritical": 35560,
+		"UpperThresholdFatal": 35700,
+		"LowerThresholdCritical": 420,
+		"LowerThresholdFatal": 280,
+		"MinReadingRange": 180,
+		"MaxReadingRange": 35800,
+		"RelatedItem": [
+		  {
+			"@odata.id": "/redfish/v1/Systems/1"
+		  },
+		  {
+			"@odata.id": "/redfish/v1/Chassis/1"
+		  }
+		]
+	  },
+	  {
+		"@odata.id": "/redfish/v1/Chassis/1/Thermal#/Fans/1",
+		"@odata.type": "#Thermal.v1_6_0.Fan",
+		"MemberId": "1",
+		"Name": "FAN2",
+		"SensorNumber": 66,
+		"PhysicalContext": "Fan",
+		"Status": {
+		  "State": "Enabled",
+		  "Health": "OK"
+		},
+		"ReadingUnits": "RPM",
+		"Reading": 10920,
+		"UpperThresholdCritical": 35560,
+		"UpperThresholdFatal": 35700,
+		"LowerThresholdCritical": 420,
+		"LowerThresholdFatal": 280,
+		"MinReadingRange": 180,
+		"MaxReadingRange": 35800,
+		"RelatedItem": [
+		  {
+			"@odata.id": "/redfish/v1/Systems/1"
+		  },
+		  {
+			"@odata.id": "/redfish/v1/Chassis/1"
+		  }
+		]
+	  },
+	  {
+		"@odata.id": "/redfish/v1/Chassis/1/Thermal#/Fans/2",
+		"@odata.type": "#Thermal.v1_6_0.Fan",
+		"MemberId": "2",
+		"Name": "FAN3",
+		"SensorNumber": 67,
+		"PhysicalContext": "Fan",
+		"Status": {
+		  "State": "Enabled",
+		  "Health": "OK"
+		},
+		"ReadingUnits": "RPM",
+		"Reading": 10920,
+		"UpperThresholdCritical": 35560,
+		"UpperThresholdFatal": 35700,
+		"LowerThresholdCritical": 420,
+		"LowerThresholdFatal": 280,
+		"MinReadingRange": 180,
+		"MaxReadingRange": 35800,
+		"RelatedItem": [
+		  {
+			"@odata.id": "/redfish/v1/Systems/1"
+		  },
+		  {
+			"@odata.id": "/redfish/v1/Chassis/1"
+		  }
+		]
+	  },
+	  {
+		"@odata.id": "/redfish/v1/Chassis/1/Thermal#/Fans/3",
+		"@odata.type": "#Thermal.v1_6_0.Fan",
+		"MemberId": "3",
+		"Name": "FAN4",
+		"SensorNumber": 68,
+		"PhysicalContext": "Fan",
+		"Status": {
+		  "State": "Enabled",
+		  "Health": "OK"
+		},
+		"ReadingUnits": "RPM",
+		"Reading": 10920,
+		"UpperThresholdCritical": 35560,
+		"UpperThresholdFatal": 35700,
+		"LowerThresholdCritical": 420,
+		"LowerThresholdFatal": 280,
+		"MinReadingRange": 180,
+		"MaxReadingRange": 35800,
+		"RelatedItem": [
+		  {
+			"@odata.id": "/redfish/v1/Systems/1"
+		  },
+		  {
+			"@odata.id": "/redfish/v1/Chassis/1"
+		  }
+		]
+	  },
+	  {
+		"@odata.id": "/redfish/v1/Chassis/1/Thermal#/Fans/4",
+		"@odata.type": "#Thermal.v1_6_0.Fan",
+		"MemberId": "4",
+		"Name": "FAN5",
+		"SensorNumber": 69,
+		"PhysicalContext": "Fan",
+		"Status": {
+		  "State": "Enabled",
+		  "Health": "OK"
+		},
+		"ReadingUnits": "RPM",
+		"Reading": 10780,
+		"UpperThresholdCritical": 35560,
+		"UpperThresholdFatal": 35700,
+		"LowerThresholdCritical": 420,
+		"LowerThresholdFatal": 280,
+		"MinReadingRange": 180,
+		"MaxReadingRange": 35800,
+		"RelatedItem": [
+		  {
+			"@odata.id": "/redfish/v1/Systems/1"
+		  },
+		  {
+			"@odata.id": "/redfish/v1/Chassis/1"
+		  }
+		]
+	  },
+	  {
+		"@odata.id": "/redfish/v1/Chassis/1/Thermal#/Fans/5",
+		"@odata.type": "#Thermal.v1_6_0.Fan",
+		"MemberId": "5",
+		"Name": "FAN6",
+		"SensorNumber": 70,
+		"PhysicalContext": "Fan",
+		"Status": {
+		  "State": "Enabled",
+		  "Health": "OK"
+		},
+		"ReadingUnits": "RPM",
+		"Reading": 10780,
+		"UpperThresholdCritical": 35560,
+		"UpperThresholdFatal": 35700,
+		"LowerThresholdCritical": 420,
+		"LowerThresholdFatal": 280,
+		"MinReadingRange": 180,
+		"MaxReadingRange": 35800,
+		"RelatedItem": [
+		  {
+			"@odata.id": "/redfish/v1/Systems/1"
+		  },
+		  {
+			"@odata.id": "/redfish/v1/Chassis/1"
+		  }
+		]
+	  }
+	]
+  }
+  `
 
 // TestThermal tests the parsing of Thermal objects.
 func TestThermal(t *testing.T) {
@@ -105,11 +577,11 @@ func TestThermal(t *testing.T) {
 		t.Errorf("Received invalid ID: %s", result.ID)
 	}
 
-	if result.Name != "ThermalOne" {
+	if result.Name != "Thermal" {
 		t.Errorf("Received invalid name: %s", result.Name)
 	}
 
-	if result.Fans[0].Name != "Charlie" {
+	if result.Fans[0].Name != "FAN1" {
 		t.Errorf("Invalid fan name: %s", result.Fans[0].Name)
 	}
 }


### PR DESCRIPTION
Fans and Temperature objects have a RelatedItem field that is actually an array of links. Switch over to extracting the links, though not exposing the URIs yet.