### PR TITLE
Use common generic fetch of collection objects

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/stmcginnis/gofish
 
-go 1.16
+go 1.18

--- a/redfish/accelerationfunction.go
+++ b/redfish/accelerationfunction.go
@@ -122,45 +122,7 @@ func GetAccelerationFunction(c common.Client, uri string) (*AccelerationFunction
 // ListReferencedAccelerationFunctions gets the collection of AccelerationFunction from
 // a provided reference.
 func ListReferencedAccelerationFunctions(c common.Client, link string) ([]*AccelerationFunction, error) {
-	var result []*AccelerationFunction
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *AccelerationFunction
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		accelerationfunction, err := GetAccelerationFunction(c, link)
-		ch <- GetResult{Item: accelerationfunction, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetAccelerationFunction)
 }
 
 // Endpoints gets the endpoints connected to this accelerator.

--- a/redfish/addresspool.go
+++ b/redfish/addresspool.go
@@ -98,45 +98,7 @@ func GetAddressPool(c common.Client, uri string) (*AddressPool, error) {
 // ListReferencedAddressPools gets the collection of AddressPool from
 // a provided reference.
 func ListReferencedAddressPools(c common.Client, link string) ([]*AddressPool, error) {
-	var result []*AddressPool
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *AddressPool
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		addresspool, err := GetAddressPool(c, link)
-		ch <- GetResult{Item: addresspool, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetAddressPool)
 }
 
 // Endpoints gets the endpoints connected to this address pool.

--- a/redfish/aggregate.go
+++ b/redfish/aggregate.go
@@ -153,43 +153,5 @@ func GetAggregate(c common.Client, uri string) (*Aggregate, error) {
 // ListReferencedAggregates gets the collection of Aggregate from
 // a provided reference.
 func ListReferencedAggregates(c common.Client, link string) ([]*Aggregate, error) {
-	var result []*Aggregate
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Aggregate
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		aggregate, err := GetAggregate(c, link)
-		ch <- GetResult{Item: aggregate, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetAggregate)
 }

--- a/redfish/aggregationservice.go
+++ b/redfish/aggregationservice.go
@@ -163,43 +163,5 @@ func GetAggregationService(c common.Client, uri string) (*AggregationService, er
 // ListReferencedAggregationServices gets the collection of AggregationService from
 // a provided reference.
 func ListReferencedAggregationServices(c common.Client, link string) ([]*AggregationService, error) {
-	var result []*AggregationService
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *AggregationService
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		aggregationservice, err := GetAggregationService(c, link)
-		ch <- GetResult{Item: aggregationservice, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetAggregationService)
 }

--- a/redfish/aggregationsource.go
+++ b/redfish/aggregationsource.go
@@ -209,45 +209,7 @@ func GetAggregationSource(c common.Client, uri string) (*AggregationSource, erro
 // ListReferencedAggregationSources gets the collection of AggregationSource from
 // a provided reference.
 func ListReferencedAggregationSources(c common.Client, link string) ([]*AggregationSource, error) {
-	var result []*AggregationSource
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *AggregationSource
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		aggregationsource, err := GetAggregationSource(c, link)
-		ch <- GetResult{Item: aggregationsource, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetAggregationSource)
 }
 
 // SNMPSettings shall contain the settings for an SNMP aggregation source.

--- a/redfish/allowdeny.go
+++ b/redfish/allowdeny.go
@@ -146,43 +146,5 @@ func GetAllowDeny(c common.Client, uri string) (*AllowDeny, error) {
 // ListReferencedAllowDenys gets the collection of AllowDeny from
 // a provided reference.
 func ListReferencedAllowDenys(c common.Client, link string) ([]*AllowDeny, error) {
-	var result []*AllowDeny
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *AllowDeny
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		allowdeny, err := GetAllowDeny(c, link)
-		ch <- GetResult{Item: allowdeny, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetAllowDeny)
 }

--- a/redfish/application.go
+++ b/redfish/application.go
@@ -94,45 +94,7 @@ func GetApplication(c common.Client, uri string) (*Application, error) {
 // ListReferencedApplications gets the collection of Application from
 // a provided reference.
 func ListReferencedApplications(c common.Client, link string) ([]*Application, error) {
-	var result []*Application
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Application
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		application, err := GetApplication(c, link)
-		ch <- GetResult{Item: application, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetApplication)
 }
 
 // SoftwareImage returns a `SoftwareInventory“ that represents the software image from which this application runs.

--- a/redfish/assembly.go
+++ b/redfish/assembly.go
@@ -80,45 +80,7 @@ func GetAssembly(c common.Client, uri string) (*Assembly, error) {
 // ListReferencedAssemblys gets the collection of Assembly from
 // a provided reference.
 func ListReferencedAssemblys(c common.Client, link string) ([]*Assembly, error) {
-	var result []*Assembly
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Assembly
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		assembly, err := GetAssembly(c, link)
-		ch <- GetResult{Item: assembly, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetAssembly)
 }
 
 // AssemblyData is information about an assembly.

--- a/redfish/battery.go
+++ b/redfish/battery.go
@@ -207,45 +207,7 @@ func GetBattery(c common.Client, uri string) (*Battery, error) {
 // ListReferencedBatterys gets the collection of Battery from
 // a provided reference.
 func ListReferencedBatterys(c common.Client, link string) ([]*Battery, error) {
-	var result []*Battery
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Battery
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		battery, err := GetBattery(c, link)
-		ch <- GetResult{Item: battery, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetBattery)
 }
 
 // Assembly get the containing assembly of this battery.

--- a/redfish/batterymetrics.go
+++ b/redfish/batterymetrics.go
@@ -91,43 +91,5 @@ func GetBatteryMetrics(c common.Client, uri string) (*BatteryMetrics, error) {
 // ListReferencedBatteryMetricss gets the collection of BatteryMetrics from
 // a provided reference.
 func ListReferencedBatteryMetricss(c common.Client, link string) ([]*BatteryMetrics, error) {
-	var result []*BatteryMetrics
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *BatteryMetrics
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		batterymetrics, err := GetBatteryMetrics(c, link)
-		ch <- GetResult{Item: batterymetrics, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetBatteryMetrics)
 }

--- a/redfish/bios.go
+++ b/redfish/bios.go
@@ -105,45 +105,7 @@ func GetBios(c common.Client, uri string) (*Bios, error) {
 
 // ListReferencedBioss gets the collection of Bios from a provided reference.
 func ListReferencedBioss(c common.Client, link string) ([]*Bios, error) {
-	var result []*Bios
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Bios
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		bios, err := GetBios(c, link)
-		ch <- GetResult{Item: bios, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetBios)
 }
 
 // ChangePassword shall change the selected BIOS password.

--- a/redfish/cable.go
+++ b/redfish/cable.go
@@ -366,43 +366,5 @@ func GetCable(c common.Client, uri string) (*Cable, error) {
 // ListReferencedCables gets the collection of Cable from
 // a provided reference.
 func ListReferencedCables(c common.Client, link string) ([]*Cable, error) {
-	var result []*Cable
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Cable
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		cable, err := GetCable(c, link)
-		ch <- GetResult{Item: cable, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetCable)
 }

--- a/redfish/certificate.go
+++ b/redfish/certificate.go
@@ -203,45 +203,7 @@ func GetCertificate(c common.Client, uri string) (*Certificate, error) {
 
 // ListReferencedCertificates gets the Certificates collection.
 func ListReferencedCertificates(c common.Client, link string) ([]*Certificate, error) {
-	var result []*Certificate
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Certificate
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		certificate, err := GetCertificate(c, link)
-		ch <- GetResult{Item: certificate, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetCertificate)
 }
 
 func (certificate *Certificate) RekeyCertificate(challengePassword, keyCurveID, keyPairAlgorithm string, keyBitLength int) error {

--- a/redfish/certificatelocations.go
+++ b/redfish/certificatelocations.go
@@ -77,45 +77,7 @@ func GetCertificateLocations(c common.Client, uri string) (*CertificateLocations
 // ListReferencedCertificateLocationss gets the collection of CertificateLocations from
 // a provided reference.
 func ListReferencedCertificateLocations(c common.Client, link string) ([]*CertificateLocations, error) {
-	var result []*CertificateLocations
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *CertificateLocations
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		certificatelocations, err := GetCertificateLocations(c, link)
-		ch <- GetResult{Item: certificatelocations, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetCertificateLocations)
 }
 
 // Certificates retrieves a collection of the Certificates installed on the system.

--- a/redfish/certificateservice.go
+++ b/redfish/certificateservice.go
@@ -89,45 +89,7 @@ func GetCertificateService(c common.Client, uri string) (*CertificateService, er
 // ListReferencedCertificateServices gets the collection of CertificateService from
 // a provided reference.
 func ListReferencedCertificateServices(c common.Client, link string) ([]*CertificateService, error) {
-	var result []*CertificateService
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *CertificateService
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		certificateservice, err := GetCertificateService(c, link)
-		ch <- GetResult{Item: certificateservice, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetCertificateService)
 }
 
 // GenerateCSRResponse shall contain the properties found in the response body for the GenerateCSR action.

--- a/redfish/chassis.go
+++ b/redfish/chassis.go
@@ -601,45 +601,7 @@ func GetChassis(c common.Client, uri string) (*Chassis, error) {
 
 // ListReferencedChassis gets the collection of Chassis from a provided reference.
 func ListReferencedChassis(c common.Client, link string) ([]*Chassis, error) {
-	var result []*Chassis
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Chassis
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		chassis, err := GetChassis(c, link)
-		ch <- GetResult{Item: chassis, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetChassis)
 }
 
 // Certificates returns certificates in this Chassis.

--- a/redfish/circuit.go
+++ b/redfish/circuit.go
@@ -516,45 +516,7 @@ func (circuit *Circuit) ResetMetrics() error {
 // ListReferencedCircuits gets the collection of Circuits from
 // a provided reference.
 func ListReferencedCircuits(c common.Client, link string) ([]*Circuit, error) {
-	var result []*Circuit
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Circuit
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		circuit, err := GetCircuit(c, link)
-		ch <- GetResult{Item: circuit, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetCircuit)
 }
 
 // BranchCircuit gets a resource that represents the branch circuit associated with this circuit.

--- a/redfish/componentintegrity.go
+++ b/redfish/componentintegrity.go
@@ -265,45 +265,7 @@ func GetComponentIntegrity(c common.Client, uri string) (*ComponentIntegrity, er
 // ListReferencedComponentIntegritys gets the collection of ComponentIntegrity from
 // a provided reference.
 func ListReferencedComponentIntegritys(c common.Client, link string) ([]*ComponentIntegrity, error) {
-	var result []*ComponentIntegrity
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *ComponentIntegrity
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		componentintegrity, err := GetComponentIntegrity(c, link)
-		ch <- GetResult{Item: componentintegrity, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetComponentIntegrity)
 }
 
 // SPDMGetSignedMeasurementsRequest contains the parameters for the SPDMGetSignedMeasurements action.

--- a/redfish/compositionreservation.go
+++ b/redfish/compositionreservation.go
@@ -81,45 +81,7 @@ func GetCompositionReservation(c common.Client, uri string) (*CompositionReserva
 // ListReferencedCompositionReservations gets the collection of CompositionReservation from
 // a provided reference.
 func ListReferencedCompositionReservations(c common.Client, link string) ([]*CompositionReservation, error) {
-	var result []*CompositionReservation
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *CompositionReservation
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		compositionreservation, err := GetCompositionReservation(c, link)
-		ch <- GetResult{Item: compositionreservation, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetCompositionReservation)
 }
 
 // ReservedResourceBlocks gets reserved resource blocks for this reservation.

--- a/redfish/compositionservice.go
+++ b/redfish/compositionservice.go
@@ -178,45 +178,7 @@ func GetCompositionService(c common.Client, uri string) (*CompositionService, er
 // ListReferencedCompositionServices gets the collection of CompositionService from
 // a provided reference.
 func ListReferencedCompositionServices(c common.Client, link string) ([]*CompositionService, error) {
-	var result []*CompositionService
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *CompositionService
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		compositionservice, err := GetCompositionService(c, link)
-		ch <- GetResult{Item: compositionservice, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetCompositionService)
 }
 
 // Compose performs a set of operations specified by a manifest.

--- a/redfish/computersystem.go
+++ b/redfish/computersystem.go
@@ -1062,45 +1062,7 @@ func GetComputerSystem(c common.Client, uri string) (*ComputerSystem, error) {
 // ListReferencedComputerSystems gets the collection of ComputerSystem from
 // a provided reference.
 func ListReferencedComputerSystems(c common.Client, link string) ([]*ComputerSystem, error) {
-	var result []*ComputerSystem
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *ComputerSystem
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		computersystem, err := GetComputerSystem(c, link)
-		ch <- GetResult{Item: computersystem, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetComputerSystem)
 }
 
 // Bios gets the Bios information for this ComputerSystem.

--- a/redfish/connection.go
+++ b/redfish/connection.go
@@ -175,45 +175,7 @@ func GetConnection(c common.Client, uri string) (*Connection, error) {
 // ListReferencedConnections gets the collection of Connection from
 // a provided reference.
 func ListReferencedConnections(c common.Client, link string) ([]*Connection, error) {
-	var result []*Connection
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Connection
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		connection, err := GetConnection(c, link)
-		ch <- GetResult{Item: connection, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetConnection)
 }
 
 // InitiatorEndpointGroups get the initiator endpoint groups associated with this connection.

--- a/redfish/connectionmethod.go
+++ b/redfish/connectionmethod.go
@@ -111,45 +111,7 @@ func GetConnectionMethod(c common.Client, uri string) (*ConnectionMethod, error)
 // ListReferencedConnectionMethods gets the collection of ConnectionMethod from
 // a provided reference.
 func ListReferencedConnectionMethods(c common.Client, link string) ([]*ConnectionMethod, error) {
-	var result []*ConnectionMethod
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *ConnectionMethod
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		connectionmethod, err := GetConnectionMethod(c, link)
-		ch <- GetResult{Item: connectionmethod, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetConnectionMethod)
 }
 
 // AggregationSources gets the access points using this connection method.

--- a/redfish/container.go
+++ b/redfish/container.go
@@ -95,45 +95,7 @@ func GetContainer(c common.Client, uri string) (*Container, error) {
 // ListReferencedContainers gets the collection of Container from
 // a provided reference.
 func ListReferencedContainers(c common.Client, link string) ([]*Container, error) {
-	var result []*Container
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Container
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		container, err := GetContainer(c, link)
-		ch <- GetResult{Item: container, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetContainer)
 }
 
 // Reset resets the container.

--- a/redfish/containerimage.go
+++ b/redfish/containerimage.go
@@ -105,45 +105,7 @@ func GetContainerImage(c common.Client, uri string) (*ContainerImage, error) {
 // ListReferencedContainerImages gets the collection of ContainerImage from
 // a provided reference.
 func ListReferencedContainerImages(c common.Client, link string) ([]*ContainerImage, error) {
-	var result []*ContainerImage
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *ContainerImage
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		containerimage, err := GetContainerImage(c, link)
-		ch <- GetResult{Item: containerimage, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetContainerImage)
 }
 
 // Containers get the container instances using this container image.

--- a/redfish/control.go
+++ b/redfish/control.go
@@ -248,45 +248,7 @@ func GetControl(c common.Client, uri string) (*Control, error) {
 // ListReferencedControls gets the collection of Control from
 // a provided reference.
 func ListReferencedControls(c common.Client, link string) ([]*Control, error) {
-	var result []*Control
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Control
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		control, err := GetControl(c, link)
-		ch <- GetResult{Item: control, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetControl)
 }
 
 // ResetToDefault resets the values of writable properties to factory defaults.

--- a/redfish/coolantconnector.go
+++ b/redfish/coolantconnector.go
@@ -184,45 +184,7 @@ func GetCoolantConnector(c common.Client, uri string) (*CoolantConnector, error)
 // ListReferencedCoolantConnectors gets the collection of CoolantConnector from
 // a provided reference.
 func ListReferencedCoolantConnectors(c common.Client, link string) ([]*CoolantConnector, error) {
-	var result []*CoolantConnector
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *CoolantConnector
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		coolantconnector, err := GetCoolantConnector(c, link)
-		ch <- GetResult{Item: coolantconnector, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetCoolantConnector)
 }
 
 // ConnectedChassis retrieves a collection of the Chassis at the other end of the connection.

--- a/redfish/coolingloop.go
+++ b/redfish/coolingloop.go
@@ -190,45 +190,7 @@ func GetCoolingLoop(c common.Client, uri string) (*CoolingLoop, error) {
 // ListReferencedCoolingLoops gets the collection of CoolingLoop from
 // a provided reference.
 func ListReferencedCoolingLoops(c common.Client, link string) ([]*CoolingLoop, error) {
-	var result []*CoolingLoop
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *CoolingLoop
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		coolingloop, err := GetCoolingLoop(c, link)
-		ch <- GetResult{Item: coolingloop, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetCoolingLoop)
 }
 
 // SecondaryCoolantConnectors gets the secondary coolant connectors for this equipment.

--- a/redfish/coolingunit.go
+++ b/redfish/coolingunit.go
@@ -206,45 +206,7 @@ func GetCoolingUnit(c common.Client, uri string) (*CoolingUnit, error) {
 // ListReferencedCoolingUnits gets the collection of CoolingUnit from
 // a provided reference.
 func ListReferencedCoolingUnits(c common.Client, link string) ([]*CoolingUnit, error) {
-	var result []*CoolingUnit
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *CoolingUnit
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		coolingunit, err := GetCoolingUnit(c, link)
-		ch <- GetResult{Item: coolingunit, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetCoolingUnit)
 }
 
 // TODO: Add functions to get linked objects

--- a/redfish/cxllogicaldevice.go
+++ b/redfish/cxllogicaldevice.go
@@ -231,45 +231,7 @@ func GetCXLLogicalDevice(c common.Client, uri string) (*CXLLogicalDevice, error)
 // ListReferencedCXLLogicalDevices gets the collection of CXLLogicalDevice from
 // a provided reference.
 func ListReferencedCXLLogicalDevices(c common.Client, link string) ([]*CXLLogicalDevice, error) {
-	var result []*CXLLogicalDevice
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *CXLLogicalDevice
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		cxllogicaldevice, err := GetCXLLogicalDevice(c, link)
-		ch <- GetResult{Item: cxllogicaldevice, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetCXLLogicalDevice)
 }
 
 // QoS shall contain the quality of service properties of this CXL logical device.

--- a/redfish/drive.go
+++ b/redfish/drive.go
@@ -444,45 +444,7 @@ func GetDrive(c common.Client, uri string) (*Drive, error) {
 
 // ListReferencedDrives gets the collection of Drives from a provided reference.
 func ListReferencedDrives(c common.Client, link string) ([]*Drive, error) {
-	var result []*Drive
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Drive
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		drive, err := GetDrive(c, link)
-		ch <- GetResult{Item: drive, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetDrive)
 }
 
 // Assembly gets the Assembly for this drive.

--- a/redfish/drivemetrics.go
+++ b/redfish/drivemetrics.go
@@ -69,43 +69,5 @@ func GetDriveMetrics(c common.Client, uri string) (*DriveMetrics, error) {
 // ListReferencedDriveMetricss gets the collection of DriveMetrics from
 // a provided reference.
 func ListReferencedDriveMetricss(c common.Client, link string) ([]*DriveMetrics, error) {
-	var result []*DriveMetrics
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *DriveMetrics
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		drivemetrics, err := GetDriveMetrics(c, link)
-		ch <- GetResult{Item: drivemetrics, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetDriveMetrics)
 }

--- a/redfish/endpoint.go
+++ b/redfish/endpoint.go
@@ -234,45 +234,7 @@ func GetEndpoint(c common.Client, uri string) (*Endpoint, error) {
 // ListReferencedEndpoints gets the collection of Endpoint from
 // a provided reference.
 func ListReferencedEndpoints(c common.Client, link string) ([]*Endpoint, error) {
-	var result []*Endpoint
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Endpoint
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		endpoint, err := GetEndpoint(c, link)
-		ch <- GetResult{Item: endpoint, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetEndpoint)
 }
 
 // GCID shall contain the Gen-Z Core Specification-defined Global

--- a/redfish/endpointgroup.go
+++ b/redfish/endpointgroup.go
@@ -143,45 +143,7 @@ func GetEndpointGroup(c common.Client, uri string) (*EndpointGroup, error) {
 // ListReferencedEndpointGroups gets the collection of EndpointGroup from
 // a provided reference.
 func ListReferencedEndpointGroups(c common.Client, link string) ([]*EndpointGroup, error) {
-	var result []*EndpointGroup
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *EndpointGroup
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		endpointgroup, err := GetEndpointGroup(c, link)
-		ch <- GetResult{Item: endpointgroup, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetEndpointGroup)
 }
 
 // Endpoints get the endpoints associated with this endpoint group.

--- a/redfish/environmentmetrics.go
+++ b/redfish/environmentmetrics.go
@@ -158,43 +158,5 @@ func GetEnvironmentMetrics(c common.Client, uri string) (*EnvironmentMetrics, er
 // ListReferencedEnvironmentMetricss gets the collection of EnvironmentMetrics from
 // a provided reference.
 func ListReferencedEnvironmentMetricss(c common.Client, link string) ([]*EnvironmentMetrics, error) {
-	var result []*EnvironmentMetrics
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *EnvironmentMetrics
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		environmentmetrics, err := GetEnvironmentMetrics(c, link)
-		ch <- GetResult{Item: environmentmetrics, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetEnvironmentMetrics)
 }

--- a/redfish/ethernetinterface.go
+++ b/redfish/ethernetinterface.go
@@ -407,45 +407,7 @@ func GetEthernetInterface(c common.Client, uri string) (*EthernetInterface, erro
 // ListReferencedEthernetInterfaces gets the collection of EthernetInterface from
 // a provided reference.
 func ListReferencedEthernetInterfaces(c common.Client, link string) ([]*EthernetInterface, error) {
-	var result []*EthernetInterface
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *EthernetInterface
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		ethernetinterface, err := GetEthernetInterface(c, link)
-		ch <- GetResult{Item: ethernetinterface, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetEthernetInterface)
 }
 
 // IPv6AddressPolicyEntry describes and entry in the Address Selection Policy

--- a/redfish/event.go
+++ b/redfish/event.go
@@ -87,45 +87,7 @@ func GetEvent(c common.Client, uri string) (*Event, error) {
 // ListReferencedEvents gets the collection of Event from
 // a provided reference.
 func ListReferencedEvents(c common.Client, link string) ([]*Event, error) {
-	var result []*Event
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Event
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		event, err := GetEvent(c, link)
-		ch <- GetResult{Item: event, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetEvent)
 }
 
 // EventRecord

--- a/redfish/eventdestination.go
+++ b/redfish/eventdestination.go
@@ -621,46 +621,7 @@ func DeleteEventDestination(c common.Client, uri string) error {
 // ListReferencedEventDestinations gets the collection of EventDestination from
 // a provided reference.
 func ListReferencedEventDestinations(c common.Client, link string) ([]*EventDestination, error) {
-	var result []*EventDestination
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *EventDestination
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-
-	get := func(link string) {
-		eventdestination, err := GetEventDestination(c, link)
-		ch <- GetResult{Item: eventdestination, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetEventDestination)
 }
 
 // HTTPHeaderProperty shall a names and value of an HTTP header to be included

--- a/redfish/eventservice.go
+++ b/redfish/eventservice.go
@@ -257,45 +257,7 @@ func GetEventService(c common.Client, uri string) (*EventService, error) {
 // ListReferencedEventServices gets the collection of EventService from
 // a provided reference.
 func ListReferencedEventServices(c common.Client, link string) ([]*EventService, error) {
-	var result []*EventService
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *EventService
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		eventservice, err := GetEventService(c, link)
-		ch <- GetResult{Item: eventservice, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetEventService)
 }
 
 // GetEventSubscriptions gets all the subscriptions using the event service.

--- a/redfish/externalaccountprovider.go
+++ b/redfish/externalaccountprovider.go
@@ -174,45 +174,7 @@ func GetExternalAccountProvider(c common.Client, uri string) (*ExternalAccountPr
 // ListReferencedExternalAccountProviders gets the collection of ExternalAccountProvider from
 // a provided reference.
 func ListReferencedExternalAccountProviders(c common.Client, link string) ([]*ExternalAccountProvider, error) {
-	var result []*ExternalAccountProvider
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *ExternalAccountProvider
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		externalaccountprovider, err := GetExternalAccountProvider(c, link)
-		ch <- GetResult{Item: externalaccountprovider, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetExternalAccountProvider)
 }
 
 // LDAPSearchSettings shall contain all required settings to search a generic LDAP service.

--- a/redfish/fabric.go
+++ b/redfish/fabric.go
@@ -147,43 +147,5 @@ func GetFabric(c common.Client, uri string) (*Fabric, error) {
 // ListReferencedFabrics gets the collection of Fabric from
 // a provided reference.
 func ListReferencedFabrics(c common.Client, link string) ([]*Fabric, error) {
-	var result []*Fabric
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Fabric
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		fabric, err := GetFabric(c, link)
-		ch <- GetResult{Item: fabric, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetFabric)
 }

--- a/redfish/fabricadapter.go
+++ b/redfish/fabricadapter.go
@@ -270,45 +270,7 @@ func GetFabricAdapter(c common.Client, uri string) (*FabricAdapter, error) {
 // ListReferencedFabricAdapters gets the collection of FabricAdapter from
 // a provided reference.
 func ListReferencedFabricAdapters(c common.Client, link string) ([]*FabricAdapter, error) {
-	var result []*FabricAdapter
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *FabricAdapter
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		fabricadapter, err := GetFabricAdapter(c, link)
-		ch <- GetResult{Item: fabricadapter, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetFabricAdapter)
 }
 
 // FabricAdapterGenZ shall contain Gen-Z related properties for a fabric adapter.

--- a/redfish/facility.go
+++ b/redfish/facility.go
@@ -514,43 +514,5 @@ func GetFacility(c common.Client, uri string) (*Facility, error) {
 // ListReferencedFacilitys gets the collection of Facility from
 // a provided reference.
 func ListReferencedFacilitys(c common.Client, link string) ([]*Facility, error) {
-	var result []*Facility
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Facility
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		facility, err := GetFacility(c, link)
-		ch <- GetResult{Item: facility, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetFacility)
 }

--- a/redfish/fan.go
+++ b/redfish/fan.go
@@ -189,43 +189,5 @@ func GetFan(c common.Client, uri string) (*Fan, error) {
 // ListReferencedFans gets the collection of Fan from
 // a provided reference.
 func ListReferencedFans(c common.Client, link string) ([]*Fan, error) {
-	var result []*Fan
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Fan
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		fan, err := GetFan(c, link)
-		ch <- GetResult{Item: fan, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetFan)
 }

--- a/redfish/filter.go
+++ b/redfish/filter.go
@@ -148,43 +148,5 @@ func GetFilter(c common.Client, uri string) (*Filter, error) {
 // ListReferencedFilters gets the collection of Filter from
 // a provided reference.
 func ListReferencedFilters(c common.Client, link string) ([]*Filter, error) {
-	var result []*Filter
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Filter
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		filter, err := GetFilter(c, link)
-		ch <- GetResult{Item: filter, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetFilter)
 }

--- a/redfish/graphicscontroller.go
+++ b/redfish/graphicscontroller.go
@@ -170,43 +170,5 @@ func GetGraphicsController(c common.Client, uri string) (*GraphicsController, er
 // ListReferencedGraphicsControllers gets the collection of GraphicsController from
 // a provided reference.
 func ListReferencedGraphicsControllers(c common.Client, link string) ([]*GraphicsController, error) {
-	var result []*GraphicsController
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *GraphicsController
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		graphicscontroller, err := GetGraphicsController(c, link)
-		ch <- GetResult{Item: graphicscontroller, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetGraphicsController)
 }

--- a/redfish/heater.go
+++ b/redfish/heater.go
@@ -292,43 +292,5 @@ func GetHeater(c common.Client, uri string) (*Heater, error) {
 // ListReferencedHeaters gets the collection of Heater from
 // a provided reference.
 func ListReferencedHeaters(c common.Client, link string) ([]*Heater, error) {
-	var result []*Heater
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Heater
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		heater, err := GetHeater(c, link)
-		ch <- GetResult{Item: heater, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetHeater)
 }

--- a/redfish/heatermetrics.go
+++ b/redfish/heatermetrics.go
@@ -99,43 +99,5 @@ func GetHeaterMetrics(c common.Client, uri string) (*HeaterMetrics, error) {
 // ListReferencedHeaterMetrics gets the collection of HeaterMetrics from
 // a provided reference.
 func ListReferencedHeaterMetrics(c common.Client, link string) ([]*HeaterMetrics, error) {
-	var result []*HeaterMetrics
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *HeaterMetrics
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		heatermetrics, err := GetHeaterMetrics(c, link)
-		ch <- GetResult{Item: heatermetrics, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetHeaterMetrics)
 }

--- a/redfish/hostinterface.go
+++ b/redfish/hostinterface.go
@@ -216,45 +216,7 @@ func GetHostInterface(c common.Client, uri string) (*HostInterface, error) {
 // ListReferencedHostInterfaces gets the collection of HostInterface from
 // a provided reference.
 func ListReferencedHostInterfaces(c common.Client, link string) ([]*HostInterface, error) {
-	var result []*HostInterface
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *HostInterface
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		hostinterface, err := GetHostInterface(c, link)
-		ch <- GetResult{Item: hostinterface, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetHostInterface)
 }
 
 // ComputerSystems references the ComputerSystems that this host interface is associated with.

--- a/redfish/job.go
+++ b/redfish/job.go
@@ -178,43 +178,5 @@ func GetJob(c common.Client, uri string) (*Job, error) {
 // ListReferencedJobs gets the collection of Job from
 // a provided reference.
 func ListReferencedJobs(c common.Client, link string) ([]*Job, error) {
-	var result []*Job
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Job
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		job, err := GetJob(c, link)
-		ch <- GetResult{Item: job, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetJob)
 }

--- a/redfish/key.go
+++ b/redfish/key.go
@@ -154,45 +154,7 @@ func GetKey(c common.Client, uri string) (*Key, error) {
 // ListReferencedKeys gets the collection of Key from
 // a provided reference.
 func ListReferencedKeys(c common.Client, link string) ([]*Key, error) {
-	var result []*Key
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Key
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		key, err := GetKey(c, link)
-		ch <- GetResult{Item: key, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetKey)
 }
 
 // KeyNVMeoF shall contain NVMe-oF specific properties for a key.

--- a/redfish/keypolicy.go
+++ b/redfish/keypolicy.go
@@ -181,45 +181,7 @@ func GetKeyPolicy(c common.Client, uri string) (*KeyPolicy, error) {
 // ListReferencedKeyPolicys gets the collection of KeyPolicy from
 // a provided reference.
 func ListReferencedKeyPolicys(c common.Client, link string) ([]*KeyPolicy, error) {
-	var result []*KeyPolicy
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *KeyPolicy
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		keypolicy, err := GetKeyPolicy(c, link)
-		ch <- GetResult{Item: keypolicy, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetKeyPolicy)
 }
 
 // NVMeoF shall contain NVMe-oF specific properties for a key policy.

--- a/redfish/keyservice.go
+++ b/redfish/keyservice.go
@@ -88,43 +88,5 @@ func GetKeyService(c common.Client, uri string) (*KeyService, error) {
 // ListReferencedKeyServices gets the collection of KeyService from
 // a provided reference.
 func ListReferencedKeyServices(c common.Client, link string) ([]*KeyService, error) {
-	var result []*KeyService
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *KeyService
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		keyservice, err := GetKeyService(c, link)
-		ch <- GetResult{Item: keyservice, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetKeyService)
 }

--- a/redfish/leakdetection.go
+++ b/redfish/leakdetection.go
@@ -80,45 +80,7 @@ func GetLeakDetection(c common.Client, uri string) (*LeakDetection, error) {
 // ListReferencedLeakDetections gets the collection of LeakDetection from
 // a provided reference.
 func ListReferencedLeakDetections(c common.Client, link string) ([]*LeakDetection, error) {
-	var result []*LeakDetection
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *LeakDetection
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		leakdetection, err := GetLeakDetection(c, link)
-		ch <- GetResult{Item: leakdetection, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetLeakDetection)
 }
 
 // LeakDetectorGroup shall contain a group of leak detection equipment that reports a unified status.

--- a/redfish/leakdetector.go
+++ b/redfish/leakdetector.go
@@ -87,45 +87,7 @@ func GetLeakDetector(c common.Client, uri string) (*LeakDetector, error) {
 // ListReferencedLeakDetectors gets the collection of LeakDetector from
 // a provided reference.
 func ListReferencedLeakDetectors(c common.Client, link string) ([]*LeakDetector, error) {
-	var result []*LeakDetector
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *LeakDetector
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		leakdetector, err := GetLeakDetector(c, link)
-		ch <- GetResult{Item: leakdetector, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetLeakDetector)
 }
 
 // LeakDetectorArrayExcerpt shall represent a state-based or digital-value leak detector for a Redfish

--- a/redfish/license.go
+++ b/redfish/license.go
@@ -218,43 +218,5 @@ func GetLicense(c common.Client, uri string) (*License, error) {
 // ListReferencedLicenses gets the collection of License from
 // a provided reference.
 func ListReferencedLicenses(c common.Client, link string) ([]*License, error) {
-	var result []*License
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *License
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		license, err := GetLicense(c, link)
-		ch <- GetResult{Item: license, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetLicense)
 }

--- a/redfish/licenseservice.go
+++ b/redfish/licenseservice.go
@@ -152,43 +152,5 @@ func GetLicenseService(c common.Client, uri string) (*LicenseService, error) {
 // ListReferencedLicenseServices gets the collection of LicenseService from
 // a provided reference.
 func ListReferencedLicenseServices(c common.Client, link string) ([]*LicenseService, error) {
-	var result []*LicenseService
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *LicenseService
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		licenseservice, err := GetLicenseService(c, link)
-		ch <- GetResult{Item: licenseservice, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetLicenseService)
 }

--- a/redfish/logentry.go
+++ b/redfish/logentry.go
@@ -610,43 +610,5 @@ func GetLogEntry(c common.Client, uri string) (*LogEntry, error) {
 // ListReferencedLogEntrys gets the collection of LogEntry from
 // a provided reference.
 func ListReferencedLogEntrys(c common.Client, link string) ([]*LogEntry, error) {
-	var result []*LogEntry
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *LogEntry
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		logentry, err := GetLogEntry(c, link)
-		ch <- GetResult{Item: logentry, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetLogEntry)
 }

--- a/redfish/logservice.go
+++ b/redfish/logservice.go
@@ -186,45 +186,7 @@ func GetLogService(c common.Client, uri string) (*LogService, error) {
 
 // ListReferencedLogServices gets the collection of LogService from a provided reference.
 func ListReferencedLogServices(c common.Client, link string) ([]*LogService, error) {
-	var result []*LogService
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *LogService
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		logservice, err := GetLogService(c, link)
-		ch <- GetResult{Item: logservice, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetLogService)
 }
 
 // Entries gets the log entries of this service.

--- a/redfish/manager.go
+++ b/redfish/manager.go
@@ -523,45 +523,7 @@ func GetManager(c common.Client, uri string) (*Manager, error) {
 
 // ListReferencedManagers gets the collection of Managers
 func ListReferencedManagers(c common.Client, link string) ([]*Manager, error) {
-	var result []*Manager
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Manager
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		manager, err := GetManager(c, link)
-		ch <- GetResult{Item: manager, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetManager)
 }
 
 // ForceFailover forces a failover to the specified manager.

--- a/redfish/manageraccount.go
+++ b/redfish/manageraccount.go
@@ -276,45 +276,7 @@ func GetManagerAccount(c common.Client, uri string) (*ManagerAccount, error) {
 // ListReferencedManagerAccounts gets the collection of ManagerAccount from
 // a provided reference.
 func ListReferencedManagerAccounts(c common.Client, link string) ([]*ManagerAccount, error) {
-	var result []*ManagerAccount
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *ManagerAccount
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		manageraccount, err := GetManagerAccount(c, link)
-		ch <- GetResult{Item: manageraccount, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetManagerAccount)
 }
 
 // SNMPUserInfo is shall contain the SNMP settings for an account.

--- a/redfish/managerdiagnosticdata.go
+++ b/redfish/managerdiagnosticdata.go
@@ -128,45 +128,7 @@ func GetManagerDiagnosticData(c common.Client, uri string) (*ManagerDiagnosticDa
 // ListReferencedManagerDiagnosticDatas gets the collection of ManagerDiagnosticData from
 // a provided reference.
 func ListReferencedManagerDiagnosticDatas(c common.Client, link string) ([]*ManagerDiagnosticData, error) {
-	var result []*ManagerDiagnosticData
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *ManagerDiagnosticData
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		managerdiagnosticdata, err := GetManagerDiagnosticData(c, link)
-		ch <- GetResult{Item: managerdiagnosticdata, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetManagerDiagnosticData)
 }
 
 // MemoryECCStatistics shall contain the memory ECC statistics of a manager.

--- a/redfish/manifest.go
+++ b/redfish/manifest.go
@@ -92,45 +92,7 @@ func GetManifest(c common.Client, uri string) (*Manifest, error) {
 // ListReferencedManifests gets the collection of Manifest from
 // a provided reference.
 func ListReferencedManifests(c common.Client, link string) ([]*Manifest, error) {
-	var result []*Manifest
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Manifest
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		manifest, err := GetManifest(c, link)
-		ch <- GetResult{Item: manifest, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetManifest)
 }
 
 // Stanza shall contain properties that describe a request to be fulfilled within a manifest.

--- a/redfish/mediacontroller.go
+++ b/redfish/mediacontroller.go
@@ -193,43 +193,5 @@ func GetMediaController(c common.Client, uri string) (*MediaController, error) {
 // ListReferencedMediaControllers gets the collection of MediaController from
 // a provided reference.
 func ListReferencedMediaControllers(c common.Client, link string) ([]*MediaController, error) {
-	var result []*MediaController
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *MediaController
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		mediacontroller, err := GetMediaController(c, link)
-		ch <- GetResult{Item: mediacontroller, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetMediaController)
 }

--- a/redfish/memory.go
+++ b/redfish/memory.go
@@ -596,45 +596,7 @@ func GetMemory(c common.Client, uri string) (*Memory, error) {
 // ListReferencedMemorys gets the collection of Memory from
 // a provided reference.
 func ListReferencedMemorys(c common.Client, link string) ([]*Memory, error) {
-	var result []*Memory
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Memory
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		memory, err := GetMemory(c, link)
-		ch <- GetResult{Item: memory, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetMemory)
 }
 
 // Assembly gets this memory's assembly.

--- a/redfish/memorychunks.go
+++ b/redfish/memorychunks.go
@@ -216,43 +216,5 @@ func GetMemoryChunks(c common.Client, uri string) (*MemoryChunks, error) {
 // ListReferencedMemoryChunks gets the collection of MemoryChunks from
 // a provided reference.
 func ListReferencedMemoryChunks(c common.Client, link string) ([]*MemoryChunks, error) {
-	var result []*MemoryChunks
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *MemoryChunks
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		memorychunks, err := GetMemoryChunks(c, link)
-		ch <- GetResult{Item: memorychunks, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetMemoryChunks)
 }

--- a/redfish/memorydomain.go
+++ b/redfish/memorydomain.go
@@ -206,45 +206,7 @@ func GetMemoryDomain(c common.Client, uri string) (*MemoryDomain, error) {
 // ListReferencedMemoryDomains gets the collection of MemoryDomain from
 // a provided reference.
 func ListReferencedMemoryDomains(c common.Client, link string) ([]*MemoryDomain, error) {
-	var result []*MemoryDomain
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *MemoryDomain
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		memorydomain, err := GetMemoryDomain(c, link)
-		ch <- GetResult{Item: memorydomain, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetMemoryDomain)
 }
 
 // MemorySet shall represent the interleave sets for a memory chunk.

--- a/redfish/memorymetrics.go
+++ b/redfish/memorymetrics.go
@@ -213,43 +213,5 @@ func GetMemoryMetrics(c common.Client, uri string) (*MemoryMetrics, error) {
 // ListReferencedMemoryMetricss gets the collection of MemoryMetrics from
 // a provided reference.
 func ListReferencedMemoryMetricss(c common.Client, link string) ([]*MemoryMetrics, error) {
-	var result []*MemoryMetrics
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *MemoryMetrics
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		memorymetrics, err := GetMemoryMetrics(c, link)
-		ch <- GetResult{Item: memorymetrics, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetMemoryMetrics)
 }

--- a/redfish/memoryregion.go
+++ b/redfish/memoryregion.go
@@ -186,43 +186,5 @@ func GetMemoryRegion(c common.Client, uri string) (*MemoryRegion, error) {
 // ListReferencedMemoryRegions gets the collection of MemoryRegion from
 // a provided reference.
 func ListReferencedMemoryRegions(c common.Client, link string) ([]*MemoryRegion, error) {
-	var result []*MemoryRegion
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *MemoryRegion
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		memoryregion, err := GetMemoryRegion(c, link)
-		ch <- GetResult{Item: memoryregion, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetMemoryRegion)
 }

--- a/redfish/messageregistryfile.go
+++ b/redfish/messageregistryfile.go
@@ -67,43 +67,5 @@ func GetMessageRegistryFile(c common.Client, uri string) (*MessageRegistryFile, 
 
 // ListReferencedMessageRegistryFiles gets the collection of MessageRegistryFile.
 func ListReferencedMessageRegistryFiles(c common.Client, link string) ([]*MessageRegistryFile, error) {
-	var result []*MessageRegistryFile
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *MessageRegistryFile
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		messageregistryfile, err := GetMessageRegistryFile(c, link)
-		ch <- GetResult{Item: messageregistryfile, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetMessageRegistryFile)
 }

--- a/redfish/metricdefinition.go
+++ b/redfish/metricdefinition.go
@@ -232,45 +232,7 @@ func GetMetricDefinition(c common.Client, uri string) (*MetricDefinition, error)
 // ListReferencedMetricDefinitions gets the collection of MetricDefinition from
 // a provided reference.
 func ListReferencedMetricDefinitions(c common.Client, link string) ([]*MetricDefinition, error) {
-	var result []*MetricDefinition
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *MetricDefinition
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		metricdefinition, err := GetMetricDefinition(c, link)
-		ch <- GetResult{Item: metricdefinition, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetMetricDefinition)
 }
 
 // Wildcard shall contain a wildcard and its substitution values.

--- a/redfish/metricreport.go
+++ b/redfish/metricreport.go
@@ -88,45 +88,7 @@ func GetMetricReport(c common.Client, uri string) (*MetricReport, error) {
 // ListReferencedMetricReports gets the collection of MetricReport from
 // a provided reference.
 func ListReferencedMetricReports(c common.Client, link string) ([]*MetricReport, error) {
-	var result []*MetricReport
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *MetricReport
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		metricreport, err := GetMetricReport(c, link)
-		ch <- GetResult{Item: metricreport, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetMetricReport)
 }
 
 // MetricValue shall contain properties that capture a metric value and other associated information.

--- a/redfish/metricreportdefinition.go
+++ b/redfish/metricreportdefinition.go
@@ -303,43 +303,5 @@ func GetMetricReportDefinition(c common.Client, uri string) (*MetricReportDefini
 // ListReferencedMetricReportDefinitions gets the collection of MetricReportDefinition from
 // a provided reference.
 func ListReferencedMetricReportDefinitions(c common.Client, link string) ([]*MetricReportDefinition, error) {
-	var result []*MetricReportDefinition
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *MetricReportDefinition
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		metricreportdefinition, err := GetMetricReportDefinition(c, link)
-		ch <- GetResult{Item: metricreportdefinition, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetMetricReportDefinition)
 }

--- a/redfish/networkadapter.go
+++ b/redfish/networkadapter.go
@@ -434,45 +434,7 @@ func GetNetworkAdapter(c common.Client, uri string) (*NetworkAdapter, error) {
 
 // ListReferencedNetworkAdapter gets the collection of Chassis from a provided reference.
 func ListReferencedNetworkAdapter(c common.Client, link string) ([]*NetworkAdapter, error) {
-	var result []*NetworkAdapter
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *NetworkAdapter
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		networkadapter, err := GetNetworkAdapter(c, link)
-		ch <- GetResult{Item: networkadapter, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetNetworkAdapter)
 }
 
 // Assembly gets this adapter's assembly.

--- a/redfish/networkadaptermetrics.go
+++ b/redfish/networkadaptermetrics.go
@@ -82,43 +82,5 @@ func GetNetworkAdapterMetrics(c common.Client, uri string) (*NetworkAdapterMetri
 // ListReferencedNetworkAdapterMetrics gets the collection of NetworkAdapterMetrics from
 // a provided reference.
 func ListReferencedNetworkAdapterMetrics(c common.Client, link string) ([]*NetworkAdapterMetrics, error) {
-	var result []*NetworkAdapterMetrics
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *NetworkAdapterMetrics
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		networkadaptermetrics, err := GetNetworkAdapterMetrics(c, link)
-		ch <- GetResult{Item: networkadaptermetrics, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetNetworkAdapterMetrics)
 }

--- a/redfish/networkdevicefunction.go
+++ b/redfish/networkdevicefunction.go
@@ -566,45 +566,7 @@ func GetNetworkDeviceFunction(c common.Client, uri string) (*NetworkDeviceFuncti
 // ListReferencedNetworkDeviceFunctions gets the collection of NetworkDeviceFunction from
 // a provided reference.
 func ListReferencedNetworkDeviceFunctions(c common.Client, link string) ([]*NetworkDeviceFunction, error) {
-	var result []*NetworkDeviceFunction
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *NetworkDeviceFunction
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		networkdevicefunction, err := GetNetworkDeviceFunction(c, link)
-		ch <- GetResult{Item: networkdevicefunction, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetNetworkDeviceFunction)
 }
 
 // ISCSIBoot shall describe the iSCSI boot capabilities, status, and

--- a/redfish/networkdevicefunctionmetrics.go
+++ b/redfish/networkdevicefunctionmetrics.go
@@ -130,43 +130,5 @@ func GetNetworkDeviceFunctionMetrics(c common.Client, uri string) (*NetworkDevic
 // ListReferencedNetworkDeviceFunctionMetricss gets the collection of NetworkDeviceFunctionMetrics from
 // a provided reference.
 func ListReferencedNetworkDeviceFunctionMetricss(c common.Client, link string) ([]*NetworkDeviceFunctionMetrics, error) {
-	var result []*NetworkDeviceFunctionMetrics
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *NetworkDeviceFunctionMetrics
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		networkdevicefunctionmetrics, err := GetNetworkDeviceFunctionMetrics(c, link)
-		ch <- GetResult{Item: networkdevicefunctionmetrics, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetNetworkDeviceFunctionMetrics)
 }

--- a/redfish/networkinterface.go
+++ b/redfish/networkinterface.go
@@ -88,45 +88,7 @@ func GetNetworkInterface(c common.Client, uri string) (*NetworkInterface, error)
 // ListReferencedNetworkInterfaces gets the collection of NetworkInterface from
 // a provided reference.
 func ListReferencedNetworkInterfaces(c common.Client, link string) ([]*NetworkInterface, error) {
-	var result []*NetworkInterface
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *NetworkInterface
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		networkinterface, err := GetNetworkInterface(c, link)
-		ch <- GetResult{Item: networkinterface, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetNetworkInterface)
 }
 
 // NetworkAdapter gets the NetworkAdapter for this interface.

--- a/redfish/networkport.go
+++ b/redfish/networkport.go
@@ -281,45 +281,7 @@ func GetNetworkPort(c common.Client, uri string) (*NetworkPort, error) {
 // ListReferencedNetworkPorts gets the collection of NetworkPort from
 // a provided reference.
 func ListReferencedNetworkPorts(c common.Client, link string) ([]*NetworkPort, error) {
-	var result []*NetworkPort
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *NetworkPort
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		networkport, err := GetNetworkPort(c, link)
-		ch <- GetResult{Item: networkport, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetNetworkPort)
 }
 
 // SupportedLinkCapabilities shall describe the static capabilities of an

--- a/redfish/operatingconfig.go
+++ b/redfish/operatingconfig.go
@@ -74,45 +74,7 @@ func GetOperatingConfig(c common.Client, uri string) (*OperatingConfig, error) {
 // ListReferencedOperatingConfigs gets the collection of OperatingConfig from
 // a provided reference.
 func ListReferencedOperatingConfigs(c common.Client, link string) ([]*OperatingConfig, error) {
-	var result []*OperatingConfig
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *OperatingConfig
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		operatingconfig, err := GetOperatingConfig(c, link)
-		ch <- GetResult{Item: operatingconfig, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetOperatingConfig)
 }
 
 // TurboProfileDatapoint shall specify the turbo profile for a set of active cores.

--- a/redfish/operatingsystem.go
+++ b/redfish/operatingsystem.go
@@ -233,45 +233,7 @@ func GetOperatingSystem(c common.Client, uri string) (*OperatingSystem, error) {
 // ListReferencedOperatingSystems gets the collection of OperatingSystem from
 // a provided reference.
 func ListReferencedOperatingSystems(c common.Client, link string) ([]*OperatingSystem, error) {
-	var result []*OperatingSystem
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *OperatingSystem
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		operatingsystem, err := GetOperatingSystem(c, link)
-		ch <- GetResult{Item: operatingsystem, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetOperatingSystem)
 }
 
 // VirtualMachineEngine shall contain a virtual machine engine running in an operating system.

--- a/redfish/outboundconnection.go
+++ b/redfish/outboundconnection.go
@@ -200,45 +200,7 @@ func GetOutboundConnection(c common.Client, uri string) (*OutboundConnection, er
 // ListReferencedOutboundConnections gets the collection of OutboundConnection from
 // a provided reference.
 func ListReferencedOutboundConnections(c common.Client, link string) ([]*OutboundConnection, error) {
-	var result []*OutboundConnection
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *OutboundConnection
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		outboundconnection, err := GetOutboundConnection(c, link)
-		ch <- GetResult{Item: outboundconnection, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetOutboundConnection)
 }
 
 // RetryPolicyType shall contain the retry policy for an outbound connection.

--- a/redfish/outlet.go
+++ b/redfish/outlet.go
@@ -380,45 +380,7 @@ func GetOutlet(c common.Client, uri string) (*Outlet, error) {
 // ListReferencedOutlets gets the collection of Outlet from
 // a provided reference.
 func ListReferencedOutlets(c common.Client, link string) ([]*Outlet, error) {
-	var result []*Outlet
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Outlet
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		outlet, err := GetOutlet(c, link)
-		ch <- GetResult{Item: outlet, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetOutlet)
 }
 
 // VoltageSensors shall contain properties that describe voltage sensor readings for an outlet.

--- a/redfish/outletgroup.go
+++ b/redfish/outletgroup.go
@@ -199,43 +199,5 @@ func GetOutletGroup(c common.Client, uri string) (*OutletGroup, error) {
 // ListReferencedOutletGroups gets the collection of OutletGroup from
 // a provided reference.
 func ListReferencedOutletGroups(c common.Client, link string) ([]*OutletGroup, error) {
-	var result []*OutletGroup
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *OutletGroup
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		outletgroup, err := GetOutletGroup(c, link)
-		ch <- GetResult{Item: outletgroup, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetOutletGroup)
 }

--- a/redfish/pciedevice.go
+++ b/redfish/pciedevice.go
@@ -363,45 +363,7 @@ func GetPCIeDevice(c common.Client, uri string) (*PCIeDevice, error) {
 // ListReferencedPCIeDevices gets the collection of PCIeDevice from
 // a provided reference.
 func ListReferencedPCIeDevices(c common.Client, link string) ([]*PCIeDevice, error) {
-	var result []*PCIeDevice
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *PCIeDevice
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		pciedevice, err := GetPCIeDevice(c, link)
-		ch <- GetResult{Item: pciedevice, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetPCIeDevice)
 }
 
 // PCIeInterface properties shall be the definition for a PCIe Interface for a

--- a/redfish/pciefunction.go
+++ b/redfish/pciefunction.go
@@ -221,45 +221,7 @@ func GetPCIeFunction(c common.Client, uri string) (*PCIeFunction, error) {
 // ListReferencedPCIeFunctions gets the collection of PCIeFunction from
 // a provided reference.
 func ListReferencedPCIeFunctions(c common.Client, link string) ([]*PCIeFunction, error) {
-	var result []*PCIeFunction
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *PCIeFunction
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		pciefunction, err := GetPCIeFunction(c, link)
-		ch <- GetResult{Item: pciefunction, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetPCIeFunction)
 }
 
 // CXLLogicalDevice gets the CXL logical device to which this PCIe function is assigned.

--- a/redfish/port.go
+++ b/redfish/port.go
@@ -1134,45 +1134,7 @@ func GetPort(c common.Client, uri string) (*Port, error) {
 // ListReferencedPorts gets the collection of Port from
 // a provided reference.
 func ListReferencedPorts(c common.Client, link string) ([]*Port, error) {
-	var result []*Port
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Port
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		port, err := GetPort(c, link)
-		ch <- GetResult{Item: port, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetPort)
 }
 
 // ResetPort resets this port.

--- a/redfish/portmetrics.go
+++ b/redfish/portmetrics.go
@@ -240,45 +240,7 @@ func GetPortMetrics(c common.Client, uri string) (*PortMetrics, error) {
 // ListReferencedPortMetricss gets the collection of PortMetrics from
 // a provided reference.
 func ListReferencedPortMetricss(c common.Client, link string) ([]*PortMetrics, error) {
-	var result []*PortMetrics
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *PortMetrics
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		portmetrics, err := GetPortMetrics(c, link)
-		ch <- GetResult{Item: portmetrics, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetPortMetrics)
 }
 
 // SASPortMetrics shall describe physical (phy) related metrics for Serial Attached SCSI (SAS).

--- a/redfish/power.go
+++ b/redfish/power.go
@@ -188,45 +188,7 @@ func GetPower(c common.Client, uri string) (*Power, error) {
 // ListReferencedPowers gets the collection of Power from
 // a provided reference.
 func ListReferencedPowers(c common.Client, link string) ([]*Power, error) {
-	var result []*Power
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Power
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		power, err := GetPower(c, link)
-		ch <- GetResult{Item: power, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetPower)
 }
 
 type PowerControl struct {

--- a/redfish/powerdistribution.go
+++ b/redfish/powerdistribution.go
@@ -305,45 +305,7 @@ func (powerDistribution *PowerDistribution) TransferControl() error {
 // ListReferencedPowerDistribution gets the collection of PowerDistribution from
 // a provided reference.
 func ListReferencedPowerDistributionUnits(c common.Client, link string) ([]*PowerDistribution, error) {
-	var result []*PowerDistribution
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *PowerDistribution
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		powerDistribution, err := GetPowerDistribution(c, link)
-		ch <- GetResult{Item: powerDistribution, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetPowerDistribution)
 }
 
 // Deprecated: (v1.3) in favor of the Sensors link in the Chassis resource.

--- a/redfish/powerdomain.go
+++ b/redfish/powerdomain.go
@@ -273,43 +273,5 @@ func GetPowerDomain(c common.Client, uri string) (*PowerDomain, error) {
 // ListReferencedPowerDomains gets the collection of PowerDomain from
 // a provided reference.
 func ListReferencedPowerDomains(c common.Client, link string) ([]*PowerDomain, error) {
-	var result []*PowerDomain
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *PowerDomain
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		powerdomain, err := GetPowerDomain(c, link)
-		ch <- GetResult{Item: powerdomain, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetPowerDomain)
 }

--- a/redfish/powersubsystem.go
+++ b/redfish/powersubsystem.go
@@ -117,43 +117,5 @@ func GetPowerSubsystem(c common.Client, uri string) (*PowerSubsystem, error) {
 // ListReferencedPowerSubsystems gets the collection of PowerSubsystem from
 // a provided reference.
 func ListReferencedPowerSubsystems(c common.Client, link string) ([]*PowerSubsystem, error) {
-	var result []*PowerSubsystem
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *PowerSubsystem
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		powersubsystem, err := GetPowerSubsystem(c, link)
-		ch <- GetResult{Item: powersubsystem, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetPowerSubsystem)
 }

--- a/redfish/powersupplyunit.go
+++ b/redfish/powersupplyunit.go
@@ -238,45 +238,7 @@ func GetPowerSupplyUnit(c common.Client, uri string) (*PowerSupplyUnit, error) {
 // ListReferencedPowerSupplyUnits gets the collection of PowerSupplies from
 // a provided reference.
 func ListReferencedPowerSupplyUnits(c common.Client, link string) ([]*PowerSupplyUnit, error) {
-	var result []*PowerSupplyUnit
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *PowerSupplyUnit
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		powerSupplyUnit, err := GetPowerSupplyUnit(c, link)
-		ch <- GetResult{Item: powerSupplyUnit, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetPowerSupplyUnit)
 }
 
 // This action shall reset a power supply. A GracefulRestart ResetType shall reset the power supply

--- a/redfish/privilegeregistry.go
+++ b/redfish/privilegeregistry.go
@@ -89,45 +89,7 @@ func GetPrivilegeRegistry(c common.Client, uri string) (*PrivilegeRegistry, erro
 // ListReferencedPrivilegeRegistrys gets the collection of PrivilegeRegistry from
 // a provided reference.
 func ListReferencedPrivilegeRegistrys(c common.Client, link string) ([]*PrivilegeRegistry, error) {
-	var result []*PrivilegeRegistry
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *PrivilegeRegistry
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		privilegeregistry, err := GetPrivilegeRegistry(c, link)
-		ch <- GetResult{Item: privilegeregistry, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetPrivilegeRegistry)
 }
 
 // TargetPrivilegeMap shall describe a mapping between one or more targets and the HTTP operations associated with

--- a/redfish/processor.go
+++ b/redfish/processor.go
@@ -1025,45 +1025,7 @@ func GetProcessor(c common.Client, uri string) (*Processor, error) {
 
 // ListReferencedProcessors gets the collection of Processor from a provided reference.
 func ListReferencedProcessors(c common.Client, link string) ([]*Processor, error) {
-	var result []*Processor
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Processor
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		processor, err := GetProcessor(c, link)
-		ch <- GetResult{Item: processor, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetProcessor)
 }
 
 // ProcessorID shall contain identification information for a processor.

--- a/redfish/processormetrics.go
+++ b/redfish/processormetrics.go
@@ -245,43 +245,5 @@ func GetProcessorMetrics(c common.Client, uri string) (*ProcessorMetrics, error)
 // ListReferencedProcessorMetricss gets the collection of ProcessorMetrics from
 // a provided reference.
 func ListReferencedProcessorMetricss(c common.Client, link string) ([]*ProcessorMetrics, error) {
-	var result []*ProcessorMetrics
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *ProcessorMetrics
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		processormetrics, err := GetProcessorMetrics(c, link)
-		ch <- GetResult{Item: processormetrics, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetProcessorMetrics)
 }

--- a/redfish/pump.go
+++ b/redfish/pump.go
@@ -181,43 +181,5 @@ func GetPump(c common.Client, uri string) (*Pump, error) {
 // ListReferencedPumps gets the collection of Pump from
 // a provided reference.
 func ListReferencedPumps(c common.Client, link string) ([]*Pump, error) {
-	var result []*Pump
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Pump
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		pump, err := GetPump(c, link)
-		ch <- GetResult{Item: pump, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetPump)
 }

--- a/redfish/redundancy.go
+++ b/redfish/redundancy.go
@@ -122,45 +122,7 @@ func GetRedundancy(c common.Client, uri string) (*Redundancy, error) {
 // ListReferencedRedundancies gets the collection of Redundancy from
 // a provided reference.
 func ListReferencedRedundancies(c common.Client, link string) ([]*Redundancy, error) {
-	var result []*Redundancy
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Redundancy
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		redundancy, err := GetRedundancy(c, link)
-		ch <- GetResult{Item: redundancy, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetRedundancy)
 }
 
 // The redundancy mode of the group.

--- a/redfish/registeredclient.go
+++ b/redfish/registeredclient.go
@@ -146,43 +146,5 @@ func GetRegisteredClient(c common.Client, uri string) (*RegisteredClient, error)
 // ListReferencedRegisteredClients gets the collection of RegisteredClient from
 // a provided reference.
 func ListReferencedRegisteredClients(c common.Client, link string) ([]*RegisteredClient, error) {
-	var result []*RegisteredClient
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *RegisteredClient
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		registeredclient, err := GetRegisteredClient(c, link)
-		ch <- GetResult{Item: registeredclient, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetRegisteredClient)
 }

--- a/redfish/reservoir.go
+++ b/redfish/reservoir.go
@@ -183,43 +183,5 @@ func GetReservoir(c common.Client, uri string) (*Reservoir, error) {
 // ListReferencedReservoirs gets the collection of Reservoir from
 // a provided reference.
 func ListReferencedReservoirs(c common.Client, link string) ([]*Reservoir, error) {
-	var result []*Reservoir
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Reservoir
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		reservoir, err := GetReservoir(c, link)
-		ch <- GetResult{Item: reservoir, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetReservoir)
 }

--- a/redfish/resource.go
+++ b/redfish/resource.go
@@ -477,45 +477,7 @@ func GetResource(c common.Client, uri string) (*Resource, error) {
 // ListReferencedResources gets the collection of Resource from
 // a provided reference.
 func ListReferencedResources(c common.Client, link string) ([]*Resource, error) {
-	var result []*Resource
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Resource
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		resource, err := GetResource(c, link)
-		ch <- GetResult{Item: resource, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetResource)
 }
 
 // ResourceCollection

--- a/redfish/resourceblock.go
+++ b/redfish/resourceblock.go
@@ -304,45 +304,7 @@ func GetResourceBlock(c common.Client, uri string) (*ResourceBlock, error) {
 // ListReferencedResourceBlocks gets the collection of ResourceBlock from
 // a provided reference.
 func ListReferencedResourceBlocks(c common.Client, link string) ([]*ResourceBlock, error) {
-	var result []*ResourceBlock
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *ResourceBlock
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		resourceblock, err := GetResourceBlock(c, link)
-		ch <- GetResult{Item: resourceblock, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetResourceBlock)
 }
 
 // ResourceBlockLimits shall specify the allowable quantities of types of resource blocks for a given composition

--- a/redfish/role.go
+++ b/redfish/role.go
@@ -132,43 +132,5 @@ func GetRole(c common.Client, uri string) (*Role, error) {
 // ListReferencedRoles gets the collection of Role from
 // a provided reference.
 func ListReferencedRoles(c common.Client, link string) ([]*Role, error) {
-	var result []*Role
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Role
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		role, err := GetRole(c, link)
-		ch <- GetResult{Item: role, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetRole)
 }

--- a/redfish/routeentry.go
+++ b/redfish/routeentry.go
@@ -103,43 +103,5 @@ func GetRouteEntry(c common.Client, uri string) (*RouteEntry, error) {
 // ListReferencedRouteEntrys gets the collection of RouteEntry from
 // a provided reference.
 func ListReferencedRouteEntrys(c common.Client, link string) ([]*RouteEntry, error) {
-	var result []*RouteEntry
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *RouteEntry
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		routeentry, err := GetRouteEntry(c, link)
-		ch <- GetResult{Item: routeentry, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetRouteEntry)
 }

--- a/redfish/routesetentry.go
+++ b/redfish/routesetentry.go
@@ -100,43 +100,5 @@ func GetRouteSetEntry(c common.Client, uri string) (*RouteSetEntry, error) {
 // ListReferencedRouteSetEntrys gets the collection of RouteSetEntry from
 // a provided reference.
 func ListReferencedRouteSetEntrys(c common.Client, link string) ([]*RouteSetEntry, error) {
-	var result []*RouteSetEntry
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *RouteSetEntry
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		routesetentry, err := GetRouteSetEntry(c, link)
-		ch <- GetResult{Item: routesetentry, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetRouteSetEntry)
 }

--- a/redfish/schedule.go
+++ b/redfish/schedule.go
@@ -158,43 +158,5 @@ func GetSchedule(c common.Client, uri string) (*Schedule, error) {
 // ListReferencedSchedules gets the collection of Schedule from
 // a provided reference.
 func ListReferencedSchedules(c common.Client, link string) ([]*Schedule, error) {
-	var result []*Schedule
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Schedule
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		schedule, err := GetSchedule(c, link)
-		ch <- GetResult{Item: schedule, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetSchedule)
 }

--- a/redfish/secureboot.go
+++ b/redfish/secureboot.go
@@ -134,45 +134,7 @@ func GetSecureBoot(c common.Client, uri string) (*SecureBoot, error) {
 // ListReferencedSecureBoots gets the collection of SecureBoot from
 // a provided reference.
 func ListReferencedSecureBoots(c common.Client, link string) ([]*SecureBoot, error) {
-	var result []*SecureBoot
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *SecureBoot
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		secureboot, err := GetSecureBoot(c, link)
-		ch <- GetResult{Item: secureboot, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetSecureBoot)
 }
 
 // ResetKeys shall perform a reset of the Secure Boot key databases. The

--- a/redfish/securebootdatabase.go
+++ b/redfish/securebootdatabase.go
@@ -118,43 +118,5 @@ func GetSecureBootDatabase(c common.Client, uri string) (*SecureBootDatabase, er
 // ListReferencedSecureBootDatabases gets the collection of SecureBootDatabase from
 // a provided reference.
 func ListReferencedSecureBootDatabases(c common.Client, link string) ([]*SecureBootDatabase, error) {
-	var result []*SecureBootDatabase
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *SecureBootDatabase
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		securebootdatabase, err := GetSecureBootDatabase(c, link)
-		ch <- GetResult{Item: securebootdatabase, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetSecureBootDatabase)
 }

--- a/redfish/securitypolicy.go
+++ b/redfish/securitypolicy.go
@@ -200,45 +200,7 @@ func GetSecurityPolicy(c common.Client, uri string) (*SecurityPolicy, error) {
 // ListReferencedSecurityPolicys gets the collection of SecurityPolicy from
 // a provided reference.
 func ListReferencedSecurityPolicys(c common.Client, link string) ([]*SecurityPolicy, error) {
-	var result []*SecurityPolicy
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *SecurityPolicy
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		securitypolicy, err := GetSecurityPolicy(c, link)
-		ch <- GetResult{Item: securitypolicy, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetSecurityPolicy)
 }
 
 // TLSAlgorithmSet shall contain TLS algorithm settings.

--- a/redfish/sensor.go
+++ b/redfish/sensor.go
@@ -489,45 +489,7 @@ func GetSensor(c common.Client, uri string) (*Sensor, error) {
 
 // ListReferencedSensor gets the Sensor collection.
 func ListReferencedSensors(c common.Client, link string) ([]*Sensor, error) {
-	var result []*Sensor
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Sensor
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		sensor, err := GetSensor(c, link)
-		ch <- GetResult{Item: sensor, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetSensor)
 }
 
 func (sensor *Sensor) ResetMetrics() error {

--- a/redfish/serialinterface.go
+++ b/redfish/serialinterface.go
@@ -222,43 +222,5 @@ func GetSerialInterface(c common.Client, uri string) (*SerialInterface, error) {
 // ListReferencedSerialInterfaces gets the collection of SerialInterface from
 // a provided reference.
 func ListReferencedSerialInterfaces(c common.Client, link string) ([]*SerialInterface, error) {
-	var result []*SerialInterface
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *SerialInterface
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		serialInterface, err := GetSerialInterface(c, link)
-		ch <- GetResult{Item: serialInterface, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetSerialInterface)
 }

--- a/redfish/serviceconditions.go
+++ b/redfish/serviceconditions.go
@@ -54,43 +54,5 @@ func GetServiceConditions(c common.Client, uri string) (*ServiceConditions, erro
 // ListReferencedServiceConditionss gets the collection of ServiceConditions from
 // a provided reference.
 func ListReferencedServiceConditionss(c common.Client, link string) ([]*ServiceConditions, error) {
-	var result []*ServiceConditions
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *ServiceConditions
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		serviceconditions, err := GetServiceConditions(c, link)
-		ch <- GetResult{Item: serviceconditions, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetServiceConditions)
 }

--- a/redfish/session.go
+++ b/redfish/session.go
@@ -176,43 +176,5 @@ func GetSession(c common.Client, uri string) (*Session, error) {
 
 // ListReferencedSessions gets the collection of Sessions
 func ListReferencedSessions(c common.Client, link string) ([]*Session, error) {
-	var result []*Session
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Session
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		session, err := GetSession(c, link)
-		ch <- GetResult{Item: session, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetSession)
 }

--- a/redfish/sessionservice.go
+++ b/redfish/sessionservice.go
@@ -109,43 +109,5 @@ func GetSessionService(c common.Client, uri string) (*SessionService, error) {
 // ListReferencedSessionServices gets the collection of SessionService from
 // a provided reference.
 func ListReferencedSessionServices(c common.Client, link string) ([]*SessionService, error) {
-	var result []*SessionService
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *SessionService
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		sessionservice, err := GetSessionService(c, link)
-		ch <- GetResult{Item: sessionservice, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetSessionService)
 }

--- a/redfish/signature.go
+++ b/redfish/signature.go
@@ -67,43 +67,5 @@ func GetSignature(c common.Client, uri string) (*Signature, error) {
 // ListReferencedSignatures gets the collection of Signature from
 // a provided reference.
 func ListReferencedSignatures(c common.Client, link string) ([]*Signature, error) {
-	var result []*Signature
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Signature
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		signature, err := GetSignature(c, link)
-		ch <- GetResult{Item: signature, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetSignature)
 }

--- a/redfish/simplestorage.go
+++ b/redfish/simplestorage.go
@@ -91,45 +91,7 @@ func GetSimpleStorage(c common.Client, uri string) (*SimpleStorage, error) {
 // ListReferencedSimpleStorages gets the collection of SimpleStorage from
 // a provided reference.
 func ListReferencedSimpleStorages(c common.Client, link string) ([]*SimpleStorage, error) {
-	var result []*SimpleStorage
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *SimpleStorage
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		simplestorage, err := GetSimpleStorage(c, link)
-		ch <- GetResult{Item: simplestorage, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetSimpleStorage)
 }
 
 // Chassis gets the chassis containing this storage service.

--- a/redfish/softwareinventory.go
+++ b/redfish/softwareinventory.go
@@ -178,43 +178,5 @@ func GetSoftwareInventory(c common.Client, uri string) (*SoftwareInventory, erro
 // ListReferencedSoftwareInventories gets the collection of SoftwareInventory from
 // a provided reference.
 func ListReferencedSoftwareInventories(c common.Client, link string) ([]*SoftwareInventory, error) {
-	var result []*SoftwareInventory
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *SoftwareInventory
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		softwareinventory, err := GetSoftwareInventory(c, link)
-		ch <- GetResult{Item: softwareinventory, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetSoftwareInventory)
 }

--- a/redfish/storage.go
+++ b/redfish/storage.go
@@ -458,45 +458,7 @@ func GetStorage(c common.Client, uri string) (*Storage, error) {
 // ListReferencedStorages gets the collection of Storage from a provided
 // reference.
 func ListReferencedStorages(c common.Client, link string) ([]*Storage, error) {
-	var result []*Storage
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Storage
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		storage, err := GetStorage(c, link)
-		ch <- GetResult{Item: storage, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetStorage)
 }
 
 // GetOperationApplyTimeValues returns the OperationApplyTime values applicable for this storage

--- a/redfish/storagecontroller.go
+++ b/redfish/storagecontroller.go
@@ -537,43 +537,5 @@ func GetStorageController(c common.Client, uri string) (*StorageController, erro
 // ListReferencedStorageControllers gets the collection of StorageControllers
 // from a provided reference.
 func ListReferencedStorageControllers(c common.Client, link string) ([]*StorageController, error) {
-	var result []*StorageController
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *StorageController
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		storagecontroller, err := GetStorageController(c, link)
-		ch <- GetResult{Item: storagecontroller, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetStorageController)
 }

--- a/redfish/storagecontrollermetrics.go
+++ b/redfish/storagecontrollermetrics.go
@@ -162,43 +162,5 @@ func GetStorageControllerMetrics(c common.Client, uri string) (*StorageControlle
 // ListReferencedStorageControllerMetrics gets the collection of StorageControllerMetrics from
 // a provided reference.
 func ListReferencedStorageControllerMetrics(c common.Client, link string) ([]*StorageControllerMetrics, error) {
-	var result []*StorageControllerMetrics
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *StorageControllerMetrics
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		storagecontrollermetrics, err := GetStorageControllerMetrics(c, link)
-		ch <- GetResult{Item: storagecontrollermetrics, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetStorageControllerMetrics)
 }

--- a/redfish/switch.go
+++ b/redfish/switch.go
@@ -304,45 +304,7 @@ func GetSwitch(c common.Client, uri string) (*Switch, error) {
 // ListReferencedSwitches gets the collection of Switch from
 // a provided reference.
 func ListReferencedSwitches(c common.Client, link string) ([]*Switch, error) {
-	var result []*Switch
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Switch
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		sw, err := GetSwitch(c, link)
-		ch <- GetResult{Item: sw, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetSwitch)
 }
 
 // VCSSwitch shall contain Virtual CXL Switch (VCS) properties for a switch.

--- a/redfish/switchmetrics.go
+++ b/redfish/switchmetrics.go
@@ -111,43 +111,5 @@ func GetSwitchMetrics(c common.Client, uri string) (*SwitchMetrics, error) {
 // ListReferencedSwitchMetricss gets the collection of SwitchMetrics from
 // a provided reference.
 func ListReferencedSwitchMetricss(c common.Client, link string) ([]*SwitchMetrics, error) {
-	var result []*SwitchMetrics
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *SwitchMetrics
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		switchmetrics, err := GetSwitchMetrics(c, link)
-		ch <- GetResult{Item: switchmetrics, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetSwitchMetrics)
 }

--- a/redfish/task.go
+++ b/redfish/task.go
@@ -192,43 +192,5 @@ func GetTask(c common.Client, uri string) (*Task, error) {
 // ListReferencedTasks gets the collection of Task from
 // a provided reference.
 func ListReferencedTasks(c common.Client, link string) ([]*Task, error) {
-	var result []*Task
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Task
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		task, err := GetTask(c, link)
-		ch <- GetResult{Item: task, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetTask)
 }

--- a/redfish/telemetryservice.go
+++ b/redfish/telemetryservice.go
@@ -232,43 +232,5 @@ func GetTelemetryService(c common.Client, uri string) (*TelemetryService, error)
 // ListReferencedTelemetryServices gets the collection of TelemetryService from
 // a provided reference.
 func ListReferencedTelemetryServices(c common.Client, link string) ([]*TelemetryService, error) {
-	var result []*TelemetryService
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *TelemetryService
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		telemetryservice, err := GetTelemetryService(c, link)
-		ch <- GetResult{Item: telemetryservice, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetTelemetryService)
 }

--- a/redfish/thermal.go
+++ b/redfish/thermal.go
@@ -375,43 +375,5 @@ func GetThermal(c common.Client, uri string) (*Thermal, error) {
 
 // ListReferencedThermals gets the collection of Thermal from a provided reference.
 func ListReferencedThermals(c common.Client, link string) ([]*Thermal, error) {
-	var result []*Thermal
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Thermal
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		thermal, err := GetThermal(c, link)
-		ch <- GetResult{Item: thermal, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetThermal)
 }

--- a/redfish/thermalequipment.go
+++ b/redfish/thermalequipment.go
@@ -111,43 +111,5 @@ func GetThermalEquipment(c common.Client, uri string) (*ThermalEquipment, error)
 // ListReferencedThermalEquipments gets the collection of ThermalEquipment from
 // a provided reference.
 func ListReferencedThermalEquipments(c common.Client, link string) ([]*ThermalEquipment, error) {
-	var result []*ThermalEquipment
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *ThermalEquipment
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		thermalequipment, err := GetThermalEquipment(c, link)
-		ch <- GetResult{Item: thermalequipment, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetThermalEquipment)
 }

--- a/redfish/thermalmetrics.go
+++ b/redfish/thermalmetrics.go
@@ -137,43 +137,5 @@ func GetThermalMetrics(c common.Client, uri string) (*ThermalMetrics, error) {
 // ListReferencedThermalMetricss gets the collection of ThermalMetrics from
 // a provided reference.
 func ListReferencedThermalMetrics(c common.Client, link string) ([]*ThermalMetrics, error) {
-	var result []*ThermalMetrics
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *ThermalMetrics
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		thermalmetrics, err := GetThermalMetrics(c, link)
-		ch <- GetResult{Item: thermalmetrics, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetThermalMetrics)
 }

--- a/redfish/thermalsubsystem.go
+++ b/redfish/thermalsubsystem.go
@@ -132,43 +132,5 @@ func GetThermalSubsystem(c common.Client, uri string) (*ThermalSubsystem, error)
 // ListReferencedThermalSubsystems gets the collection of ThermalSubsystem from
 // a provided reference.
 func ListReferencedThermalSubsystems(c common.Client, link string) ([]*ThermalSubsystem, error) {
-	var result []*ThermalSubsystem
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *ThermalSubsystem
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		thermalsubsystem, err := GetThermalSubsystem(c, link)
-		ch <- GetResult{Item: thermalsubsystem, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetThermalSubsystem)
 }

--- a/redfish/triggers.go
+++ b/redfish/triggers.go
@@ -284,43 +284,5 @@ func GetTriggers(c common.Client, uri string) (*Triggers, error) {
 // ListReferencedTriggerss gets the collection of Triggers from
 // a provided reference.
 func ListReferencedTriggerss(c common.Client, link string) ([]*Triggers, error) {
-	var result []*Triggers
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Triggers
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		triggers, err := GetTriggers(c, link)
-		ch <- GetResult{Item: triggers, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetTriggers)
 }

--- a/redfish/trustedcomponent.go
+++ b/redfish/trustedcomponent.go
@@ -261,43 +261,5 @@ func GetTrustedComponent(c common.Client, uri string) (*TrustedComponent, error)
 // ListReferencedTrustedComponents gets the collection of TrustedComponent from
 // a provided reference.
 func ListReferencedTrustedComponents(c common.Client, link string) ([]*TrustedComponent, error) {
-	var result []*TrustedComponent
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *TrustedComponent
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		trustedcomponent, err := GetTrustedComponent(c, link)
-		ch <- GetResult{Item: trustedcomponent, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetTrustedComponent)
 }

--- a/redfish/usbcontroller.go
+++ b/redfish/usbcontroller.go
@@ -132,43 +132,5 @@ func GetUSBController(c common.Client, uri string) (*USBController, error) {
 // ListReferencedUSBControllers gets the collection of USBController from
 // a provided reference.
 func ListReferencedUSBControllers(c common.Client, link string) ([]*USBController, error) {
-	var result []*USBController
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *USBController
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		usbcontroller, err := GetUSBController(c, link)
-		ch <- GetResult{Item: usbcontroller, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetUSBController)
 }

--- a/redfish/vcatentry.go
+++ b/redfish/vcatentry.go
@@ -92,48 +92,10 @@ func GetVCATEntry(c common.Client, uri string) (*VCATEntry, error) {
 	return &vcatentry, nil
 }
 
-// ListReferencedVCATEntrys gets the collection of VCATEntry from
+// ListReferencedVCATEntries gets the collection of VCATEntry from
 // a provided reference.
-func ListReferencedVCATEntrys(c common.Client, link string) ([]*VCATEntry, error) {
-	var result []*VCATEntry
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *VCATEntry
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		vcatentry, err := GetVCATEntry(c, link)
-		ch <- GetResult{Item: vcatentry, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+func ListReferencedVCATEntries(c common.Client, link string) ([]*VCATEntry, error) {
+	return common.GetCollectionObjects(c, link, GetVCATEntry)
 }
 
 // VCATableEntry shall contain a Virtual Channel entry definition that describes a specific Virtual Channel.

--- a/redfish/virtualmedia.go
+++ b/redfish/virtualmedia.go
@@ -349,43 +349,5 @@ func GetVirtualMedia(c common.Client, uri string) (*VirtualMedia, error) {
 // ListReferencedVirtualMedias gets the collection of VirtualMedia from
 // a provided reference.
 func ListReferencedVirtualMedias(c common.Client, link string) ([]*VirtualMedia, error) {
-	var result []*VirtualMedia
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *VirtualMedia
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		virtualmedia, err := GetVirtualMedia(c, link)
-		ch <- GetResult{Item: virtualmedia, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetVirtualMedia)
 }

--- a/redfish/vlannetworkinterface.go
+++ b/redfish/vlannetworkinterface.go
@@ -96,43 +96,5 @@ func GetVLanNetworkInterface(c common.Client, uri string) (*VLanNetworkInterface
 // ListReferencedVLanNetworkInterfaces gets the collection of VLanNetworkInterface from
 // a provided reference.
 func ListReferencedVLanNetworkInterfaces(c common.Client, link string) ([]*VLanNetworkInterface, error) {
-	var result []*VLanNetworkInterface
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *VLanNetworkInterface
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		vlannetworkinterface, err := GetVLanNetworkInterface(c, link)
-		ch <- GetResult{Item: vlannetworkinterface, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetVLanNetworkInterface)
 }

--- a/redfish/volume.go
+++ b/redfish/volume.go
@@ -1059,45 +1059,7 @@ func GetVolume(c common.Client, uri string) (*Volume, error) {
 
 // ListReferencedVolumes gets the collection of Volumes from a provided reference.
 func ListReferencedVolumes(c common.Client, link string) ([]*Volume, error) {
-	var result []*Volume
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Volume
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		volume, err := GetVolume(c, link)
-		ch <- GetResult{Item: volume, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetVolume)
 }
 
 // AllowedVolumesUpdateApplyTimes returns the set of allowed apply times to request when setting the volumes values

--- a/redfish/zone.go
+++ b/redfish/zone.go
@@ -389,43 +389,5 @@ func GetZone(c common.Client, uri string) (*Zone, error) {
 // ListReferencedZones gets the collection of Zone from
 // a provided reference.
 func ListReferencedZones(c common.Client, link string) ([]*Zone, error) {
-	var result []*Zone
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Zone
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		zone, err := GetZone(c, link)
-		ch <- GetResult{Item: zone, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetZone)
 }

--- a/swordfish/capacity.go
+++ b/swordfish/capacity.go
@@ -125,45 +125,7 @@ func GetCapacitySource(c common.Client, uri string) (*CapacitySource, error) {
 // ListReferencedCapacitySources gets the collection of CapacitySources from
 // a provided reference.
 func ListReferencedCapacitySources(c common.Client, link string) ([]*CapacitySource, error) {
-	var result []*CapacitySource
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *CapacitySource
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		capacitysource, err := GetCapacitySource(c, link)
-		ch <- GetResult{Item: capacitysource, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetCapacitySource)
 }
 
 // ProvidedClassOfService gets the ClassOfService from the ProvidingDrives,

--- a/swordfish/classofservice.go
+++ b/swordfish/classofservice.go
@@ -94,45 +94,7 @@ func GetClassOfService(c common.Client, uri string) (*ClassOfService, error) {
 // ListReferencedClassOfServices gets the collection of ClassOfService from
 // a provided reference.
 func ListReferencedClassOfServices(c common.Client, link string) ([]*ClassOfService, error) {
-	var result []*ClassOfService
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *ClassOfService
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		classofservice, err := GetClassOfService(c, link)
-		ch <- GetResult{Item: classofservice, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetClassOfService)
 }
 
 // DataProtectionLinesOfServices gets the DataProtectionLinesOfService that are

--- a/swordfish/consistencygroup.go
+++ b/swordfish/consistencygroup.go
@@ -323,43 +323,5 @@ func GetConsistencyGroup(c common.Client, uri string) (*ConsistencyGroup, error)
 // ListReferencedConsistencyGroups gets the collection of ConsistencyGroup from
 // a provided reference.
 func ListReferencedConsistencyGroups(c common.Client, link string) ([]*ConsistencyGroup, error) {
-	var result []*ConsistencyGroup
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *ConsistencyGroup
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		consistencygroup, err := GetConsistencyGroup(c, link)
-		ch <- GetResult{Item: consistencygroup, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetConsistencyGroup)
 }

--- a/swordfish/dataprotectionlineofservice.go
+++ b/swordfish/dataprotectionlineofservice.go
@@ -66,45 +66,7 @@ func GetDataProtectionLineOfService(c common.Client, uri string) (*DataProtectio
 // ListReferencedDataProtectionLineOfServices gets the collection of DataProtectionLineOfService from
 // a provided reference.
 func ListReferencedDataProtectionLineOfServices(c common.Client, link string) ([]*DataProtectionLineOfService, error) {
-	var result []*DataProtectionLineOfService
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *DataProtectionLineOfService
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		dataprotectionlineofservice, err := GetDataProtectionLineOfService(c, link)
-		ch <- GetResult{Item: dataprotectionlineofservice, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetDataProtectionLineOfService)
 }
 
 // ReplicaRequest is a request for a replica.

--- a/swordfish/dataprotectionloscapabilities.go
+++ b/swordfish/dataprotectionloscapabilities.go
@@ -184,45 +184,7 @@ func GetDataProtectionLoSCapabilities(c common.Client, uri string) (*DataProtect
 // ListReferencedDataProtectionLoSCapabilities gets the collection of DataProtectionLoSCapabilities from
 // a provided reference.
 func ListReferencedDataProtectionLoSCapabilities(c common.Client, link string) ([]*DataProtectionLoSCapabilities, error) {
-	var result []*DataProtectionLoSCapabilities
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *DataProtectionLoSCapabilities
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		dataprotectionloscapabilities, err := GetDataProtectionLoSCapabilities(c, link)
-		ch <- GetResult{Item: dataprotectionloscapabilities, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetDataProtectionLoSCapabilities)
 }
 
 // SupportedReplicaOptions gets the support replica ClassesOfService.

--- a/swordfish/datasecuritylineofservice.go
+++ b/swordfish/datasecuritylineofservice.go
@@ -52,43 +52,5 @@ func GetDataSecurityLineOfService(c common.Client, uri string) (*DataSecurityLin
 // ListReferencedDataSecurityLineOfServices gets the collection of DataSecurityLineOfService from
 // a provided reference.
 func ListReferencedDataSecurityLineOfServices(c common.Client, link string) ([]*DataSecurityLineOfService, error) {
-	var result []*DataSecurityLineOfService
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *DataSecurityLineOfService
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		datasecuritylineofservice, err := GetDataSecurityLineOfService(c, link)
-		ch <- GetResult{Item: datasecuritylineofservice, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetDataSecurityLineOfService)
 }

--- a/swordfish/datasecurityloscapabilities.go
+++ b/swordfish/datasecurityloscapabilities.go
@@ -206,43 +206,5 @@ func GetDataSecurityLoSCapabilities(c common.Client, uri string) (*DataSecurityL
 // ListReferencedDataSecurityLoSCapabilities gets the collection of DataSecurityLoSCapabilities from
 // a provided reference.
 func ListReferencedDataSecurityLoSCapabilities(c common.Client, link string) ([]*DataSecurityLoSCapabilities, error) {
-	var result []*DataSecurityLoSCapabilities
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *DataSecurityLoSCapabilities
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		datasecurityloscapabilities, err := GetDataSecurityLoSCapabilities(c, link)
-		ch <- GetResult{Item: datasecurityloscapabilities, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetDataSecurityLoSCapabilities)
 }

--- a/swordfish/datastoragelineofservice.go
+++ b/swordfish/datastoragelineofservice.go
@@ -101,43 +101,5 @@ func GetDataStorageLineOfService(c common.Client, uri string) (*DataStorageLineO
 // ListReferencedDataStorageLineOfServices gets the collection of DataStorageLineOfService from
 // a provided reference.
 func ListReferencedDataStorageLineOfServices(c common.Client, link string) ([]*DataStorageLineOfService, error) {
-	var result []*DataStorageLineOfService
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *DataStorageLineOfService
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		datastoragelineofservice, err := GetDataStorageLineOfService(c, link)
-		ch <- GetResult{Item: datastoragelineofservice, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetDataStorageLineOfService)
 }

--- a/swordfish/datastorageloscapabilities.go
+++ b/swordfish/datastorageloscapabilities.go
@@ -137,43 +137,5 @@ func GetDataStorageLoSCapabilities(c common.Client, uri string) (*DataStorageLoS
 // ListReferencedDataStorageLoSCapabilities gets the collection of DataStorageLoSCapabilities from
 // a provided reference.
 func ListReferencedDataStorageLoSCapabilities(c common.Client, link string) ([]*DataStorageLoSCapabilities, error) {
-	var result []*DataStorageLoSCapabilities
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *DataStorageLoSCapabilities
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		datastorageloscapabilities, err := GetDataStorageLoSCapabilities(c, link)
-		ch <- GetResult{Item: datastorageloscapabilities, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetDataStorageLoSCapabilities)
 }

--- a/swordfish/endpointgroup.go
+++ b/swordfish/endpointgroup.go
@@ -137,45 +137,7 @@ func GetEndpointGroup(c common.Client, uri string) (*EndpointGroup, error) {
 // ListReferencedEndpointGroups gets the collection of EndpointGroup from
 // a provided reference.
 func ListReferencedEndpointGroups(c common.Client, link string) ([]*EndpointGroup, error) {
-	var result []*EndpointGroup
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *EndpointGroup
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		endpointgroup, err := GetEndpointGroup(c, link)
-		ch <- GetResult{Item: endpointgroup, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetEndpointGroup)
 }
 
 // Endpoints gets the group's endpoints.

--- a/swordfish/featuresregistry.go
+++ b/swordfish/featuresregistry.go
@@ -60,45 +60,7 @@ func GetFeaturesRegistry(c common.Client, uri string) (*FeaturesRegistry, error)
 // ListReferencedFeaturesRegistrys gets the collection of FeaturesRegistry from
 // a provided reference.
 func ListReferencedFeaturesRegistrys(c common.Client, link string) ([]*FeaturesRegistry, error) {
-	var result []*FeaturesRegistry
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *FeaturesRegistry
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		featuresregistry, err := GetFeaturesRegistry(c, link)
-		ch <- GetResult{Item: featuresregistry, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetFeaturesRegistry)
 }
 
 // FeaturesRegistryProperty shall represent the suffix to be used in the Feature and shall be unique within this

--- a/swordfish/fileshare.go
+++ b/swordfish/fileshare.go
@@ -170,45 +170,7 @@ func GetFileShare(c common.Client, uri string) (*FileShare, error) {
 // ListReferencedFileShares gets the collection of FileShare from a provided
 // reference.
 func ListReferencedFileShares(c common.Client, link string) ([]*FileShare, error) {
-	var result []*FileShare
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *FileShare
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		fileshare, err := GetFileShare(c, link)
-		ch <- GetResult{Item: fileshare, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetFileShare)
 }
 
 // ClassOfService gets the file share's class of service.

--- a/swordfish/filesystem.go
+++ b/swordfish/filesystem.go
@@ -278,45 +278,7 @@ func GetFileSystem(c common.Client, uri string) (*FileSystem, error) {
 // ListReferencedFileSystems gets the collection of FileSystem from
 // a provided reference.
 func ListReferencedFileSystems(c common.Client, link string) ([]*FileSystem, error) {
-	var result []*FileSystem
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *FileSystem
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		filesystem, err := GetFileSystem(c, link)
-		ch <- GetResult{Item: filesystem, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetFileSystem)
 }
 
 // ExportedShares gets the exported file shares for this file system.

--- a/swordfish/filesystemmetrics.go
+++ b/swordfish/filesystemmetrics.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-//nolint:dupl
 package swordfish
 
 import (
@@ -50,43 +49,5 @@ func GetFileSystemMetrics(c common.Client, uri string) (*FileSystemMetrics, erro
 // ListReferencedFileSystemMetricss gets the collection of FileSystemMetrics from
 // a provided reference.
 func ListReferencedFileSystemMetricss(c common.Client, link string) ([]*FileSystemMetrics, error) {
-	var result []*FileSystemMetrics
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *FileSystemMetrics
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		filesystemmetrics, err := GetFileSystemMetrics(c, link)
-		ch <- GetResult{Item: filesystemmetrics, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetFileSystemMetrics)
 }

--- a/swordfish/ioconnectivitylineofservice.go
+++ b/swordfish/ioconnectivitylineofservice.go
@@ -91,43 +91,5 @@ func GetIOConnectivityLineOfService(c common.Client, uri string) (*IOConnectivit
 // ListReferencedIOConnectivityLineOfServices gets the collection of IOConnectivityLineOfService from
 // a provided reference.
 func ListReferencedIOConnectivityLineOfServices(c common.Client, link string) ([]*IOConnectivityLineOfService, error) {
-	var result []*IOConnectivityLineOfService
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *IOConnectivityLineOfService
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		ioconnectivitylineofservice, err := GetIOConnectivityLineOfService(c, link)
-		ch <- GetResult{Item: ioconnectivitylineofservice, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetIOConnectivityLineOfService)
 }

--- a/swordfish/ioconnectivityloscapabilities.go
+++ b/swordfish/ioconnectivityloscapabilities.go
@@ -100,43 +100,5 @@ func GetIOConnectivityLoSCapabilities(c common.Client, uri string) (*IOConnectiv
 // ListReferencedIOConnectivityLoSCapabilitiess gets the collection of
 // IOConnectivityLoSCapabilities from a provided reference.
 func ListReferencedIOConnectivityLoSCapabilitiess(c common.Client, link string) ([]*IOConnectivityLoSCapabilities, error) {
-	var result []*IOConnectivityLoSCapabilities
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *IOConnectivityLoSCapabilities
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		ioconnectivityloscapabilities, err := GetIOConnectivityLoSCapabilities(c, link)
-		ch <- GetResult{Item: ioconnectivityloscapabilities, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetIOConnectivityLoSCapabilities)
 }

--- a/swordfish/ioperformancelineofservice.go
+++ b/swordfish/ioperformancelineofservice.go
@@ -103,43 +103,5 @@ func GetIOPerformanceLineOfService(c common.Client, uri string) (*IOPerformanceL
 // ListReferencedIOPerformanceLineOfServices gets the collection of IOPerformanceLineOfService from
 // a provided reference.
 func ListReferencedIOPerformanceLineOfServices(c common.Client, link string) ([]*IOPerformanceLineOfService, error) {
-	var result []*IOPerformanceLineOfService
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *IOPerformanceLineOfService
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		ioperformancelineofservice, err := GetIOPerformanceLineOfService(c, link)
-		ch <- GetResult{Item: ioperformancelineofservice, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetIOPerformanceLineOfService)
 }

--- a/swordfish/ioperformanceloscapabilities.go
+++ b/swordfish/ioperformanceloscapabilities.go
@@ -128,45 +128,7 @@ func GetIOPerformanceLoSCapabilities(c common.Client, uri string) (*IOPerformanc
 // ListReferencedIOPerformanceLoSCapabilitiess gets the collection of IOPerformanceLoSCapabilities from
 // a provided reference.
 func ListReferencedIOPerformanceLoSCapabilitiess(c common.Client, link string) ([]*IOPerformanceLoSCapabilities, error) {
-	var result []*IOPerformanceLoSCapabilities
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *IOPerformanceLoSCapabilities
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		ioperformanceloscapabilities, err := GetIOPerformanceLoSCapabilities(c, link)
-		ch <- GetResult{Item: ioperformanceloscapabilities, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetIOPerformanceLoSCapabilities)
 }
 
 // IOWorkload is used to describe an IO Workload.

--- a/swordfish/lineofservice.go
+++ b/swordfish/lineofservice.go
@@ -48,43 +48,5 @@ func GetLineOfService(c common.Client, uri string) (*LineOfService, error) {
 // ListReferencedLineOfServices gets the collection of LineOfService from
 // a provided reference.
 func ListReferencedLineOfServices(c common.Client, link string) ([]*LineOfService, error) {
-	var result []*LineOfService
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *LineOfService
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		lineofservice, err := GetLineOfService(c, link)
-		ch <- GetResult{Item: lineofservice, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetLineOfService)
 }

--- a/swordfish/nvmedomain.go
+++ b/swordfish/nvmedomain.go
@@ -188,43 +188,5 @@ func GetNVMeDomain(c common.Client, uri string) (*NVMeDomain, error) {
 // ListReferencedNVMeDomains gets the collection of NVMeDomain from
 // a provided reference.
 func ListReferencedNVMeDomains(c common.Client, link string) ([]*NVMeDomain, error) {
-	var result []*NVMeDomain
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *NVMeDomain
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		nvmedomain, err := GetNVMeDomain(c, link)
-		ch <- GetResult{Item: nvmedomain, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetNVMeDomain)
 }

--- a/swordfish/nvmefirmwareimage.go
+++ b/swordfish/nvmefirmwareimage.go
@@ -68,43 +68,5 @@ func GetNVMeFirmwareImage(c common.Client, uri string) (*NVMeFirmwareImage, erro
 // ListReferencedNVMeFirmwareImages gets the collection of NVMeFirmwareImage from
 // a provided reference.
 func ListReferencedNVMeFirmwareImages(c common.Client, link string) ([]*NVMeFirmwareImage, error) {
-	var result []*NVMeFirmwareImage
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *NVMeFirmwareImage
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		nvmefirmwareimage, err := GetNVMeFirmwareImage(c, link)
-		ch <- GetResult{Item: nvmefirmwareimage, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetNVMeFirmwareImage)
 }

--- a/swordfish/spareresourceset.go
+++ b/swordfish/spareresourceset.go
@@ -115,45 +115,7 @@ func GetSpareResourceSet(c common.Client, uri string) (*SpareResourceSet, error)
 // ListReferencedSpareResourceSets gets the collection of SpareResourceSet from
 // a provided reference.
 func ListReferencedSpareResourceSets(c common.Client, link string) ([]*SpareResourceSet, error) {
-	var result []*SpareResourceSet
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *SpareResourceSet
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		spareresourceset, err := GetSpareResourceSet(c, link)
-		ch <- GetResult{Item: spareresourceset, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetSpareResourceSet)
 }
 
 // ReplacementSpareSets gets other spare sets that can be utilized to replenish

--- a/swordfish/storagegroup.go
+++ b/swordfish/storagegroup.go
@@ -226,45 +226,7 @@ func GetStorageGroup(c common.Client, uri string) (*StorageGroup, error) {
 // ListReferencedStorageGroups gets the collection of StorageGroup from
 // a provided reference.
 func ListReferencedStorageGroups(c common.Client, link string) ([]*StorageGroup, error) {
-	var result []*StorageGroup
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *StorageGroup
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		storagegroup, err := GetStorageGroup(c, link)
-		ch <- GetResult{Item: storagegroup, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetStorageGroup)
 }
 
 // ChildStorageGroups gets child groups of this group.

--- a/swordfish/storagepool.go
+++ b/swordfish/storagepool.go
@@ -350,45 +350,7 @@ func GetStoragePool(c common.Client, uri string) (*StoragePool, error) {
 // ListReferencedStoragePools gets the collection of StoragePool from
 // a provided reference.
 func ListReferencedStoragePools(c common.Client, link string) ([]*StoragePool, error) {
-	var result []*StoragePool
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *StoragePool
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		storagepool, err := GetStoragePool(c, link)
-		ch <- GetResult{Item: storagepool, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetStoragePool)
 }
 
 // DedicatedSpareDrives gets the Drive entities which are currently assigned as

--- a/swordfish/storagepoolmetrics.go
+++ b/swordfish/storagepoolmetrics.go
@@ -68,43 +68,5 @@ func GetStoragePoolMetrics(c common.Client, uri string) (*StoragePoolMetrics, er
 // ListReferencedStoragePoolMetricss gets the collection of StoragePoolMetrics from
 // a provided reference.
 func ListReferencedStoragePoolMetricss(c common.Client, link string) ([]*StoragePoolMetrics, error) {
-	var result []*StoragePoolMetrics
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *StoragePoolMetrics
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		storagepoolmetrics, err := GetStoragePoolMetrics(c, link)
-		ch <- GetResult{Item: storagepoolmetrics, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetStoragePoolMetrics)
 }

--- a/swordfish/storagereplicainfo.go
+++ b/swordfish/storagereplicainfo.go
@@ -471,43 +471,5 @@ func GetStorageReplicaInfo(c common.Client, uri string) (*StorageReplicaInfo, er
 // ListReferencedStorageReplicaInfos gets the collection of StorageReplicaInfo from
 // a provided reference.
 func ListReferencedStorageReplicaInfos(c common.Client, link string) ([]*StorageReplicaInfo, error) {
-	var result []*StorageReplicaInfo
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *StorageReplicaInfo
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		storagereplicainfo, err := GetStorageReplicaInfo(c, link)
-		ch <- GetResult{Item: storagereplicainfo, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetStorageReplicaInfo)
 }

--- a/swordfish/storageservice.go
+++ b/swordfish/storageservice.go
@@ -220,45 +220,7 @@ func GetStorageService(c common.Client, uri string) (*StorageService, error) {
 // ListReferencedStorageServices gets the collection of StorageService from
 // a provided reference.
 func ListReferencedStorageServices(c common.Client, link string) ([]*StorageService, error) {
-	var result []*StorageService
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *StorageService
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		storageservice, err := GetStorageService(c, link)
-		ch <- GetResult{Item: storageservice, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetStorageService)
 }
 
 // ClassesOfService gets the storage service's classes of service.

--- a/swordfish/storageservicemetrics.go
+++ b/swordfish/storageservicemetrics.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-//nolint:dupl
 package swordfish
 
 import (
@@ -51,43 +50,5 @@ func GetStorageServiceMetrics(c common.Client, uri string) (*StorageServiceMetri
 // ListReferencedStorageServiceMetricss gets the collection of StorageServiceMetrics from
 // a provided reference.
 func ListReferencedStorageServiceMetricss(c common.Client, link string) ([]*StorageServiceMetrics, error) {
-	var result []*StorageServiceMetrics
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *StorageServiceMetrics
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		storageservicemetrics, err := GetStorageServiceMetrics(c, link)
-		ch <- GetResult{Item: storageservicemetrics, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetStorageServiceMetrics)
 }

--- a/swordfish/storagesystem.go
+++ b/swordfish/storagesystem.go
@@ -22,43 +22,5 @@ func GetStorageSystem(c common.Client, uri string) (*StorageSystem, error) {
 
 // ListReferencedStorageSystems gets the collection of StorageSystems.
 func ListReferencedStorageSystems(c common.Client, link string) ([]*StorageSystem, error) {
-	var result []*StorageSystem
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *StorageSystem
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		storagesystem, err := GetStorageSystem(c, link)
-		ch <- GetResult{Item: storagesystem, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetStorageSystem)
 }

--- a/swordfish/volume.go
+++ b/swordfish/volume.go
@@ -801,45 +801,7 @@ func GetVolume(c common.Client, uri string) (*Volume, error) {
 
 // ListReferencedVolumes gets the collection of Volume from a provided reference.
 func ListReferencedVolumes(c common.Client, link string) ([]*Volume, error) {
-	var result []*Volume
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *Volume
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		volume, err := GetVolume(c, link)
-		ch <- GetResult{Item: volume, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetVolume)
 }
 
 // CacheDataVolumes gets the data volumes this volume serves as a cache volume.

--- a/swordfish/volumemetrics.go
+++ b/swordfish/volumemetrics.go
@@ -69,43 +69,5 @@ func GetVolumeMetrics(c common.Client, uri string) (*VolumeMetrics, error) {
 // ListReferencedVolumeMetricss gets the collection of VolumeMetrics from
 // a provided reference.
 func ListReferencedVolumeMetricss(c common.Client, link string) ([]*VolumeMetrics, error) {
-	var result []*VolumeMetrics
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *VolumeMetrics
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		volumemetrics, err := GetVolumeMetrics(c, link)
-		ch <- GetResult{Item: volumemetrics, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, GetVolumeMetrics)
 }

--- a/tools/source.tmpl
+++ b/tools/source.tmpl
@@ -107,45 +107,7 @@ func Get{{ class.name }}(c common.Client, uri string) (*{{ class.name }}, error)
 // ListReferenced{{ class.name }}s gets the collection of {{ class.name }} from
 // a provided reference.
 func ListReferenced{{ class.name }}s(c common.Client, link string) ([]*{{ class.name }}, error) {
-    var result []*{{ class.name }}
-	if link == "" {
-		return result, nil
-	}
-
-	type GetResult struct {
-		Item  *{{ class.name }}
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
-	collectionError := common.NewCollectionError()
-	get := func(link string) {
-		{{ class.name|lower }}, err := Get{{ class.name }}(c, link)
-		ch <- GetResult{Item: {{ class.name|lower }}, Link: link, Error: err}
-	}
-
-	go func() {
-		err := common.CollectList(get, c, link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		}
-		close(ch)
-	}()
-
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects(c, link, Get{{ class.name }})
 }
 
 {% endif %}


### PR DESCRIPTION
This moves the minimum supported Go version to 1.18 to allow the use of gneerics in the code.

This adds a common function for getting all objects in a collection referenced by a link. This is used by most objects to retrieve a set of all objects of the given type. With the ability to use generics now, this eliminates a lot of repetitive code.