### PR TITLE
ListReferencedX: return ordered results.

### DIFF
--- a/redfish/accelerationfunction.go
+++ b/redfish/accelerationfunction.go
@@ -121,10 +121,9 @@ func GetAccelerationFunction(c common.Client, uri string) (*AccelerationFunction
 
 // ListReferencedAccelerationFunctions gets the collection of AccelerationFunction from
 // a provided reference.
-func ListReferencedAccelerationFunctions(c common.Client, link string) ([]*AccelerationFunction, error) {
-	var result []*AccelerationFunction
+func ListReferencedAccelerationFunctions(c common.Client, link string) ([]*AccelerationFunction, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -140,27 +139,36 @@ func ListReferencedAccelerationFunctions(c common.Client, link string) ([]*Accel
 		ch <- GetResult{Item: accelerationfunction, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-AccelerationFunction helper map.
+	unorderedResults := map[string]*AccelerationFunction{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*AccelerationFunction, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }
 
 // Endpoints gets the endpoints connected to this accelerator.

--- a/redfish/aggregate.go
+++ b/redfish/aggregate.go
@@ -152,10 +152,9 @@ func GetAggregate(c common.Client, uri string) (*Aggregate, error) {
 
 // ListReferencedAggregates gets the collection of Aggregate from
 // a provided reference.
-func ListReferencedAggregates(c common.Client, link string) ([]*Aggregate, error) {
-	var result []*Aggregate
+func ListReferencedAggregates(c common.Client, link string) ([]*Aggregate, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -171,25 +170,34 @@ func ListReferencedAggregates(c common.Client, link string) ([]*Aggregate, error
 		ch <- GetResult{Item: aggregate, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-Aggregate helper map.
+	unorderedResults := map[string]*Aggregate{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*Aggregate, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }

--- a/redfish/allowdeny.go
+++ b/redfish/allowdeny.go
@@ -145,10 +145,9 @@ func GetAllowDeny(c common.Client, uri string) (*AllowDeny, error) {
 
 // ListReferencedAllowDenys gets the collection of AllowDeny from
 // a provided reference.
-func ListReferencedAllowDenys(c common.Client, link string) ([]*AllowDeny, error) {
-	var result []*AllowDeny
+func ListReferencedAllowDenys(c common.Client, link string) ([]*AllowDeny, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -164,25 +163,34 @@ func ListReferencedAllowDenys(c common.Client, link string) ([]*AllowDeny, error
 		ch <- GetResult{Item: allowdeny, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-AllowDeny helper map.
+	unorderedResults := map[string]*AllowDeny{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*AllowDeny, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }

--- a/redfish/batterymetrics.go
+++ b/redfish/batterymetrics.go
@@ -90,10 +90,9 @@ func GetBatteryMetrics(c common.Client, uri string) (*BatteryMetrics, error) {
 
 // ListReferencedBatteryMetricss gets the collection of BatteryMetrics from
 // a provided reference.
-func ListReferencedBatteryMetricss(c common.Client, link string) ([]*BatteryMetrics, error) {
-	var result []*BatteryMetrics
+func ListReferencedBatteryMetricss(c common.Client, link string) ([]*BatteryMetrics, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -109,25 +108,34 @@ func ListReferencedBatteryMetricss(c common.Client, link string) ([]*BatteryMetr
 		ch <- GetResult{Item: batterymetrics, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-BatteryMetrics helper map.
+	unorderedResults := map[string]*BatteryMetrics{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*BatteryMetrics, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }

--- a/redfish/cable.go
+++ b/redfish/cable.go
@@ -365,10 +365,9 @@ func GetCable(c common.Client, uri string) (*Cable, error) {
 
 // ListReferencedCables gets the collection of Cable from
 // a provided reference.
-func ListReferencedCables(c common.Client, link string) ([]*Cable, error) {
-	var result []*Cable
+func ListReferencedCables(c common.Client, link string) ([]*Cable, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -384,25 +383,34 @@ func ListReferencedCables(c common.Client, link string) ([]*Cable, error) {
 		ch <- GetResult{Item: cable, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-Cable helper map.
+	unorderedResults := map[string]*Cable{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*Cable, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }

--- a/redfish/containerimage.go
+++ b/redfish/containerimage.go
@@ -104,10 +104,9 @@ func GetContainerImage(c common.Client, uri string) (*ContainerImage, error) {
 
 // ListReferencedContainerImages gets the collection of ContainerImage from
 // a provided reference.
-func ListReferencedContainerImages(c common.Client, link string) ([]*ContainerImage, error) {
-	var result []*ContainerImage
+func ListReferencedContainerImages(c common.Client, link string) ([]*ContainerImage, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -123,27 +122,36 @@ func ListReferencedContainerImages(c common.Client, link string) ([]*ContainerIm
 		ch <- GetResult{Item: containerimage, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-ContainerImage helper map.
+	unorderedResults := map[string]*ContainerImage{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*ContainerImage, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }
 
 // Containers get the container instances using this container image.

--- a/redfish/coolingunit.go
+++ b/redfish/coolingunit.go
@@ -205,10 +205,9 @@ func GetCoolingUnit(c common.Client, uri string) (*CoolingUnit, error) {
 
 // ListReferencedCoolingUnits gets the collection of CoolingUnit from
 // a provided reference.
-func ListReferencedCoolingUnits(c common.Client, link string) ([]*CoolingUnit, error) {
-	var result []*CoolingUnit
+func ListReferencedCoolingUnits(c common.Client, link string) ([]*CoolingUnit, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -224,27 +223,36 @@ func ListReferencedCoolingUnits(c common.Client, link string) ([]*CoolingUnit, e
 		ch <- GetResult{Item: coolingunit, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-CoolingUnit helper map.
+	unorderedResults := map[string]*CoolingUnit{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*CoolingUnit, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }
 
 // TODO: Add functions to get linked objects

--- a/redfish/event.go
+++ b/redfish/event.go
@@ -86,10 +86,9 @@ func GetEvent(c common.Client, uri string) (*Event, error) {
 
 // ListReferencedEvents gets the collection of Event from
 // a provided reference.
-func ListReferencedEvents(c common.Client, link string) ([]*Event, error) {
-	var result []*Event
+func ListReferencedEvents(c common.Client, link string) ([]*Event, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -105,27 +104,36 @@ func ListReferencedEvents(c common.Client, link string) ([]*Event, error) {
 		ch <- GetResult{Item: event, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-Event helper map.
+	unorderedResults := map[string]*Event{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*Event, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }
 
 // EventRecord

--- a/redfish/heater.go
+++ b/redfish/heater.go
@@ -291,10 +291,9 @@ func GetHeater(c common.Client, uri string) (*Heater, error) {
 
 // ListReferencedHeaters gets the collection of Heater from
 // a provided reference.
-func ListReferencedHeaters(c common.Client, link string) ([]*Heater, error) {
-	var result []*Heater
+func ListReferencedHeaters(c common.Client, link string) ([]*Heater, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -310,25 +309,34 @@ func ListReferencedHeaters(c common.Client, link string) ([]*Heater, error) {
 		ch <- GetResult{Item: heater, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-Heater helper map.
+	unorderedResults := map[string]*Heater{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*Heater, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }

--- a/redfish/keyservice.go
+++ b/redfish/keyservice.go
@@ -87,10 +87,9 @@ func GetKeyService(c common.Client, uri string) (*KeyService, error) {
 
 // ListReferencedKeyServices gets the collection of KeyService from
 // a provided reference.
-func ListReferencedKeyServices(c common.Client, link string) ([]*KeyService, error) {
-	var result []*KeyService
+func ListReferencedKeyServices(c common.Client, link string) ([]*KeyService, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -106,25 +105,34 @@ func ListReferencedKeyServices(c common.Client, link string) ([]*KeyService, err
 		ch <- GetResult{Item: keyservice, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-KeyService helper map.
+	unorderedResults := map[string]*KeyService{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*KeyService, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }

--- a/redfish/leakdetection.go
+++ b/redfish/leakdetection.go
@@ -79,10 +79,9 @@ func GetLeakDetection(c common.Client, uri string) (*LeakDetection, error) {
 
 // ListReferencedLeakDetections gets the collection of LeakDetection from
 // a provided reference.
-func ListReferencedLeakDetections(c common.Client, link string) ([]*LeakDetection, error) {
-	var result []*LeakDetection
+func ListReferencedLeakDetections(c common.Client, link string) ([]*LeakDetection, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -98,27 +97,36 @@ func ListReferencedLeakDetections(c common.Client, link string) ([]*LeakDetectio
 		ch <- GetResult{Item: leakdetection, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-LeakDetection helper map.
+	unorderedResults := map[string]*LeakDetection{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*LeakDetection, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }
 
 // LeakDetectorGroup shall contain a group of leak detection equipment that reports a unified status.

--- a/redfish/license.go
+++ b/redfish/license.go
@@ -217,10 +217,9 @@ func GetLicense(c common.Client, uri string) (*License, error) {
 
 // ListReferencedLicenses gets the collection of License from
 // a provided reference.
-func ListReferencedLicenses(c common.Client, link string) ([]*License, error) {
-	var result []*License
+func ListReferencedLicenses(c common.Client, link string) ([]*License, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -236,25 +235,34 @@ func ListReferencedLicenses(c common.Client, link string) ([]*License, error) {
 		ch <- GetResult{Item: license, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-License helper map.
+	unorderedResults := map[string]*License{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*License, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }

--- a/redfish/logservice.go
+++ b/redfish/logservice.go
@@ -185,10 +185,9 @@ func GetLogService(c common.Client, uri string) (*LogService, error) {
 }
 
 // ListReferencedLogServices gets the collection of LogService from a provided reference.
-func ListReferencedLogServices(c common.Client, link string) ([]*LogService, error) {
-	var result []*LogService
+func ListReferencedLogServices(c common.Client, link string) ([]*LogService, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -204,27 +203,36 @@ func ListReferencedLogServices(c common.Client, link string) ([]*LogService, err
 		ch <- GetResult{Item: logservice, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-LogService helper map.
+	unorderedResults := map[string]*LogService{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*LogService, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }
 
 // Entries gets the log entries of this service.

--- a/redfish/metricdefinition.go
+++ b/redfish/metricdefinition.go
@@ -231,10 +231,9 @@ func GetMetricDefinition(c common.Client, uri string) (*MetricDefinition, error)
 
 // ListReferencedMetricDefinitions gets the collection of MetricDefinition from
 // a provided reference.
-func ListReferencedMetricDefinitions(c common.Client, link string) ([]*MetricDefinition, error) {
-	var result []*MetricDefinition
+func ListReferencedMetricDefinitions(c common.Client, link string) ([]*MetricDefinition, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -250,27 +249,36 @@ func ListReferencedMetricDefinitions(c common.Client, link string) ([]*MetricDef
 		ch <- GetResult{Item: metricdefinition, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-MetricDefinition helper map.
+	unorderedResults := map[string]*MetricDefinition{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*MetricDefinition, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }
 
 // Wildcard shall contain a wildcard and its substitution values.

--- a/redfish/networkdevicefunctionmetrics.go
+++ b/redfish/networkdevicefunctionmetrics.go
@@ -129,10 +129,9 @@ func GetNetworkDeviceFunctionMetrics(c common.Client, uri string) (*NetworkDevic
 
 // ListReferencedNetworkDeviceFunctionMetricss gets the collection of NetworkDeviceFunctionMetrics from
 // a provided reference.
-func ListReferencedNetworkDeviceFunctionMetricss(c common.Client, link string) ([]*NetworkDeviceFunctionMetrics, error) {
-	var result []*NetworkDeviceFunctionMetrics
+func ListReferencedNetworkDeviceFunctionMetricss(c common.Client, link string) ([]*NetworkDeviceFunctionMetrics, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -148,25 +147,34 @@ func ListReferencedNetworkDeviceFunctionMetricss(c common.Client, link string) (
 		ch <- GetResult{Item: networkdevicefunctionmetrics, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-NetworkDeviceFunctionMetrics helper map.
+	unorderedResults := map[string]*NetworkDeviceFunctionMetrics{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*NetworkDeviceFunctionMetrics, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }

--- a/redfish/operatingconfig.go
+++ b/redfish/operatingconfig.go
@@ -73,10 +73,9 @@ func GetOperatingConfig(c common.Client, uri string) (*OperatingConfig, error) {
 
 // ListReferencedOperatingConfigs gets the collection of OperatingConfig from
 // a provided reference.
-func ListReferencedOperatingConfigs(c common.Client, link string) ([]*OperatingConfig, error) {
-	var result []*OperatingConfig
+func ListReferencedOperatingConfigs(c common.Client, link string) ([]*OperatingConfig, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -92,27 +91,36 @@ func ListReferencedOperatingConfigs(c common.Client, link string) ([]*OperatingC
 		ch <- GetResult{Item: operatingconfig, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-OperatingConfig helper map.
+	unorderedResults := map[string]*OperatingConfig{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*OperatingConfig, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }
 
 // TurboProfileDatapoint shall specify the turbo profile for a set of active cores.

--- a/redfish/outletgroup.go
+++ b/redfish/outletgroup.go
@@ -198,10 +198,9 @@ func GetOutletGroup(c common.Client, uri string) (*OutletGroup, error) {
 
 // ListReferencedOutletGroups gets the collection of OutletGroup from
 // a provided reference.
-func ListReferencedOutletGroups(c common.Client, link string) ([]*OutletGroup, error) {
-	var result []*OutletGroup
+func ListReferencedOutletGroups(c common.Client, link string) ([]*OutletGroup, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -217,25 +216,34 @@ func ListReferencedOutletGroups(c common.Client, link string) ([]*OutletGroup, e
 		ch <- GetResult{Item: outletgroup, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-OutletGroup helper map.
+	unorderedResults := map[string]*OutletGroup{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*OutletGroup, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }

--- a/redfish/port.go
+++ b/redfish/port.go
@@ -1133,10 +1133,9 @@ func GetPort(c common.Client, uri string) (*Port, error) {
 
 // ListReferencedPorts gets the collection of Port from
 // a provided reference.
-func ListReferencedPorts(c common.Client, link string) ([]*Port, error) {
-	var result []*Port
+func ListReferencedPorts(c common.Client, link string) ([]*Port, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -1152,27 +1151,36 @@ func ListReferencedPorts(c common.Client, link string) ([]*Port, error) {
 		ch <- GetResult{Item: port, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-Port helper map.
+	unorderedResults := map[string]*Port{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*Port, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }
 
 // ResetPort resets this port.

--- a/redfish/powerdistribution.go
+++ b/redfish/powerdistribution.go
@@ -304,10 +304,9 @@ func (powerDistribution *PowerDistribution) TransferControl() error {
 
 // ListReferencedPowerDistribution gets the collection of PowerDistribution from
 // a provided reference.
-func ListReferencedPowerDistributionUnits(c common.Client, link string) ([]*PowerDistribution, error) {
-	var result []*PowerDistribution
+func ListReferencedPowerDistributionUnits(c common.Client, link string) ([]*PowerDistribution, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -319,31 +318,40 @@ func ListReferencedPowerDistributionUnits(c common.Client, link string) ([]*Powe
 	ch := make(chan GetResult)
 	collectionError := common.NewCollectionError()
 	get := func(link string) {
-		powerDistribution, err := GetPowerDistribution(c, link)
-		ch <- GetResult{Item: powerDistribution, Link: link, Error: err}
+		powerdistribution, err := GetPowerDistribution(c, link)
+		ch <- GetResult{Item: powerdistribution, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-PowerDistribution helper map.
+	unorderedResults := map[string]*PowerDistribution{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*PowerDistribution, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }
 
 // Deprecated: (v1.3) in favor of the Sensors link in the Chassis resource.

--- a/redfish/resource.go
+++ b/redfish/resource.go
@@ -476,10 +476,9 @@ func GetResource(c common.Client, uri string) (*Resource, error) {
 
 // ListReferencedResources gets the collection of Resource from
 // a provided reference.
-func ListReferencedResources(c common.Client, link string) ([]*Resource, error) {
-	var result []*Resource
+func ListReferencedResources(c common.Client, link string) ([]*Resource, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -495,27 +494,36 @@ func ListReferencedResources(c common.Client, link string) ([]*Resource, error) 
 		ch <- GetResult{Item: resource, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-Resource helper map.
+	unorderedResults := map[string]*Resource{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*Resource, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }
 
 // ResourceCollection

--- a/redfish/resourceblock.go
+++ b/redfish/resourceblock.go
@@ -303,10 +303,9 @@ func GetResourceBlock(c common.Client, uri string) (*ResourceBlock, error) {
 
 // ListReferencedResourceBlocks gets the collection of ResourceBlock from
 // a provided reference.
-func ListReferencedResourceBlocks(c common.Client, link string) ([]*ResourceBlock, error) {
-	var result []*ResourceBlock
+func ListReferencedResourceBlocks(c common.Client, link string) ([]*ResourceBlock, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -322,27 +321,36 @@ func ListReferencedResourceBlocks(c common.Client, link string) ([]*ResourceBloc
 		ch <- GetResult{Item: resourceblock, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-ResourceBlock helper map.
+	unorderedResults := map[string]*ResourceBlock{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*ResourceBlock, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }
 
 // ResourceBlockLimits shall specify the allowable quantities of types of resource blocks for a given composition

--- a/redfish/role.go
+++ b/redfish/role.go
@@ -131,10 +131,9 @@ func GetRole(c common.Client, uri string) (*Role, error) {
 
 // ListReferencedRoles gets the collection of Role from
 // a provided reference.
-func ListReferencedRoles(c common.Client, link string) ([]*Role, error) {
-	var result []*Role
+func ListReferencedRoles(c common.Client, link string) ([]*Role, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -150,25 +149,34 @@ func ListReferencedRoles(c common.Client, link string) ([]*Role, error) {
 		ch <- GetResult{Item: role, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-Role helper map.
+	unorderedResults := map[string]*Role{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*Role, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }

--- a/redfish/signature.go
+++ b/redfish/signature.go
@@ -66,10 +66,9 @@ func GetSignature(c common.Client, uri string) (*Signature, error) {
 
 // ListReferencedSignatures gets the collection of Signature from
 // a provided reference.
-func ListReferencedSignatures(c common.Client, link string) ([]*Signature, error) {
-	var result []*Signature
+func ListReferencedSignatures(c common.Client, link string) ([]*Signature, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -85,25 +84,34 @@ func ListReferencedSignatures(c common.Client, link string) ([]*Signature, error
 		ch <- GetResult{Item: signature, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-Signature helper map.
+	unorderedResults := map[string]*Signature{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*Signature, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }

--- a/redfish/softwareinventory.go
+++ b/redfish/softwareinventory.go
@@ -177,10 +177,9 @@ func GetSoftwareInventory(c common.Client, uri string) (*SoftwareInventory, erro
 
 // ListReferencedSoftwareInventories gets the collection of SoftwareInventory from
 // a provided reference.
-func ListReferencedSoftwareInventories(c common.Client, link string) ([]*SoftwareInventory, error) {
-	var result []*SoftwareInventory
+func ListReferencedSoftwareInventories(c common.Client, link string) ([]*SoftwareInventory, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -196,25 +195,34 @@ func ListReferencedSoftwareInventories(c common.Client, link string) ([]*Softwar
 		ch <- GetResult{Item: softwareinventory, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-SoftwareInventory helper map.
+	unorderedResults := map[string]*SoftwareInventory{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*SoftwareInventory, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }

--- a/redfish/storagecontroller.go
+++ b/redfish/storagecontroller.go
@@ -536,10 +536,9 @@ func GetStorageController(c common.Client, uri string) (*StorageController, erro
 
 // ListReferencedStorageControllers gets the collection of StorageControllers
 // from a provided reference.
-func ListReferencedStorageControllers(c common.Client, link string) ([]*StorageController, error) {
-	var result []*StorageController
+func ListReferencedStorageControllers(c common.Client, link string) ([]*StorageController, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -555,25 +554,34 @@ func ListReferencedStorageControllers(c common.Client, link string) ([]*StorageC
 		ch <- GetResult{Item: storagecontroller, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-StorageController helper map.
+	unorderedResults := map[string]*StorageController{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*StorageController, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }

--- a/redfish/switch.go
+++ b/redfish/switch.go
@@ -303,10 +303,9 @@ func GetSwitch(c common.Client, uri string) (*Switch, error) {
 
 // ListReferencedSwitches gets the collection of Switch from
 // a provided reference.
-func ListReferencedSwitches(c common.Client, link string) ([]*Switch, error) {
-	var result []*Switch
+func ListReferencedSwitches(c common.Client, link string) ([]*Switch, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -322,27 +321,36 @@ func ListReferencedSwitches(c common.Client, link string) ([]*Switch, error) {
 		ch <- GetResult{Item: sw, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-Switch helper map.
+	unorderedResults := map[string]*Switch{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*Switch, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }
 
 // VCSSwitch shall contain Virtual CXL Switch (VCS) properties for a switch.

--- a/redfish/task.go
+++ b/redfish/task.go
@@ -191,10 +191,9 @@ func GetTask(c common.Client, uri string) (*Task, error) {
 
 // ListReferencedTasks gets the collection of Task from
 // a provided reference.
-func ListReferencedTasks(c common.Client, link string) ([]*Task, error) {
-	var result []*Task
+func ListReferencedTasks(c common.Client, link string) ([]*Task, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -210,25 +209,34 @@ func ListReferencedTasks(c common.Client, link string) ([]*Task, error) {
 		ch <- GetResult{Item: task, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-Task helper map.
+	unorderedResults := map[string]*Task{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*Task, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }

--- a/redfish/thermalsubsystem.go
+++ b/redfish/thermalsubsystem.go
@@ -131,10 +131,9 @@ func GetThermalSubsystem(c common.Client, uri string) (*ThermalSubsystem, error)
 
 // ListReferencedThermalSubsystems gets the collection of ThermalSubsystem from
 // a provided reference.
-func ListReferencedThermalSubsystems(c common.Client, link string) ([]*ThermalSubsystem, error) {
-	var result []*ThermalSubsystem
+func ListReferencedThermalSubsystems(c common.Client, link string) ([]*ThermalSubsystem, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -150,25 +149,34 @@ func ListReferencedThermalSubsystems(c common.Client, link string) ([]*ThermalSu
 		ch <- GetResult{Item: thermalsubsystem, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-ThermalSubsystem helper map.
+	unorderedResults := map[string]*ThermalSubsystem{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*ThermalSubsystem, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }

--- a/redfish/trustedcomponent.go
+++ b/redfish/trustedcomponent.go
@@ -260,10 +260,9 @@ func GetTrustedComponent(c common.Client, uri string) (*TrustedComponent, error)
 
 // ListReferencedTrustedComponents gets the collection of TrustedComponent from
 // a provided reference.
-func ListReferencedTrustedComponents(c common.Client, link string) ([]*TrustedComponent, error) {
-	var result []*TrustedComponent
+func ListReferencedTrustedComponents(c common.Client, link string) ([]*TrustedComponent, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -279,25 +278,34 @@ func ListReferencedTrustedComponents(c common.Client, link string) ([]*TrustedCo
 		ch <- GetResult{Item: trustedcomponent, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-TrustedComponent helper map.
+	unorderedResults := map[string]*TrustedComponent{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*TrustedComponent, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }

--- a/redfish/usbcontroller.go
+++ b/redfish/usbcontroller.go
@@ -131,10 +131,9 @@ func GetUSBController(c common.Client, uri string) (*USBController, error) {
 
 // ListReferencedUSBControllers gets the collection of USBController from
 // a provided reference.
-func ListReferencedUSBControllers(c common.Client, link string) ([]*USBController, error) {
-	var result []*USBController
+func ListReferencedUSBControllers(c common.Client, link string) ([]*USBController, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -150,25 +149,34 @@ func ListReferencedUSBControllers(c common.Client, link string) ([]*USBControlle
 		ch <- GetResult{Item: usbcontroller, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-USBController helper map.
+	unorderedResults := map[string]*USBController{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*USBController, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }

--- a/redfish/vlannetworkinterface.go
+++ b/redfish/vlannetworkinterface.go
@@ -95,10 +95,9 @@ func GetVLanNetworkInterface(c common.Client, uri string) (*VLanNetworkInterface
 
 // ListReferencedVLanNetworkInterfaces gets the collection of VLanNetworkInterface from
 // a provided reference.
-func ListReferencedVLanNetworkInterfaces(c common.Client, link string) ([]*VLanNetworkInterface, error) {
-	var result []*VLanNetworkInterface
+func ListReferencedVLanNetworkInterfaces(c common.Client, link string) ([]*VLanNetworkInterface, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -114,25 +113,34 @@ func ListReferencedVLanNetworkInterfaces(c common.Client, link string) ([]*VLanN
 		ch <- GetResult{Item: vlannetworkinterface, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-VLanNetworkInterface helper map.
+	unorderedResults := map[string]*VLanNetworkInterface{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*VLanNetworkInterface, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }

--- a/redfish/volume.go
+++ b/redfish/volume.go
@@ -1058,10 +1058,9 @@ func GetVolume(c common.Client, uri string) (*Volume, error) {
 }
 
 // ListReferencedVolumes gets the collection of Volumes from a provided reference.
-func ListReferencedVolumes(c common.Client, link string) ([]*Volume, error) {
-	var result []*Volume
+func ListReferencedVolumes(c common.Client, link string) ([]*Volume, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -1077,27 +1076,36 @@ func ListReferencedVolumes(c common.Client, link string) ([]*Volume, error) {
 		ch <- GetResult{Item: volume, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-Volume helper map.
+	unorderedResults := map[string]*Volume{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*Volume, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }
 
 // AllowedVolumesUpdateApplyTimes returns the set of allowed apply times to request when setting the volumes values

--- a/swordfish/capacity.go
+++ b/swordfish/capacity.go
@@ -124,10 +124,9 @@ func GetCapacitySource(c common.Client, uri string) (*CapacitySource, error) {
 
 // ListReferencedCapacitySources gets the collection of CapacitySources from
 // a provided reference.
-func ListReferencedCapacitySources(c common.Client, link string) ([]*CapacitySource, error) {
-	var result []*CapacitySource
+func ListReferencedCapacitySources(c common.Client, link string) ([]*CapacitySource, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -143,27 +142,36 @@ func ListReferencedCapacitySources(c common.Client, link string) ([]*CapacitySou
 		ch <- GetResult{Item: capacitysource, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-CapacitySource helper map.
+	unorderedResults := map[string]*CapacitySource{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*CapacitySource, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }
 
 // ProvidedClassOfService gets the ClassOfService from the ProvidingDrives,

--- a/swordfish/datastorageloscapabilities.go
+++ b/swordfish/datastorageloscapabilities.go
@@ -136,10 +136,9 @@ func GetDataStorageLoSCapabilities(c common.Client, uri string) (*DataStorageLoS
 
 // ListReferencedDataStorageLoSCapabilities gets the collection of DataStorageLoSCapabilities from
 // a provided reference.
-func ListReferencedDataStorageLoSCapabilities(c common.Client, link string) ([]*DataStorageLoSCapabilities, error) {
-	var result []*DataStorageLoSCapabilities
+func ListReferencedDataStorageLoSCapabilities(c common.Client, link string) ([]*DataStorageLoSCapabilities, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -155,25 +154,34 @@ func ListReferencedDataStorageLoSCapabilities(c common.Client, link string) ([]*
 		ch <- GetResult{Item: datastorageloscapabilities, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-DataStorageLoSCapabilities helper map.
+	unorderedResults := map[string]*DataStorageLoSCapabilities{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*DataStorageLoSCapabilities, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }

--- a/swordfish/endpointgroup.go
+++ b/swordfish/endpointgroup.go
@@ -136,10 +136,9 @@ func GetEndpointGroup(c common.Client, uri string) (*EndpointGroup, error) {
 
 // ListReferencedEndpointGroups gets the collection of EndpointGroup from
 // a provided reference.
-func ListReferencedEndpointGroups(c common.Client, link string) ([]*EndpointGroup, error) {
-	var result []*EndpointGroup
+func ListReferencedEndpointGroups(c common.Client, link string) ([]*EndpointGroup, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -155,27 +154,36 @@ func ListReferencedEndpointGroups(c common.Client, link string) ([]*EndpointGrou
 		ch <- GetResult{Item: endpointgroup, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-EndpointGroup helper map.
+	unorderedResults := map[string]*EndpointGroup{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*EndpointGroup, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }
 
 // Endpoints gets the group's endpoints.

--- a/swordfish/nvmefirmwareimage.go
+++ b/swordfish/nvmefirmwareimage.go
@@ -67,10 +67,9 @@ func GetNVMeFirmwareImage(c common.Client, uri string) (*NVMeFirmwareImage, erro
 
 // ListReferencedNVMeFirmwareImages gets the collection of NVMeFirmwareImage from
 // a provided reference.
-func ListReferencedNVMeFirmwareImages(c common.Client, link string) ([]*NVMeFirmwareImage, error) {
-	var result []*NVMeFirmwareImage
+func ListReferencedNVMeFirmwareImages(c common.Client, link string) ([]*NVMeFirmwareImage, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -86,25 +85,34 @@ func ListReferencedNVMeFirmwareImages(c common.Client, link string) ([]*NVMeFirm
 		ch <- GetResult{Item: nvmefirmwareimage, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-NVMeFirmwareImage helper map.
+	unorderedResults := map[string]*NVMeFirmwareImage{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*NVMeFirmwareImage, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }

--- a/swordfish/storageservice.go
+++ b/swordfish/storageservice.go
@@ -219,10 +219,9 @@ func GetStorageService(c common.Client, uri string) (*StorageService, error) {
 
 // ListReferencedStorageServices gets the collection of StorageService from
 // a provided reference.
-func ListReferencedStorageServices(c common.Client, link string) ([]*StorageService, error) {
-	var result []*StorageService
+func ListReferencedStorageServices(c common.Client, link string) ([]*StorageService, error) { //nolint:dupl
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -238,27 +237,36 @@ func ListReferencedStorageServices(c common.Client, link string) ([]*StorageServ
 		ch <- GetResult{Item: storageservice, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-StorageService helper map.
+	unorderedResults := map[string]*StorageService{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*StorageService, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }
 
 // ClassesOfService gets the storage service's classes of service.

--- a/tools/source.tmpl
+++ b/tools/source.tmpl
@@ -107,9 +107,8 @@ func Get{{ class.name }}(c common.Client, uri string) (*{{ class.name }}, error)
 // ListReferenced{{ class.name }}s gets the collection of {{ class.name }} from
 // a provided reference.
 func ListReferenced{{ class.name }}s(c common.Client, link string) ([]*{{ class.name }}, error) {
-    var result []*{{ class.name }}
 	if link == "" {
-		return result, nil
+		return nil, nil
 	}
 
 	type GetResult struct {
@@ -125,27 +124,36 @@ func ListReferenced{{ class.name }}s(c common.Client, link string) ([]*{{ class.
 		ch <- GetResult{Item: {{ class.name|lower }}, Link: link, Error: err}
 	}
 
+	var links []string
+	var err error
 	go func() {
-		err := common.CollectList(get, c, link)
+		links, err = common.CollectList(get, c, link)
 		if err != nil {
 			collectionError.Failures[link] = err
 		}
 		close(ch)
 	}()
 
+	// Save unordered results into link-to-{{ class.name }} helper map.
+	unorderedResults := map[string]*{{ class.name }}{}
 	for r := range ch {
 		if r.Error != nil {
 			collectionError.Failures[r.Link] = r.Error
 		} else {
-			result = append(result, r.Item)
+			unorderedResults[r.Link] = r.Item
 		}
 	}
 
-	if collectionError.Empty() {
-		return result, nil
+	if !collectionError.Empty() {
+		return nil, collectionError
+	}
+	// Build the final ordered slice based on the original order from the links list.
+	results := make([]*{{ class.name }}, len(links))
+	for i, link := range links {
+		results[i] = unorderedResults[link]
 	}
 
-	return result, collectionError
+	return results, nil
 }
 
 {% endif %}


### PR DESCRIPTION
Due to the parallelization of the collection's links retrieval, the returned list of the ListReferencedX funcs cannot be trusted to be ordered. This commit ensures that the returned list keeps the same order as the collection's members list.

Update common.GetCollection() to return the list of the collection's links in the same order they were retrieved.

Then, ListReferencedX funcs  use the original link list to reorder the results before returning them. This proposal uses a helper map to store the unordered resultsDue to the parallelization of the collection's links retrieval, the returned list of the ListReferencedX funcs cannot be trusted to be ordered. This commit ensures that the returned list keeps the same order as the collection's members list..

I've updated all affected packages plus the template in the tools folder.