### PR TITLE
Fix Output.PowerControl PowerState argument type

### DIFF
--- a/redfish/outlet.go
+++ b/redfish/outlet.go
@@ -248,9 +248,9 @@ func (outlet *Outlet) UnmarshalJSON(b []byte) error {
 }
 
 // PowerControl controls the power state of the outlet.
-func (outlet *Outlet) PowerControl(powerState PowerState) error {
+func (outlet *Outlet) PowerControl(powerState ActionPowerState) error {
 	params := struct {
-		PowerState PowerState
+		PowerState ActionPowerState
 	}{
 		PowerState: powerState,
 	}

--- a/redfish/outlet_test.go
+++ b/redfish/outlet_test.go
@@ -178,7 +178,7 @@ func TestOutletPowerControl(t *testing.T) {
 	testClient := &common.TestClient{}
 	result.SetClient(testClient)
 
-	err = result.PowerControl(OffPowerState)
+	err = result.PowerControl(OffActionPowerState)
 	if err != nil {
 		t.Errorf("Error making PowerControl call: %s", err)
 	}


### PR DESCRIPTION
The PowerState property is the common PowerState enum, but the action call for PowerControl needs to use the more limited ActionPowerState that only includes the valid power control request state.

Closes: #339