### PR TITLE
r/hostinterface.go: Correct "CredentialBootstrapping" type

### DIFF
--- a/redfish/hostinterface.go
+++ b/redfish/hostinterface.go
@@ -70,7 +70,7 @@ type HostInterface struct {
 	// CredentialBootstrapping shall contain settings for the Redfish Host Interface Specification-defined 'credential
 	// bootstrapping via IPMI commands' feature for this interface. This property shall be absent if credential
 	// bootstrapping is not supported by the service.
-	CredentialBootstrapping string
+	CredentialBootstrapping CredentialBootstrapping
 	// Description provides a description of this resource.
 	Description string
 	// ExternallyAccessible is used by external clients, and this property


### PR DESCRIPTION
Attempted use of Hostinterface (ie `redfish.GetHostInterface(c, uri)`) led to error:
```
json: cannot unmarshal object into Go struct field .CredentialBootstrapping of type string
```

The CredentialBootstrapping variable may have intended to be of type "CredentialBootstrapping" (struct defined earlier), which was not referenced elsewhere in gofish.

This commit resolves the unmarshal issue.