### PR TITLE
Workaround for NVIDIA PowerSubsystem issue

### DIFF
--- a/redfish/powersubsystem.go
+++ b/redfish/powersubsystem.go
@@ -59,7 +59,22 @@ func (powersubsystem *PowerSubsystem) UnmarshalJSON(b []byte) error {
 
 	err := json.Unmarshal(b, &t)
 	if err != nil {
-		return err
+		// Work around a bug in NVIDIA's implementation
+		var u struct {
+			temp
+			Batteries     common.Link
+			PowerSupplies common.Link
+			Allocation    []interface{}
+		}
+		err2 := json.Unmarshal(b, &u)
+		if err2 != nil {
+			// Still didn't work, return original error
+			return err
+		}
+
+		t.temp = u.temp
+		t.Batteries = u.Batteries
+		t.PowerSupplies = u.PowerSupplies
 	}
 
 	*powersubsystem = PowerSubsystem(t.temp)

--- a/redfish/powersubsystem_test.go
+++ b/redfish/powersubsystem_test.go
@@ -49,6 +49,56 @@ var powerSubsystemBody = `{
 	"@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem"
   }`
 
+var powerSubsystemNVBody = `{
+	"@odata.context": "/redfish/v1/$metadata#PowerSubsystem.PowerSubsystem",
+	"@odata.etag": "\"1715094363\"",
+	"@odata.id": "/redfish/v1/Chassis/DGX/PowerSubsystem",
+	"@odata.type": "#PowerSubsystem.v1_1_0.PowerSubsystem",
+	"Allocation": [],
+	"Description": "PowerSubsytem for this Chassis",
+	"Id": "PowerSubsytem",
+	"Name": "PowerSubsytem",
+	"PowerSupplies": {
+	  "@odata.id": "/redfish/v1/Chassis/DGX/PowerSubsystem/PowerSupplies"
+	},
+	"PowerSupplyRedundancy": [
+	  {
+		"MaxSupportedInGroup": 6,
+		"MinNeededInGroup": 1,
+		"RedundancyGroup": [
+		  {
+			"@odata.id": "/redfish/v1/Chassis/DGX/PowerSubsystem/PowerSupplies/PSU0"
+		  },
+		  {
+			"@odata.id": "/redfish/v1/Chassis/DGX/PowerSubsystem/PowerSupplies/PSU1"
+		  },
+		  {
+			"@odata.id": "/redfish/v1/Chassis/DGX/PowerSubsystem/PowerSupplies/PSU2"
+		  },
+		  {
+			"@odata.id": "/redfish/v1/Chassis/DGX/PowerSubsystem/PowerSupplies/PSU3"
+		  },
+		  {
+			"@odata.id": "/redfish/v1/Chassis/DGX/PowerSubsystem/PowerSupplies/PSU4"
+		  },
+		  {
+			"@odata.id": "/redfish/v1/Chassis/DGX/PowerSubsystem/PowerSupplies/PSU5"
+		  }
+		],
+		"RedundancyGroup@odata.count": 6,
+		"RedundancyType": "NPlusM",
+		"Status": {
+		  "Health": "OK",
+		  "State": "Enabled"
+		}
+	  }
+	],
+	"Status": {
+	  "Health": "OK",
+	  "State": "Enabled"
+	}
+  }`
+
 // TestPowerSubsystem tests the parsing of PowerSubsystem objects.
 func TestPowerSubsystem(t *testing.T) {
 	var result PowerSubsystem
@@ -66,4 +116,14 @@ func TestPowerSubsystem(t *testing.T) {
 	assertEquals(t, "Failover", string(result.PowerSupplyRedundancy[0].RedundancyType))
 	assertEquals(t, "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/Bay2", result.PowerSupplyRedundancy[0].redundancyGroup[1])
 	assertEquals(t, "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies", result.powerSupplies)
+}
+
+// TestPowerSubsystemNVWorkaround tests the workaround for a non-spec implementation of PowerSubsystem objects.
+func TestPowerSubsystemNVWorkaround(t *testing.T) {
+	var result PowerSubsystem
+	err := json.NewDecoder(strings.NewReader(powerSubsystemNVBody)).Decode(&result)
+
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
 }


### PR DESCRIPTION
Their implmentation incorrectly returns PowerSubsystem.Attributes as an array, causing unmarshal errors. This works around that by skipping it.