### PR TITLE
Fix ComputerSystem.ManagedBy access

### DIFF
--- a/redfish/computersystem_test.go
+++ b/redfish/computersystem_test.go
@@ -304,11 +304,11 @@ func TestComputerSystem(t *testing.T) { //nolint
 		t.Errorf("Invalid allowable reset actions, expected 6, got %d",
 			len(result.SupportedResetTypes))
 	}
-	if len(result.ManagedBy) != 1 {
-		t.Errorf("Received invalid number of ManagedBy: %d", len(result.ManagedBy))
+	if len(result.managedBy) != 1 {
+		t.Errorf("Received invalid number of ManagedBy: %d", len(result.managedBy))
 	}
-	if result.ManagedBy[0] != "/redfish/v1/Managers/BMC-1" {
-		t.Errorf("Received invalid Managers reference: %s", result.ManagedBy[0])
+	if result.managedBy[0] != "/redfish/v1/Managers/BMC-1" {
+		t.Errorf("Received invalid Managers reference: %s", result.managedBy[0])
 	}
 }
 


### PR DESCRIPTION
This is an array of links to Managers. We had been just collecting the strings for the URIs, but to make this consistent with how other related objects are handled this makes the objects themselves accessible by a method call.