### PR TITLE
Expose OEM information for PCIeDevice and PCIeFunction

### DIFF
--- a/redfish/pciedevice.go
+++ b/redfish/pciedevice.go
@@ -229,6 +229,10 @@ type PCIeDevice struct {
 	// Model shall be the name by which the manufacturer generally refers to the
 	// PCIe device.
 	Model string
+	// Oem shall contain the OEM extensions. All values for properties that
+	// this object contains shall conform to the Redfish Specification
+	// described requirements.
+	Oem json.RawMessage
 	// PCIeInterface is used to connect this PCIe Device to its host or
 	// upstream switch.
 	PCIeInterface PCIeInterface

--- a/redfish/pciefunction.go
+++ b/redfish/pciefunction.go
@@ -111,6 +111,10 @@ type PCIeFunction struct {
 	// FunctionType shall be the function type of the PCIe device function such
 	// as Physical or Virtual.
 	FunctionType FunctionType
+	// Oem shall contain the OEM extensions. All values for properties that
+	// this object contains shall conform to the Redfish Specification
+	// described requirements.
+	Oem json.RawMessage
 	// RevisionID shall be the PCI Revision ID of the PCIe device function.
 	RevisionID string
 	// Status shall contain any status or health properties of the resource.


### PR DESCRIPTION
Some vendors include useful information in their OEM information for these objects. Make it possible to access this data.