### PR TITLE
Add OEM field for ComputerSystem

### DIFF
--- a/redfish/computersystem.go
+++ b/redfish/computersystem.go
@@ -825,6 +825,9 @@ type ComputerSystem struct {
 	// networkInterfaces shall be a link to a collection of type
 	// NetworkInterfaceCollection.
 	networkInterfaces string
+	// Oem shall contain the OEM extensions. All values for properties that this object contains shall conform to the
+	// Redfish Specification-described requirements.
+	OEM json.RawMessage `json:"Oem"`
 	// OperatingSystem shall contain a link to a resource of type OperatingSystem that contains operating system
 	// information for this system.
 	OperatingSystem string


### PR DESCRIPTION
I'd like to add `ComputerSystem.OEM` field as HPE and Dell provide it.

It's not part of the Redfish API schema so not sure if this is the right way to do it.