### PR TITLE
expose the ActionInfo property under Actions under the Managers colle…

### DIFF
--- a/redfish/manager.go
+++ b/redfish/manager.go
@@ -379,6 +379,8 @@ type Manager struct {
 	modifyRedundancySetTarget string
 	// resetTarget is the internal URL to send reset targets to.
 	resetTarget string
+	// resetInfo contains URI for an ActionInfo Resource that describes this action.
+	actionInfo string
 	// SupportedResetTypes, if provided, is the reset types this system supports.
 	SupportedResetTypes   []ResetType
 	resetToDefaultsTarget string
@@ -393,6 +395,7 @@ func (manager *Manager) UnmarshalJSON(b []byte) error {
 		ForceFailover       common.ActionTarget `json:"#Manager.ForceFailover"`
 		ModifyRedundancySet common.ActionTarget `json:"#Manager.ModifyRedundancySet"`
 		Reset               struct {
+			ActionInfo        string      `json:"@Redfish.ActionInfo"`
 			AllowedResetTypes []ResetType `json:"ResetType@Redfish.AllowableValues"`
 			Target            string
 		} `json:"#Manager.Reset"`
@@ -479,6 +482,7 @@ func (manager *Manager) UnmarshalJSON(b []byte) error {
 	manager.SupportedResetTypes = t.Actions.Reset.AllowedResetTypes
 	manager.resetTarget = t.Actions.Reset.Target
 	manager.resetToDefaultsTarget = t.Actions.ResetToDefaults.Target
+	manager.actionInfo = t.Actions.Reset.ActionInfo
 
 	// This is a read/write object, so we need to save the raw object data for later
 	manager.rawData = b

--- a/redfish/manager.go
+++ b/redfish/manager.go
@@ -588,6 +588,14 @@ func (manager *Manager) ModifyRedundancySet(addManagers, removeManagers []*Manag
 // Reset shall perform a reset of the manager.
 func (manager *Manager) Reset(resetType ResetType) error {
 	if len(manager.SupportedResetTypes) == 0 {
+		if len(manager.actionInfo) > 0 {
+			// reset without confirming the type is supported by the manager.
+			// done to minimize overhead though technically not as correct as first checking the supported reset types
+			t := struct {
+				ResetType ResetType
+			}{ResetType: resetType}
+			return manager.Post(manager.resetTarget, t)
+		}
 		// reset directly without reset type. HPE server has the behavior
 		return manager.Post(manager.resetTarget, struct{}{})
 	}

--- a/redfish/manager.go
+++ b/redfish/manager.go
@@ -588,7 +588,7 @@ func (manager *Manager) ModifyRedundancySet(addManagers, removeManagers []*Manag
 // Reset shall perform a reset of the manager.
 func (manager *Manager) Reset(resetType ResetType) error {
 	if len(manager.SupportedResetTypes) == 0 {
-		if len(manager.actionInfo) > 0 {
+		if manager.actionInfo != "" {
 			// reset without confirming the type is supported by the manager.
 			// done to minimize overhead though technically not as correct as first checking the supported reset types
 			t := struct {


### PR DESCRIPTION
exposes the ActionInfo property under Actions under the Managers collection

per Redfish docs `ActionInfo` is a common property across the `Actions` object. Exposing that property in the Managers collection