### PR TITLE
Add generic object retrieval

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.20.0'
+        go-version: '1.22.0'
 
     # Build the code
     - name: Run build
@@ -39,7 +39,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.20.0'
+        go-version: '1.22.0'
 
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v6

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GOLANGCI_VERSION := "v1.57"
 all: lint build test
 
 test:
-	go test -v $(PKGS)
+	go test -v $(PKGS) -cover -race
 
 build:
 	go build

--- a/oem/zt/eventservice_test.go
+++ b/oem/zt/eventservice_test.go
@@ -5,7 +5,6 @@
 package zt
 
 import (
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -174,7 +173,6 @@ func TestSubscribeZT(t *testing.T) {
 		if req.Method == http.MethodGet &&
 			req.URL.String() == redfishBaseURL &&
 			requestCounter < 2 { // ServiceRoot
-			log.Printf("Mock received login request")
 			contentType := req.Header.Get("Content-Type")
 			if contentType != "application/json" {
 				t.Errorf("gofish connect sent wrong header. Content-Type:"+
@@ -190,16 +188,12 @@ func TestSubscribeZT(t *testing.T) {
 		} else if req.Method == http.MethodGet && // Get event service
 			req.URL.String() == "/redfish/v1/EventService" &&
 			requestCounter == 2 {
-			log.Printf("Getting event service")
-
 			requestCounter++
 
 			rw.Write([]byte(eventServiceBody)) //nolint:errcheck
 		} else if req.Method == http.MethodPost && // Subscribe
 			req.URL.String() == "/redfish/v1/EventService/Subscriptions" &&
 			requestCounter == 3 {
-			log.Printf("Mock got suscription POST")
-
 			requestCounter++
 
 			rw.Write([]byte(subscribeResponseBody)) //nolint:errcheck

--- a/redfish/accelerationfunction.go
+++ b/redfish/accelerationfunction.go
@@ -103,26 +103,13 @@ func (accelerationfunction *AccelerationFunction) UnmarshalJSON(b []byte) error 
 
 // GetAccelerationFunction will get a AccelerationFunction instance from the service.
 func GetAccelerationFunction(c common.Client, uri string) (*AccelerationFunction, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var accelerationfunction AccelerationFunction
-	err = json.NewDecoder(resp.Body).Decode(&accelerationfunction)
-	if err != nil {
-		return nil, err
-	}
-
-	accelerationfunction.SetClient(c)
-	return &accelerationfunction, nil
+	return common.GetObject[AccelerationFunction](c, uri)
 }
 
 // ListReferencedAccelerationFunctions gets the collection of AccelerationFunction from
 // a provided reference.
 func ListReferencedAccelerationFunctions(c common.Client, link string) ([]*AccelerationFunction, error) {
-	return common.GetCollectionObjects(c, link, GetAccelerationFunction)
+	return common.GetCollectionObjects[AccelerationFunction](c, link)
 }
 
 // Endpoints gets the endpoints connected to this accelerator.

--- a/redfish/accountservice.go
+++ b/redfish/accountservice.go
@@ -476,8 +476,7 @@ func (accountservice *AccountService) Update() error {
 // GetAccountService will get the AccountService instance from the Redfish
 // service.
 func GetAccountService(c common.Client, uri string) (*AccountService, error) {
-	var accountService AccountService
-	return &accountService, accountService.Get(c, uri, &accountService)
+	return common.GetObject[AccountService](c, uri)
 }
 
 // Accounts get the accounts from the account service

--- a/redfish/addresspool.go
+++ b/redfish/addresspool.go
@@ -79,26 +79,13 @@ func (addresspool *AddressPool) UnmarshalJSON(b []byte) error {
 
 // GetAddressPool will get a AddressPool instance from the service.
 func GetAddressPool(c common.Client, uri string) (*AddressPool, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var addresspool AddressPool
-	err = json.NewDecoder(resp.Body).Decode(&addresspool)
-	if err != nil {
-		return nil, err
-	}
-
-	addresspool.SetClient(c)
-	return &addresspool, nil
+	return common.GetObject[AddressPool](c, uri)
 }
 
 // ListReferencedAddressPools gets the collection of AddressPool from
 // a provided reference.
 func ListReferencedAddressPools(c common.Client, link string) ([]*AddressPool, error) {
-	return common.GetCollectionObjects(c, link, GetAddressPool)
+	return common.GetCollectionObjects[AddressPool](c, link)
 }
 
 // Endpoints gets the endpoints connected to this address pool.

--- a/redfish/aggregate.go
+++ b/redfish/aggregate.go
@@ -134,24 +134,11 @@ func (aggregate *Aggregate) SetDefaultBootOrder() error {
 
 // GetAggregate will get a Aggregate instance from the service.
 func GetAggregate(c common.Client, uri string) (*Aggregate, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var aggregate Aggregate
-	err = json.NewDecoder(resp.Body).Decode(&aggregate)
-	if err != nil {
-		return nil, err
-	}
-
-	aggregate.SetClient(c)
-	return &aggregate, nil
+	return common.GetObject[Aggregate](c, uri)
 }
 
 // ListReferencedAggregates gets the collection of Aggregate from
 // a provided reference.
 func ListReferencedAggregates(c common.Client, link string) ([]*Aggregate, error) {
-	return common.GetCollectionObjects(c, link, GetAggregate)
+	return common.GetCollectionObjects[Aggregate](c, link)
 }

--- a/redfish/aggregationservice.go
+++ b/redfish/aggregationservice.go
@@ -144,24 +144,11 @@ func (aggregationservice *AggregationService) Update() error {
 
 // GetAggregationService will get a AggregationService instance from the service.
 func GetAggregationService(c common.Client, uri string) (*AggregationService, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var aggregationservice AggregationService
-	err = json.NewDecoder(resp.Body).Decode(&aggregationservice)
-	if err != nil {
-		return nil, err
-	}
-
-	aggregationservice.SetClient(c)
-	return &aggregationservice, nil
+	return common.GetObject[AggregationService](c, uri)
 }
 
 // ListReferencedAggregationServices gets the collection of AggregationService from
 // a provided reference.
 func ListReferencedAggregationServices(c common.Client, link string) ([]*AggregationService, error) {
-	return common.GetCollectionObjects(c, link, GetAggregationService)
+	return common.GetCollectionObjects[AggregationService](c, link)
 }

--- a/redfish/aggregationsource.go
+++ b/redfish/aggregationsource.go
@@ -190,26 +190,13 @@ func (aggregationsource *AggregationSource) Update() error {
 
 // GetAggregationSource will get a AggregationSource instance from the service.
 func GetAggregationSource(c common.Client, uri string) (*AggregationSource, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var aggregationsource AggregationSource
-	err = json.NewDecoder(resp.Body).Decode(&aggregationsource)
-	if err != nil {
-		return nil, err
-	}
-
-	aggregationsource.SetClient(c)
-	return &aggregationsource, nil
+	return common.GetObject[AggregationSource](c, uri)
 }
 
 // ListReferencedAggregationSources gets the collection of AggregationSource from
 // a provided reference.
 func ListReferencedAggregationSources(c common.Client, link string) ([]*AggregationSource, error) {
-	return common.GetCollectionObjects(c, link, GetAggregationSource)
+	return common.GetCollectionObjects[AggregationSource](c, link)
 }
 
 // SNMPSettings shall contain the settings for an SNMP aggregation source.

--- a/redfish/allowdeny.go
+++ b/redfish/allowdeny.go
@@ -127,24 +127,11 @@ func (allowdeny *AllowDeny) Update() error {
 
 // GetAllowDeny will get a AllowDeny instance from the service.
 func GetAllowDeny(c common.Client, uri string) (*AllowDeny, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var allowdeny AllowDeny
-	err = json.NewDecoder(resp.Body).Decode(&allowdeny)
-	if err != nil {
-		return nil, err
-	}
-
-	allowdeny.SetClient(c)
-	return &allowdeny, nil
+	return common.GetObject[AllowDeny](c, uri)
 }
 
 // ListReferencedAllowDenys gets the collection of AllowDeny from
 // a provided reference.
 func ListReferencedAllowDenys(c common.Client, link string) ([]*AllowDeny, error) {
-	return common.GetCollectionObjects(c, link, GetAllowDeny)
+	return common.GetCollectionObjects[AllowDeny](c, link)
 }

--- a/redfish/application.go
+++ b/redfish/application.go
@@ -75,26 +75,13 @@ func (application *Application) UnmarshalJSON(b []byte) error {
 
 // GetApplication will get a Application instance from the service.
 func GetApplication(c common.Client, uri string) (*Application, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var application Application
-	err = json.NewDecoder(resp.Body).Decode(&application)
-	if err != nil {
-		return nil, err
-	}
-
-	application.SetClient(c)
-	return &application, nil
+	return common.GetObject[Application](c, uri)
 }
 
 // ListReferencedApplications gets the collection of Application from
 // a provided reference.
 func ListReferencedApplications(c common.Client, link string) ([]*Application, error) {
-	return common.GetCollectionObjects(c, link, GetApplication)
+	return common.GetCollectionObjects[Application](c, link)
 }
 
 // SoftwareImage returns a `SoftwareInventory“ that represents the software image from which this application runs.

--- a/redfish/assembly.go
+++ b/redfish/assembly.go
@@ -73,14 +73,13 @@ func (assembly *Assembly) Update() error {
 
 // GetAssembly will get a Assembly instance from the service.
 func GetAssembly(c common.Client, uri string) (*Assembly, error) {
-	var assembly Assembly
-	return &assembly, assembly.Get(c, uri, &assembly)
+	return common.GetObject[Assembly](c, uri)
 }
 
 // ListReferencedAssemblys gets the collection of Assembly from
 // a provided reference.
 func ListReferencedAssemblys(c common.Client, link string) ([]*Assembly, error) {
-	return common.GetCollectionObjects(c, link, GetAssembly)
+	return common.GetCollectionObjects[Assembly](c, link)
 }
 
 // AssemblyData is information about an assembly.

--- a/redfish/attributeregistry.go
+++ b/redfish/attributeregistry.go
@@ -306,6 +306,5 @@ type AttributeRegistry struct {
 // GetAttributeRegistry will get an AttributeRegistry instance from the Redfish service,
 // e.g. BiosAttributeRegistry
 func GetAttributeRegistry(c common.Client, uri string) (*AttributeRegistry, error) {
-	var attributeRegistry AttributeRegistry
-	return &attributeRegistry, attributeRegistry.Get(c, uri, &attributeRegistry)
+	return common.GetObject[AttributeRegistry](c, uri)
 }

--- a/redfish/battery.go
+++ b/redfish/battery.go
@@ -188,26 +188,13 @@ func (battery *Battery) Update() error {
 
 // GetBattery will get a Battery instance from the service.
 func GetBattery(c common.Client, uri string) (*Battery, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var battery Battery
-	err = json.NewDecoder(resp.Body).Decode(&battery)
-	if err != nil {
-		return nil, err
-	}
-
-	battery.SetClient(c)
-	return &battery, nil
+	return common.GetObject[Battery](c, uri)
 }
 
 // ListReferencedBatterys gets the collection of Battery from
 // a provided reference.
 func ListReferencedBatterys(c common.Client, link string) ([]*Battery, error) {
-	return common.GetCollectionObjects(c, link, GetBattery)
+	return common.GetCollectionObjects[Battery](c, link)
 }
 
 // Assembly get the containing assembly of this battery.

--- a/redfish/batterymetrics.go
+++ b/redfish/batterymetrics.go
@@ -5,8 +5,6 @@
 package redfish
 
 import (
-	"encoding/json"
-
 	"github.com/stmcginnis/gofish/common"
 )
 
@@ -72,24 +70,11 @@ type BatteryMetrics struct {
 
 // GetBatteryMetrics will get a BatteryMetrics instance from the service.
 func GetBatteryMetrics(c common.Client, uri string) (*BatteryMetrics, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var batterymetrics BatteryMetrics
-	err = json.NewDecoder(resp.Body).Decode(&batterymetrics)
-	if err != nil {
-		return nil, err
-	}
-
-	batterymetrics.SetClient(c)
-	return &batterymetrics, nil
+	return common.GetObject[BatteryMetrics](c, uri)
 }
 
 // ListReferencedBatteryMetricss gets the collection of BatteryMetrics from
 // a provided reference.
 func ListReferencedBatteryMetricss(c common.Client, link string) ([]*BatteryMetrics, error) {
-	return common.GetCollectionObjects(c, link, GetBatteryMetrics)
+	return common.GetCollectionObjects[BatteryMetrics](c, link)
 }

--- a/redfish/bios.go
+++ b/redfish/bios.go
@@ -99,13 +99,12 @@ func (bios *Bios) UnmarshalJSON(b []byte) error {
 
 // GetBios will get a Bios instance from the service.
 func GetBios(c common.Client, uri string) (*Bios, error) {
-	var bios Bios
-	return &bios, bios.Get(c, uri, &bios)
+	return common.GetObject[Bios](c, uri)
 }
 
 // ListReferencedBioss gets the collection of Bios from a provided reference.
 func ListReferencedBioss(c common.Client, link string) ([]*Bios, error) {
-	return common.GetCollectionObjects(c, link, GetBios)
+	return common.GetCollectionObjects[Bios](c, link)
 }
 
 // ChangePassword shall change the selected BIOS password.

--- a/redfish/cable.go
+++ b/redfish/cable.go
@@ -347,24 +347,11 @@ func (cable *Cable) Update() error {
 
 // GetCable will get a Cable instance from the service.
 func GetCable(c common.Client, uri string) (*Cable, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var cable Cable
-	err = json.NewDecoder(resp.Body).Decode(&cable)
-	if err != nil {
-		return nil, err
-	}
-
-	cable.SetClient(c)
-	return &cable, nil
+	return common.GetObject[Cable](c, uri)
 }
 
 // ListReferencedCables gets the collection of Cable from
 // a provided reference.
 func ListReferencedCables(c common.Client, link string) ([]*Cable, error) {
-	return common.GetCollectionObjects(c, link, GetCable)
+	return common.GetCollectionObjects[Cable](c, link)
 }

--- a/redfish/certificate.go
+++ b/redfish/certificate.go
@@ -197,13 +197,12 @@ func (certificate *Certificate) UnmarshalJSON(b []byte) error {
 
 // GetCertificate will get a Certificate instance from the Redfish service.
 func GetCertificate(c common.Client, uri string) (*Certificate, error) {
-	var certificate Certificate
-	return &certificate, certificate.Get(c, uri, &certificate)
+	return common.GetObject[Certificate](c, uri)
 }
 
 // ListReferencedCertificates gets the Certificates collection.
 func ListReferencedCertificates(c common.Client, link string) ([]*Certificate, error) {
-	return common.GetCollectionObjects(c, link, GetCertificate)
+	return common.GetCollectionObjects[Certificate](c, link)
 }
 
 func (certificate *Certificate) RekeyCertificate(challengePassword, keyCurveID, keyPairAlgorithm string, keyBitLength int) error {

--- a/redfish/certificatelocations.go
+++ b/redfish/certificatelocations.go
@@ -58,26 +58,13 @@ func (certificatelocations *CertificateLocations) UnmarshalJSON(b []byte) error 
 
 // GetCertificateLocations will get a CertificateLocations instance from the service.
 func GetCertificateLocations(c common.Client, uri string) (*CertificateLocations, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var certificatelocations CertificateLocations
-	err = json.NewDecoder(resp.Body).Decode(&certificatelocations)
-	if err != nil {
-		return nil, err
-	}
-
-	certificatelocations.SetClient(c)
-	return &certificatelocations, nil
+	return common.GetObject[CertificateLocations](c, uri)
 }
 
 // ListReferencedCertificateLocationss gets the collection of CertificateLocations from
 // a provided reference.
 func ListReferencedCertificateLocations(c common.Client, link string) ([]*CertificateLocations, error) {
-	return common.GetCollectionObjects(c, link, GetCertificateLocations)
+	return common.GetCollectionObjects[CertificateLocations](c, link)
 }
 
 // Certificates retrieves a collection of the Certificates installed on the system.

--- a/redfish/certificateservice.go
+++ b/redfish/certificateservice.go
@@ -70,26 +70,13 @@ func (certificateservice *CertificateService) CertificateLocations() (*Certifica
 
 // GetCertificateService will get a CertificateService instance from the service.
 func GetCertificateService(c common.Client, uri string) (*CertificateService, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var certificateservice CertificateService
-	err = json.NewDecoder(resp.Body).Decode(&certificateservice)
-	if err != nil {
-		return nil, err
-	}
-
-	certificateservice.SetClient(c)
-	return &certificateservice, nil
+	return common.GetObject[CertificateService](c, uri)
 }
 
 // ListReferencedCertificateServices gets the collection of CertificateService from
 // a provided reference.
 func ListReferencedCertificateServices(c common.Client, link string) ([]*CertificateService, error) {
-	return common.GetCollectionObjects(c, link, GetCertificateService)
+	return common.GetCollectionObjects[CertificateService](c, link)
 }
 
 // GenerateCSRResponse shall contain the properties found in the response body for the GenerateCSR action.

--- a/redfish/chassis.go
+++ b/redfish/chassis.go
@@ -595,13 +595,12 @@ func (chassis *Chassis) Update() error {
 
 // GetChassis will get a Chassis instance from the Redfish service.
 func GetChassis(c common.Client, uri string) (*Chassis, error) {
-	var chassis Chassis
-	return &chassis, chassis.Get(c, uri, &chassis)
+	return common.GetObject[Chassis](c, uri)
 }
 
 // ListReferencedChassis gets the collection of Chassis from a provided reference.
 func ListReferencedChassis(c common.Client, link string) ([]*Chassis, error) {
-	return common.GetCollectionObjects(c, link, GetChassis)
+	return common.GetCollectionObjects[Chassis](c, link)
 }
 
 // Certificates returns certificates in this Chassis.

--- a/redfish/circuit.go
+++ b/redfish/circuit.go
@@ -441,8 +441,7 @@ func (circuit *Circuit) UnmarshalJSON(b []byte) error {
 
 // GetCircuit will get a Circuit instance from the Redfish service.
 func GetCircuit(c common.Client, uri string) (*Circuit, error) {
-	var circuit Circuit
-	return &circuit, circuit.Get(c, uri, &circuit)
+	return common.GetObject[Circuit](c, uri)
 }
 
 // Update commits updates to this object's properties to the running system.
@@ -516,7 +515,7 @@ func (circuit *Circuit) ResetMetrics() error {
 // ListReferencedCircuits gets the collection of Circuits from
 // a provided reference.
 func ListReferencedCircuits(c common.Client, link string) ([]*Circuit, error) {
-	return common.GetCollectionObjects(c, link, GetCircuit)
+	return common.GetCollectionObjects[Circuit](c, link)
 }
 
 // BranchCircuit gets a resource that represents the branch circuit associated with this circuit.

--- a/redfish/componentintegrity.go
+++ b/redfish/componentintegrity.go
@@ -246,26 +246,13 @@ func (componentintegrity *ComponentIntegrity) Update() error {
 
 // GetComponentIntegrity will get a ComponentIntegrity instance from the service.
 func GetComponentIntegrity(c common.Client, uri string) (*ComponentIntegrity, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var componentintegrity ComponentIntegrity
-	err = json.NewDecoder(resp.Body).Decode(&componentintegrity)
-	if err != nil {
-		return nil, err
-	}
-
-	componentintegrity.SetClient(c)
-	return &componentintegrity, nil
+	return common.GetObject[ComponentIntegrity](c, uri)
 }
 
 // ListReferencedComponentIntegritys gets the collection of ComponentIntegrity from
 // a provided reference.
 func ListReferencedComponentIntegritys(c common.Client, link string) ([]*ComponentIntegrity, error) {
-	return common.GetCollectionObjects(c, link, GetComponentIntegrity)
+	return common.GetCollectionObjects[ComponentIntegrity](c, link)
 }
 
 // SPDMGetSignedMeasurementsRequest contains the parameters for the SPDMGetSignedMeasurements action.

--- a/redfish/compositionreservation.go
+++ b/redfish/compositionreservation.go
@@ -62,26 +62,13 @@ func (compositionreservation *CompositionReservation) UnmarshalJSON(b []byte) er
 
 // GetCompositionReservation will get a CompositionReservation instance from the service.
 func GetCompositionReservation(c common.Client, uri string) (*CompositionReservation, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var compositionreservation CompositionReservation
-	err = json.NewDecoder(resp.Body).Decode(&compositionreservation)
-	if err != nil {
-		return nil, err
-	}
-
-	compositionreservation.SetClient(c)
-	return &compositionreservation, nil
+	return common.GetObject[CompositionReservation](c, uri)
 }
 
 // ListReferencedCompositionReservations gets the collection of CompositionReservation from
 // a provided reference.
 func ListReferencedCompositionReservations(c common.Client, link string) ([]*CompositionReservation, error) {
-	return common.GetCollectionObjects(c, link, GetCompositionReservation)
+	return common.GetCollectionObjects[CompositionReservation](c, link)
 }
 
 // ReservedResourceBlocks gets reserved resource blocks for this reservation.

--- a/redfish/compositionservice.go
+++ b/redfish/compositionservice.go
@@ -171,14 +171,13 @@ func (compositionservice *CompositionService) Update() error {
 
 // GetCompositionService will get a CompositionService instance from the service.
 func GetCompositionService(c common.Client, uri string) (*CompositionService, error) {
-	var compositionservice CompositionService
-	return &compositionservice, compositionservice.Get(c, uri, &compositionservice)
+	return common.GetObject[CompositionService](c, uri)
 }
 
 // ListReferencedCompositionServices gets the collection of CompositionService from
 // a provided reference.
 func ListReferencedCompositionServices(c common.Client, link string) ([]*CompositionService, error) {
-	return common.GetCollectionObjects(c, link, GetCompositionService)
+	return common.GetCollectionObjects[CompositionService](c, link)
 }
 
 // Compose performs a set of operations specified by a manifest.

--- a/redfish/computersystem.go
+++ b/redfish/computersystem.go
@@ -1055,14 +1055,13 @@ func (computersystem *ComputerSystem) Update() error {
 
 // GetComputerSystem will get a ComputerSystem instance from the service.
 func GetComputerSystem(c common.Client, uri string) (*ComputerSystem, error) {
-	var computersystem ComputerSystem
-	return &computersystem, computersystem.Get(c, uri, &computersystem)
+	return common.GetObject[ComputerSystem](c, uri)
 }
 
 // ListReferencedComputerSystems gets the collection of ComputerSystem from
 // a provided reference.
 func ListReferencedComputerSystems(c common.Client, link string) ([]*ComputerSystem, error) {
-	return common.GetCollectionObjects(c, link, GetComputerSystem)
+	return common.GetCollectionObjects[ComputerSystem](c, link)
 }
 
 // Bios gets the Bios information for this ComputerSystem.

--- a/redfish/connection.go
+++ b/redfish/connection.go
@@ -156,26 +156,13 @@ func (connection *Connection) UnmarshalJSON(b []byte) error {
 
 // GetConnection will get a Connection instance from the service.
 func GetConnection(c common.Client, uri string) (*Connection, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var connection Connection
-	err = json.NewDecoder(resp.Body).Decode(&connection)
-	if err != nil {
-		return nil, err
-	}
-
-	connection.SetClient(c)
-	return &connection, nil
+	return common.GetObject[Connection](c, uri)
 }
 
 // ListReferencedConnections gets the collection of Connection from
 // a provided reference.
 func ListReferencedConnections(c common.Client, link string) ([]*Connection, error) {
-	return common.GetCollectionObjects(c, link, GetConnection)
+	return common.GetCollectionObjects[Connection](c, link)
 }
 
 // InitiatorEndpointGroups get the initiator endpoint groups associated with this connection.

--- a/redfish/connectionmethod.go
+++ b/redfish/connectionmethod.go
@@ -92,26 +92,13 @@ func (connectionmethod *ConnectionMethod) UnmarshalJSON(b []byte) error {
 
 // GetConnectionMethod will get a ConnectionMethod instance from the service.
 func GetConnectionMethod(c common.Client, uri string) (*ConnectionMethod, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var connectionmethod ConnectionMethod
-	err = json.NewDecoder(resp.Body).Decode(&connectionmethod)
-	if err != nil {
-		return nil, err
-	}
-
-	connectionmethod.SetClient(c)
-	return &connectionmethod, nil
+	return common.GetObject[ConnectionMethod](c, uri)
 }
 
 // ListReferencedConnectionMethods gets the collection of ConnectionMethod from
 // a provided reference.
 func ListReferencedConnectionMethods(c common.Client, link string) ([]*ConnectionMethod, error) {
-	return common.GetCollectionObjects(c, link, GetConnectionMethod)
+	return common.GetCollectionObjects[ConnectionMethod](c, link)
 }
 
 // AggregationSources gets the access points using this connection method.

--- a/redfish/container.go
+++ b/redfish/container.go
@@ -76,26 +76,13 @@ func (container *Container) UnmarshalJSON(b []byte) error {
 
 // GetContainer will get a Container instance from the service.
 func GetContainer(c common.Client, uri string) (*Container, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var container Container
-	err = json.NewDecoder(resp.Body).Decode(&container)
-	if err != nil {
-		return nil, err
-	}
-
-	container.SetClient(c)
-	return &container, nil
+	return common.GetObject[Container](c, uri)
 }
 
 // ListReferencedContainers gets the collection of Container from
 // a provided reference.
 func ListReferencedContainers(c common.Client, link string) ([]*Container, error) {
-	return common.GetCollectionObjects(c, link, GetContainer)
+	return common.GetCollectionObjects[Container](c, link)
 }
 
 // Reset resets the container.

--- a/redfish/containerimage.go
+++ b/redfish/containerimage.go
@@ -86,26 +86,13 @@ func (containerimage *ContainerImage) UnmarshalJSON(b []byte) error {
 
 // GetContainerImage will get a ContainerImage instance from the service.
 func GetContainerImage(c common.Client, uri string) (*ContainerImage, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var containerimage ContainerImage
-	err = json.NewDecoder(resp.Body).Decode(&containerimage)
-	if err != nil {
-		return nil, err
-	}
-
-	containerimage.SetClient(c)
-	return &containerimage, nil
+	return common.GetObject[ContainerImage](c, uri)
 }
 
 // ListReferencedContainerImages gets the collection of ContainerImage from
 // a provided reference.
 func ListReferencedContainerImages(c common.Client, link string) ([]*ContainerImage, error) {
-	return common.GetCollectionObjects(c, link, GetContainerImage)
+	return common.GetCollectionObjects[ContainerImage](c, link)
 }
 
 // Containers get the container instances using this container image.

--- a/redfish/control.go
+++ b/redfish/control.go
@@ -229,26 +229,13 @@ func (control *Control) Update() error {
 
 // GetControl will get a Control instance from the service.
 func GetControl(c common.Client, uri string) (*Control, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var control Control
-	err = json.NewDecoder(resp.Body).Decode(&control)
-	if err != nil {
-		return nil, err
-	}
-
-	control.SetClient(c)
-	return &control, nil
+	return common.GetObject[Control](c, uri)
 }
 
 // ListReferencedControls gets the collection of Control from
 // a provided reference.
 func ListReferencedControls(c common.Client, link string) ([]*Control, error) {
-	return common.GetCollectionObjects(c, link, GetControl)
+	return common.GetCollectionObjects[Control](c, link)
 }
 
 // ResetToDefault resets the values of writable properties to factory defaults.

--- a/redfish/coolantconnector.go
+++ b/redfish/coolantconnector.go
@@ -165,26 +165,13 @@ func (coolantconnector *CoolantConnector) Update() error {
 
 // GetCoolantConnector will get a CoolantConnector instance from the service.
 func GetCoolantConnector(c common.Client, uri string) (*CoolantConnector, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var coolantconnector CoolantConnector
-	err = json.NewDecoder(resp.Body).Decode(&coolantconnector)
-	if err != nil {
-		return nil, err
-	}
-
-	coolantconnector.SetClient(c)
-	return &coolantconnector, nil
+	return common.GetObject[CoolantConnector](c, uri)
 }
 
 // ListReferencedCoolantConnectors gets the collection of CoolantConnector from
 // a provided reference.
 func ListReferencedCoolantConnectors(c common.Client, link string) ([]*CoolantConnector, error) {
-	return common.GetCollectionObjects(c, link, GetCoolantConnector)
+	return common.GetCollectionObjects[CoolantConnector](c, link)
 }
 
 // ConnectedChassis retrieves a collection of the Chassis at the other end of the connection.

--- a/redfish/coolingloop.go
+++ b/redfish/coolingloop.go
@@ -171,26 +171,13 @@ func (coolingloop *CoolingLoop) Update() error {
 
 // GetCoolingLoop will get a CoolingLoop instance from the service.
 func GetCoolingLoop(c common.Client, uri string) (*CoolingLoop, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var coolingloop CoolingLoop
-	err = json.NewDecoder(resp.Body).Decode(&coolingloop)
-	if err != nil {
-		return nil, err
-	}
-
-	coolingloop.SetClient(c)
-	return &coolingloop, nil
+	return common.GetObject[CoolingLoop](c, uri)
 }
 
 // ListReferencedCoolingLoops gets the collection of CoolingLoop from
 // a provided reference.
 func ListReferencedCoolingLoops(c common.Client, link string) ([]*CoolingLoop, error) {
-	return common.GetCollectionObjects(c, link, GetCoolingLoop)
+	return common.GetCollectionObjects[CoolingLoop](c, link)
 }
 
 // SecondaryCoolantConnectors gets the secondary coolant connectors for this equipment.

--- a/redfish/coolingunit.go
+++ b/redfish/coolingunit.go
@@ -187,26 +187,13 @@ func (coolingunit *CoolingUnit) Update() error {
 
 // GetCoolingUnit will get a CoolingUnit instance from the service.
 func GetCoolingUnit(c common.Client, uri string) (*CoolingUnit, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var coolingunit CoolingUnit
-	err = json.NewDecoder(resp.Body).Decode(&coolingunit)
-	if err != nil {
-		return nil, err
-	}
-
-	coolingunit.SetClient(c)
-	return &coolingunit, nil
+	return common.GetObject[CoolingUnit](c, uri)
 }
 
 // ListReferencedCoolingUnits gets the collection of CoolingUnit from
 // a provided reference.
 func ListReferencedCoolingUnits(c common.Client, link string) ([]*CoolingUnit, error) {
-	return common.GetCollectionObjects(c, link, GetCoolingUnit)
+	return common.GetCollectionObjects[CoolingUnit](c, link)
 }
 
 // TODO: Add functions to get linked objects

--- a/redfish/cxllogicaldevice.go
+++ b/redfish/cxllogicaldevice.go
@@ -212,26 +212,13 @@ func (cxllogicaldevice *CXLLogicalDevice) PCIeFunctions() ([]*PCIeDevice, error)
 
 // GetCXLLogicalDevice will get a CXLLogicalDevice instance from the service.
 func GetCXLLogicalDevice(c common.Client, uri string) (*CXLLogicalDevice, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var cxllogicaldevice CXLLogicalDevice
-	err = json.NewDecoder(resp.Body).Decode(&cxllogicaldevice)
-	if err != nil {
-		return nil, err
-	}
-
-	cxllogicaldevice.SetClient(c)
-	return &cxllogicaldevice, nil
+	return common.GetObject[CXLLogicalDevice](c, uri)
 }
 
 // ListReferencedCXLLogicalDevices gets the collection of CXLLogicalDevice from
 // a provided reference.
 func ListReferencedCXLLogicalDevices(c common.Client, link string) ([]*CXLLogicalDevice, error) {
-	return common.GetCollectionObjects(c, link, GetCXLLogicalDevice)
+	return common.GetCollectionObjects[CXLLogicalDevice](c, link)
 }
 
 // QoS shall contain the quality of service properties of this CXL logical device.

--- a/redfish/drive.go
+++ b/redfish/drive.go
@@ -438,13 +438,12 @@ func (drive *Drive) Update() error {
 
 // GetDrive will get a Drive instance from the service.
 func GetDrive(c common.Client, uri string) (*Drive, error) {
-	var drive Drive
-	return &drive, drive.Get(c, uri, &drive)
+	return common.GetObject[Drive](c, uri)
 }
 
 // ListReferencedDrives gets the collection of Drives from a provided reference.
 func ListReferencedDrives(c common.Client, link string) ([]*Drive, error) {
-	return common.GetCollectionObjects(c, link, GetDrive)
+	return common.GetCollectionObjects[Drive](c, link)
 }
 
 // Assembly gets the Assembly for this drive.

--- a/redfish/drivemetrics.go
+++ b/redfish/drivemetrics.go
@@ -5,8 +5,6 @@
 package redfish
 
 import (
-	"encoding/json"
-
 	"github.com/stmcginnis/gofish/common"
 )
 
@@ -50,24 +48,11 @@ type DriveMetrics struct {
 
 // GetDriveMetrics will get a DriveMetrics instance from the service.
 func GetDriveMetrics(c common.Client, uri string) (*DriveMetrics, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var drivemetrics DriveMetrics
-	err = json.NewDecoder(resp.Body).Decode(&drivemetrics)
-	if err != nil {
-		return nil, err
-	}
-
-	drivemetrics.SetClient(c)
-	return &drivemetrics, nil
+	return common.GetObject[DriveMetrics](c, uri)
 }
 
 // ListReferencedDriveMetricss gets the collection of DriveMetrics from
 // a provided reference.
 func ListReferencedDriveMetricss(c common.Client, link string) ([]*DriveMetrics, error) {
-	return common.GetCollectionObjects(c, link, GetDriveMetrics)
+	return common.GetCollectionObjects[DriveMetrics](c, link)
 }

--- a/redfish/endpoint.go
+++ b/redfish/endpoint.go
@@ -227,14 +227,13 @@ func (endpoint *Endpoint) UnmarshalJSON(b []byte) error {
 
 // GetEndpoint will get a Endpoint instance from the service.
 func GetEndpoint(c common.Client, uri string) (*Endpoint, error) {
-	var endpoint Endpoint
-	return &endpoint, endpoint.Get(c, uri, &endpoint)
+	return common.GetObject[Endpoint](c, uri)
 }
 
 // ListReferencedEndpoints gets the collection of Endpoint from
 // a provided reference.
 func ListReferencedEndpoints(c common.Client, link string) ([]*Endpoint, error) {
-	return common.GetCollectionObjects(c, link, GetEndpoint)
+	return common.GetCollectionObjects[Endpoint](c, link)
 }
 
 // GCID shall contain the Gen-Z Core Specification-defined Global

--- a/redfish/endpointgroup.go
+++ b/redfish/endpointgroup.go
@@ -124,26 +124,13 @@ func (endpointgroup *EndpointGroup) Update() error {
 
 // GetEndpointGroup will get a EndpointGroup instance from the service.
 func GetEndpointGroup(c common.Client, uri string) (*EndpointGroup, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var endpointgroup EndpointGroup
-	err = json.NewDecoder(resp.Body).Decode(&endpointgroup)
-	if err != nil {
-		return nil, err
-	}
-
-	endpointgroup.SetClient(c)
-	return &endpointgroup, nil
+	return common.GetObject[EndpointGroup](c, uri)
 }
 
 // ListReferencedEndpointGroups gets the collection of EndpointGroup from
 // a provided reference.
 func ListReferencedEndpointGroups(c common.Client, link string) ([]*EndpointGroup, error) {
-	return common.GetCollectionObjects(c, link, GetEndpointGroup)
+	return common.GetCollectionObjects[EndpointGroup](c, link)
 }
 
 // Endpoints get the endpoints associated with this endpoint group.

--- a/redfish/environmentmetrics.go
+++ b/redfish/environmentmetrics.go
@@ -139,24 +139,11 @@ func (environmentmetrics *EnvironmentMetrics) Update() error {
 
 // GetEnvironmentMetrics will get a EnvironmentMetrics instance from the service.
 func GetEnvironmentMetrics(c common.Client, uri string) (*EnvironmentMetrics, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var environmentmetrics EnvironmentMetrics
-	err = json.NewDecoder(resp.Body).Decode(&environmentmetrics)
-	if err != nil {
-		return nil, err
-	}
-
-	environmentmetrics.SetClient(c)
-	return &environmentmetrics, nil
+	return common.GetObject[EnvironmentMetrics](c, uri)
 }
 
 // ListReferencedEnvironmentMetricss gets the collection of EnvironmentMetrics from
 // a provided reference.
 func ListReferencedEnvironmentMetricss(c common.Client, link string) ([]*EnvironmentMetrics, error) {
-	return common.GetCollectionObjects(c, link, GetEnvironmentMetrics)
+	return common.GetCollectionObjects[EnvironmentMetrics](c, link)
 }

--- a/redfish/ethernetinterface.go
+++ b/redfish/ethernetinterface.go
@@ -400,14 +400,13 @@ func (ethernetinterface *EthernetInterface) Update() error {
 
 // GetEthernetInterface will get a EthernetInterface instance from the service.
 func GetEthernetInterface(c common.Client, uri string) (*EthernetInterface, error) {
-	var ethernetInterface EthernetInterface
-	return &ethernetInterface, ethernetInterface.Get(c, uri, &ethernetInterface)
+	return common.GetObject[EthernetInterface](c, uri)
 }
 
 // ListReferencedEthernetInterfaces gets the collection of EthernetInterface from
 // a provided reference.
 func ListReferencedEthernetInterfaces(c common.Client, link string) ([]*EthernetInterface, error) {
-	return common.GetCollectionObjects(c, link, GetEthernetInterface)
+	return common.GetCollectionObjects[EthernetInterface](c, link)
 }
 
 // IPv6AddressPolicyEntry describes and entry in the Address Selection Policy

--- a/redfish/event.go
+++ b/redfish/event.go
@@ -68,26 +68,13 @@ type Event struct {
 
 // GetEvent will get a Event instance from the service.
 func GetEvent(c common.Client, uri string) (*Event, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var event Event
-	err = json.NewDecoder(resp.Body).Decode(&event)
-	if err != nil {
-		return nil, err
-	}
-
-	event.SetClient(c)
-	return &event, nil
+	return common.GetObject[Event](c, uri)
 }
 
 // ListReferencedEvents gets the collection of Event from
 // a provided reference.
 func ListReferencedEvents(c common.Client, link string) ([]*Event, error) {
-	return common.GetCollectionObjects(c, link, GetEvent)
+	return common.GetCollectionObjects[Event](c, link)
 }
 
 // EventRecord

--- a/redfish/eventdestination.go
+++ b/redfish/eventdestination.go
@@ -391,13 +391,7 @@ func (eventdestination *EventDestination) Update() error {
 
 // GetEventDestination will get a EventDestination instance from the service.
 func GetEventDestination(c common.Client, uri string) (*EventDestination, error) {
-	// validate uri
-	if strings.TrimSpace(uri) == "" {
-		return nil, fmt.Errorf("uri should not be empty")
-	}
-
-	var eventdestination EventDestination
-	return &eventdestination, eventdestination.Get(c, uri, &eventdestination)
+	return common.GetObject[EventDestination](c, uri)
 }
 
 // subscriptionPayload is the payload to create the event subscription
@@ -621,7 +615,7 @@ func DeleteEventDestination(c common.Client, uri string) error {
 // ListReferencedEventDestinations gets the collection of EventDestination from
 // a provided reference.
 func ListReferencedEventDestinations(c common.Client, link string) ([]*EventDestination, error) {
-	return common.GetCollectionObjects(c, link, GetEventDestination)
+	return common.GetCollectionObjects[EventDestination](c, link)
 }
 
 // HTTPHeaderProperty shall a names and value of an HTTP header to be included

--- a/redfish/eventservice.go
+++ b/redfish/eventservice.go
@@ -250,14 +250,13 @@ func (eventservice *EventService) Update() error {
 
 // GetEventService will get a EventService instance from the service.
 func GetEventService(c common.Client, uri string) (*EventService, error) {
-	var eventService EventService
-	return &eventService, eventService.Get(c, uri, &eventService)
+	return common.GetObject[EventService](c, uri)
 }
 
 // ListReferencedEventServices gets the collection of EventService from
 // a provided reference.
 func ListReferencedEventServices(c common.Client, link string) ([]*EventService, error) {
-	return common.GetCollectionObjects(c, link, GetEventService)
+	return common.GetCollectionObjects[EventService](c, link)
 }
 
 // GetEventSubscriptions gets all the subscriptions using the event service.
@@ -271,6 +270,9 @@ func (eventservice *EventService) GetEventSubscriptions() ([]*EventDestination, 
 
 // GetEventSubscription gets a specific subscription using the event service.
 func (eventservice *EventService) GetEventSubscription(uri string) (*EventDestination, error) {
+	if uri == "" {
+		return nil, errors.New("uri should not be empty")
+	}
 	return GetEventDestination(eventservice.GetClient(), uri)
 }
 

--- a/redfish/eventservice_test.go
+++ b/redfish/eventservice_test.go
@@ -747,13 +747,6 @@ func TestEventServiceGetEventSubscriptionInputParametersValidation(t *testing.T)
 	// validate the returned error
 	expectedError := "uri should not be empty"
 	assertError(t, expectedError, err.Error())
-
-	// get event subscription
-	_, err = result.GetEventSubscription(" ")
-
-	// validate the returned error
-	expectedError = "uri should not be empty"
-	assertError(t, expectedError, err.Error())
 }
 
 // TestEventServiceGetEventSubscriptionsEmptySubscriptionsLink

--- a/redfish/externalaccountprovider.go
+++ b/redfish/externalaccountprovider.go
@@ -155,26 +155,13 @@ func (externalaccountprovider *ExternalAccountProvider) Update() error {
 
 // GetExternalAccountProvider will get a ExternalAccountProvider instance from the service.
 func GetExternalAccountProvider(c common.Client, uri string) (*ExternalAccountProvider, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var externalaccountprovider ExternalAccountProvider
-	err = json.NewDecoder(resp.Body).Decode(&externalaccountprovider)
-	if err != nil {
-		return nil, err
-	}
-
-	externalaccountprovider.SetClient(c)
-	return &externalaccountprovider, nil
+	return common.GetObject[ExternalAccountProvider](c, uri)
 }
 
 // ListReferencedExternalAccountProviders gets the collection of ExternalAccountProvider from
 // a provided reference.
 func ListReferencedExternalAccountProviders(c common.Client, link string) ([]*ExternalAccountProvider, error) {
-	return common.GetCollectionObjects(c, link, GetExternalAccountProvider)
+	return common.GetCollectionObjects[ExternalAccountProvider](c, link)
 }
 
 // LDAPSearchSettings shall contain all required settings to search a generic LDAP service.

--- a/redfish/fabric.go
+++ b/redfish/fabric.go
@@ -128,24 +128,11 @@ func (fabric *Fabric) Update() error {
 
 // GetFabric will get a Fabric instance from the service.
 func GetFabric(c common.Client, uri string) (*Fabric, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var fabric Fabric
-	err = json.NewDecoder(resp.Body).Decode(&fabric)
-	if err != nil {
-		return nil, err
-	}
-
-	fabric.SetClient(c)
-	return &fabric, nil
+	return common.GetObject[Fabric](c, uri)
 }
 
 // ListReferencedFabrics gets the collection of Fabric from
 // a provided reference.
 func ListReferencedFabrics(c common.Client, link string) ([]*Fabric, error) {
-	return common.GetCollectionObjects(c, link, GetFabric)
+	return common.GetCollectionObjects[Fabric](c, link)
 }

--- a/redfish/fabricadapter.go
+++ b/redfish/fabricadapter.go
@@ -251,26 +251,13 @@ func (fabricadapter *FabricAdapter) Update() error {
 
 // GetFabricAdapter will get a FabricAdapter instance from the service.
 func GetFabricAdapter(c common.Client, uri string) (*FabricAdapter, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var fabricadapter FabricAdapter
-	err = json.NewDecoder(resp.Body).Decode(&fabricadapter)
-	if err != nil {
-		return nil, err
-	}
-
-	fabricadapter.SetClient(c)
-	return &fabricadapter, nil
+	return common.GetObject[FabricAdapter](c, uri)
 }
 
 // ListReferencedFabricAdapters gets the collection of FabricAdapter from
 // a provided reference.
 func ListReferencedFabricAdapters(c common.Client, link string) ([]*FabricAdapter, error) {
-	return common.GetCollectionObjects(c, link, GetFabricAdapter)
+	return common.GetCollectionObjects[FabricAdapter](c, link)
 }
 
 // FabricAdapterGenZ shall contain Gen-Z related properties for a fabric adapter.

--- a/redfish/facility.go
+++ b/redfish/facility.go
@@ -495,24 +495,11 @@ func (facility *Facility) TransferSwitches() ([]*PowerDistribution, error) {
 
 // GetFacility will get a Facility instance from the service.
 func GetFacility(c common.Client, uri string) (*Facility, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var facility Facility
-	err = json.NewDecoder(resp.Body).Decode(&facility)
-	if err != nil {
-		return nil, err
-	}
-
-	facility.SetClient(c)
-	return &facility, nil
+	return common.GetObject[Facility](c, uri)
 }
 
-// ListReferencedFacilitys gets the collection of Facility from
+// ListReferencedFacilities gets the collection of Facility from
 // a provided reference.
-func ListReferencedFacilitys(c common.Client, link string) ([]*Facility, error) {
-	return common.GetCollectionObjects(c, link, GetFacility)
+func ListReferencedFacilities(c common.Client, link string) ([]*Facility, error) {
+	return common.GetCollectionObjects[Facility](c, link)
 }

--- a/redfish/fan.go
+++ b/redfish/fan.go
@@ -170,24 +170,11 @@ func (fan *Fan) Update() error {
 
 // GetFan will get a Fan instance from the service.
 func GetFan(c common.Client, uri string) (*Fan, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var fan Fan
-	err = json.NewDecoder(resp.Body).Decode(&fan)
-	if err != nil {
-		return nil, err
-	}
-
-	fan.SetClient(c)
-	return &fan, nil
+	return common.GetObject[Fan](c, uri)
 }
 
 // ListReferencedFans gets the collection of Fan from
 // a provided reference.
 func ListReferencedFans(c common.Client, link string) ([]*Fan, error) {
-	return common.GetCollectionObjects(c, link, GetFan)
+	return common.GetCollectionObjects[Fan](c, link)
 }

--- a/redfish/filter.go
+++ b/redfish/filter.go
@@ -129,24 +129,11 @@ func (filter *Filter) Update() error {
 
 // GetFilter will get a Filter instance from the service.
 func GetFilter(c common.Client, uri string) (*Filter, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var filter Filter
-	err = json.NewDecoder(resp.Body).Decode(&filter)
-	if err != nil {
-		return nil, err
-	}
-
-	filter.SetClient(c)
-	return &filter, nil
+	return common.GetObject[Filter](c, uri)
 }
 
 // ListReferencedFilters gets the collection of Filter from
 // a provided reference.
 func ListReferencedFilters(c common.Client, link string) ([]*Filter, error) {
-	return common.GetCollectionObjects(c, link, GetFilter)
+	return common.GetCollectionObjects[Filter](c, link)
 }

--- a/redfish/graphicscontroller.go
+++ b/redfish/graphicscontroller.go
@@ -151,24 +151,11 @@ func (graphicscontroller *GraphicsController) Update() error {
 
 // GetGraphicsController will get a GraphicsController instance from the service.
 func GetGraphicsController(c common.Client, uri string) (*GraphicsController, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var graphicscontroller GraphicsController
-	err = json.NewDecoder(resp.Body).Decode(&graphicscontroller)
-	if err != nil {
-		return nil, err
-	}
-
-	graphicscontroller.SetClient(c)
-	return &graphicscontroller, nil
+	return common.GetObject[GraphicsController](c, uri)
 }
 
 // ListReferencedGraphicsControllers gets the collection of GraphicsController from
 // a provided reference.
 func ListReferencedGraphicsControllers(c common.Client, link string) ([]*GraphicsController, error) {
-	return common.GetCollectionObjects(c, link, GetGraphicsController)
+	return common.GetCollectionObjects[GraphicsController](c, link)
 }

--- a/redfish/heater.go
+++ b/redfish/heater.go
@@ -273,24 +273,11 @@ func (heater *Heater) Update() error {
 
 // GetHeater will get a Heater instance from the service.
 func GetHeater(c common.Client, uri string) (*Heater, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var heater Heater
-	err = json.NewDecoder(resp.Body).Decode(&heater)
-	if err != nil {
-		return nil, err
-	}
-
-	heater.SetClient(c)
-	return &heater, nil
+	return common.GetObject[Heater](c, uri)
 }
 
 // ListReferencedHeaters gets the collection of Heater from
 // a provided reference.
 func ListReferencedHeaters(c common.Client, link string) ([]*Heater, error) {
-	return common.GetCollectionObjects(c, link, GetHeater)
+	return common.GetCollectionObjects[Heater](c, link)
 }

--- a/redfish/heatermetrics.go
+++ b/redfish/heatermetrics.go
@@ -80,24 +80,11 @@ func (heatermetrics *HeaterMetrics) ResetMetrics() error {
 
 // GetHeaterMetrics will get a HeaterMetrics instance from the service.
 func GetHeaterMetrics(c common.Client, uri string) (*HeaterMetrics, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var heatermetrics HeaterMetrics
-	err = json.NewDecoder(resp.Body).Decode(&heatermetrics)
-	if err != nil {
-		return nil, err
-	}
-
-	heatermetrics.SetClient(c)
-	return &heatermetrics, nil
+	return common.GetObject[HeaterMetrics](c, uri)
 }
 
 // ListReferencedHeaterMetrics gets the collection of HeaterMetrics from
 // a provided reference.
 func ListReferencedHeaterMetrics(c common.Client, link string) ([]*HeaterMetrics, error) {
-	return common.GetCollectionObjects(c, link, GetHeaterMetrics)
+	return common.GetCollectionObjects[HeaterMetrics](c, link)
 }

--- a/redfish/hostinterface.go
+++ b/redfish/hostinterface.go
@@ -209,14 +209,13 @@ func (hostinterface *HostInterface) Update() error {
 
 // GetHostInterface will get a HostInterface instance from the service.
 func GetHostInterface(c common.Client, uri string) (*HostInterface, error) {
-	var hostInterface HostInterface
-	return &hostInterface, hostInterface.Get(c, uri, &hostInterface)
+	return common.GetObject[HostInterface](c, uri)
 }
 
 // ListReferencedHostInterfaces gets the collection of HostInterface from
 // a provided reference.
 func ListReferencedHostInterfaces(c common.Client, link string) ([]*HostInterface, error) {
-	return common.GetCollectionObjects(c, link, GetHostInterface)
+	return common.GetCollectionObjects[HostInterface](c, link)
 }
 
 // ComputerSystems references the ComputerSystems that this host interface is associated with.

--- a/redfish/job.go
+++ b/redfish/job.go
@@ -171,12 +171,11 @@ func (job *Job) Steps() ([]*Job, error) {
 
 // GetJob will get a Job instance from the service.
 func GetJob(c common.Client, uri string) (*Job, error) {
-	var job Job
-	return &job, job.Get(c, uri, &job)
+	return common.GetObject[Job](c, uri)
 }
 
 // ListReferencedJobs gets the collection of Job from
 // a provided reference.
 func ListReferencedJobs(c common.Client, link string) ([]*Job, error) {
-	return common.GetCollectionObjects(c, link, GetJob)
+	return common.GetCollectionObjects[Job](c, link)
 }

--- a/redfish/jobservice.go
+++ b/redfish/jobservice.go
@@ -77,8 +77,7 @@ func (jobservice *JobService) UnmarshalJSON(b []byte) error {
 
 // GetJobService will get a JobService instance from the service.
 func GetJobService(c common.Client, uri string) (*JobService, error) {
-	var jobService JobService
-	return &jobService, jobService.Get(c, uri, &jobService)
+	return common.GetObject[JobService](c, uri)
 }
 
 // Jobs gets the collection of jobs of this job service

--- a/redfish/key.go
+++ b/redfish/key.go
@@ -135,26 +135,13 @@ func (key *Key) Update() error {
 
 // GetKey will get a Key instance from the service.
 func GetKey(c common.Client, uri string) (*Key, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var key Key
-	err = json.NewDecoder(resp.Body).Decode(&key)
-	if err != nil {
-		return nil, err
-	}
-
-	key.SetClient(c)
-	return &key, nil
+	return common.GetObject[Key](c, uri)
 }
 
 // ListReferencedKeys gets the collection of Key from
 // a provided reference.
 func ListReferencedKeys(c common.Client, link string) ([]*Key, error) {
-	return common.GetCollectionObjects(c, link, GetKey)
+	return common.GetCollectionObjects[Key](c, link)
 }
 
 // KeyNVMeoF shall contain NVMe-oF specific properties for a key.

--- a/redfish/keypolicy.go
+++ b/redfish/keypolicy.go
@@ -162,26 +162,13 @@ func (keypolicy *KeyPolicy) Update() error {
 
 // GetKeyPolicy will get a KeyPolicy instance from the service.
 func GetKeyPolicy(c common.Client, uri string) (*KeyPolicy, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var keypolicy KeyPolicy
-	err = json.NewDecoder(resp.Body).Decode(&keypolicy)
-	if err != nil {
-		return nil, err
-	}
-
-	keypolicy.SetClient(c)
-	return &keypolicy, nil
+	return common.GetObject[KeyPolicy](c, uri)
 }
 
 // ListReferencedKeyPolicys gets the collection of KeyPolicy from
 // a provided reference.
 func ListReferencedKeyPolicys(c common.Client, link string) ([]*KeyPolicy, error) {
-	return common.GetCollectionObjects(c, link, GetKeyPolicy)
+	return common.GetCollectionObjects[KeyPolicy](c, link)
 }
 
 // NVMeoF shall contain NVMe-oF specific properties for a key policy.

--- a/redfish/keyservice.go
+++ b/redfish/keyservice.go
@@ -69,24 +69,11 @@ func (keyservice *KeyService) NVMeoFSecrets() ([]*Key, error) {
 
 // GetKeyService will get a KeyService instance from the service.
 func GetKeyService(c common.Client, uri string) (*KeyService, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var keyservice KeyService
-	err = json.NewDecoder(resp.Body).Decode(&keyservice)
-	if err != nil {
-		return nil, err
-	}
-
-	keyservice.SetClient(c)
-	return &keyservice, nil
+	return common.GetObject[KeyService](c, uri)
 }
 
 // ListReferencedKeyServices gets the collection of KeyService from
 // a provided reference.
 func ListReferencedKeyServices(c common.Client, link string) ([]*KeyService, error) {
-	return common.GetCollectionObjects(c, link, GetKeyService)
+	return common.GetCollectionObjects[KeyService](c, link)
 }

--- a/redfish/leakdetection.go
+++ b/redfish/leakdetection.go
@@ -61,26 +61,13 @@ func (leakdetection *LeakDetection) LeakDetectors() ([]*LeakDetector, error) {
 
 // GetLeakDetection will get a LeakDetection instance from the service.
 func GetLeakDetection(c common.Client, uri string) (*LeakDetection, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var leakdetection LeakDetection
-	err = json.NewDecoder(resp.Body).Decode(&leakdetection)
-	if err != nil {
-		return nil, err
-	}
-
-	leakdetection.SetClient(c)
-	return &leakdetection, nil
+	return common.GetObject[LeakDetection](c, uri)
 }
 
 // ListReferencedLeakDetections gets the collection of LeakDetection from
 // a provided reference.
 func ListReferencedLeakDetections(c common.Client, link string) ([]*LeakDetection, error) {
-	return common.GetCollectionObjects(c, link, GetLeakDetection)
+	return common.GetCollectionObjects[LeakDetection](c, link)
 }
 
 // LeakDetectorGroup shall contain a group of leak detection equipment that reports a unified status.

--- a/redfish/leakdetector.go
+++ b/redfish/leakdetector.go
@@ -68,26 +68,13 @@ type LeakDetector struct {
 
 // GetLeakDetector will get a LeakDetector instance from the service.
 func GetLeakDetector(c common.Client, uri string) (*LeakDetector, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var leakdetector LeakDetector
-	err = json.NewDecoder(resp.Body).Decode(&leakdetector)
-	if err != nil {
-		return nil, err
-	}
-
-	leakdetector.SetClient(c)
-	return &leakdetector, nil
+	return common.GetObject[LeakDetector](c, uri)
 }
 
 // ListReferencedLeakDetectors gets the collection of LeakDetector from
 // a provided reference.
 func ListReferencedLeakDetectors(c common.Client, link string) ([]*LeakDetector, error) {
-	return common.GetCollectionObjects(c, link, GetLeakDetector)
+	return common.GetCollectionObjects[LeakDetector](c, link)
 }
 
 // LeakDetectorArrayExcerpt shall represent a state-based or digital-value leak detector for a Redfish

--- a/redfish/license.go
+++ b/redfish/license.go
@@ -199,24 +199,11 @@ func (license *License) TargetServices() ([]*Manager, error) {
 
 // GetLicense will get a License instance from the service.
 func GetLicense(c common.Client, uri string) (*License, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var license License
-	err = json.NewDecoder(resp.Body).Decode(&license)
-	if err != nil {
-		return nil, err
-	}
-
-	license.SetClient(c)
-	return &license, nil
+	return common.GetObject[License](c, uri)
 }
 
 // ListReferencedLicenses gets the collection of License from
 // a provided reference.
 func ListReferencedLicenses(c common.Client, link string) ([]*License, error) {
-	return common.GetCollectionObjects(c, link, GetLicense)
+	return common.GetCollectionObjects[License](c, link)
 }

--- a/redfish/licenseservice.go
+++ b/redfish/licenseservice.go
@@ -133,24 +133,11 @@ func (licenseservice *LicenseService) Update() error {
 
 // GetLicenseService will get a LicenseService instance from the service.
 func GetLicenseService(c common.Client, uri string) (*LicenseService, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var licenseservice LicenseService
-	err = json.NewDecoder(resp.Body).Decode(&licenseservice)
-	if err != nil {
-		return nil, err
-	}
-
-	licenseservice.SetClient(c)
-	return &licenseservice, nil
+	return common.GetObject[LicenseService](c, uri)
 }
 
 // ListReferencedLicenseServices gets the collection of LicenseService from
 // a provided reference.
 func ListReferencedLicenseServices(c common.Client, link string) ([]*LicenseService, error) {
-	return common.GetCollectionObjects(c, link, GetLicenseService)
+	return common.GetCollectionObjects[LicenseService](c, link)
 }

--- a/redfish/logentry.go
+++ b/redfish/logentry.go
@@ -603,12 +603,11 @@ func (logentry *LogEntry) Update() error {
 
 // GetLogEntry will get a LogEntry instance from the service.
 func GetLogEntry(c common.Client, uri string) (*LogEntry, error) {
-	var logEntry LogEntry
-	return &logEntry, logEntry.Get(c, uri, &logEntry)
+	return common.GetObject[LogEntry](c, uri)
 }
 
 // ListReferencedLogEntrys gets the collection of LogEntry from
 // a provided reference.
 func ListReferencedLogEntrys(c common.Client, link string) ([]*LogEntry, error) {
-	return common.GetCollectionObjects(c, link, GetLogEntry)
+	return common.GetCollectionObjects[LogEntry](c, link)
 }

--- a/redfish/logservice.go
+++ b/redfish/logservice.go
@@ -180,13 +180,12 @@ func (logservice *LogService) Update() error {
 
 // GetLogService will get a LogService instance from the service.
 func GetLogService(c common.Client, uri string) (*LogService, error) {
-	var logService LogService
-	return &logService, logService.Get(c, uri, &logService)
+	return common.GetObject[LogService](c, uri)
 }
 
 // ListReferencedLogServices gets the collection of LogService from a provided reference.
 func ListReferencedLogServices(c common.Client, link string) ([]*LogService, error) {
-	return common.GetCollectionObjects(c, link, GetLogService)
+	return common.GetCollectionObjects[LogService](c, link)
 }
 
 // Entries gets the log entries of this service.

--- a/redfish/manager.go
+++ b/redfish/manager.go
@@ -517,13 +517,12 @@ func (manager *Manager) Update() error {
 
 // GetManager will get a Manager instance from the Swordfish service.
 func GetManager(c common.Client, uri string) (*Manager, error) {
-	var manager Manager
-	return &manager, manager.Get(c, uri, &manager)
+	return common.GetObject[Manager](c, uri)
 }
 
 // ListReferencedManagers gets the collection of Managers
 func ListReferencedManagers(c common.Client, link string) ([]*Manager, error) {
-	return common.GetCollectionObjects(c, link, GetManager)
+	return common.GetCollectionObjects[Manager](c, link)
 }
 
 // ForceFailover forces a failover to the specified manager.

--- a/redfish/manageraccount.go
+++ b/redfish/manageraccount.go
@@ -269,14 +269,13 @@ func (manageraccount *ManagerAccount) Update() error {
 
 // GetManagerAccount will get a ManagerAccount instance from the service.
 func GetManagerAccount(c common.Client, uri string) (*ManagerAccount, error) {
-	var managerAccount ManagerAccount
-	return &managerAccount, managerAccount.Get(c, uri, &managerAccount)
+	return common.GetObject[ManagerAccount](c, uri)
 }
 
 // ListReferencedManagerAccounts gets the collection of ManagerAccount from
 // a provided reference.
 func ListReferencedManagerAccounts(c common.Client, link string) ([]*ManagerAccount, error) {
-	return common.GetCollectionObjects(c, link, GetManagerAccount)
+	return common.GetCollectionObjects[ManagerAccount](c, link)
 }
 
 // SNMPUserInfo is shall contain the SNMP settings for an account.

--- a/redfish/managerdiagnosticdata.go
+++ b/redfish/managerdiagnosticdata.go
@@ -109,26 +109,13 @@ func (manager *Manager) ResetMetrics() error {
 
 // GetManagerDiagnosticData will get a ManagerDiagnosticData instance from the service.
 func GetManagerDiagnosticData(c common.Client, uri string) (*ManagerDiagnosticData, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var managerdiagnosticdata ManagerDiagnosticData
-	err = json.NewDecoder(resp.Body).Decode(&managerdiagnosticdata)
-	if err != nil {
-		return nil, err
-	}
-
-	managerdiagnosticdata.SetClient(c)
-	return &managerdiagnosticdata, nil
+	return common.GetObject[ManagerDiagnosticData](c, uri)
 }
 
 // ListReferencedManagerDiagnosticDatas gets the collection of ManagerDiagnosticData from
 // a provided reference.
 func ListReferencedManagerDiagnosticDatas(c common.Client, link string) ([]*ManagerDiagnosticData, error) {
-	return common.GetCollectionObjects(c, link, GetManagerDiagnosticData)
+	return common.GetCollectionObjects[ManagerDiagnosticData](c, link)
 }
 
 // MemoryECCStatistics shall contain the memory ECC statistics of a manager.

--- a/redfish/manifest.go
+++ b/redfish/manifest.go
@@ -62,6 +62,8 @@ const (
 
 // Manifest shall describe a manifest containing a set of requests to be fulfilled.
 type Manifest struct {
+	// The schema doesn't define this as a full Entity object, but it shouldn't hurt.
+	common.Entity
 	// Description provides a description of this resource.
 	Description string
 	// Expand shall contain the expansion control for references in manifest responses.
@@ -74,25 +76,13 @@ type Manifest struct {
 
 // GetManifest will get a Manifest instance from the service.
 func GetManifest(c common.Client, uri string) (*Manifest, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var manifest Manifest
-	err = json.NewDecoder(resp.Body).Decode(&manifest)
-	if err != nil {
-		return nil, err
-	}
-
-	return &manifest, nil
+	return common.GetObject[Manifest](c, uri)
 }
 
 // ListReferencedManifests gets the collection of Manifest from
 // a provided reference.
 func ListReferencedManifests(c common.Client, link string) ([]*Manifest, error) {
-	return common.GetCollectionObjects(c, link, GetManifest)
+	return common.GetCollectionObjects[Manifest](c, link)
 }
 
 // Stanza shall contain properties that describe a request to be fulfilled within a manifest.

--- a/redfish/mediacontroller.go
+++ b/redfish/mediacontroller.go
@@ -174,24 +174,11 @@ func (mediacontroller *MediaController) MemoryDomains() ([]*MemoryDomain, error)
 
 // GetMediaController will get a MediaController instance from the service.
 func GetMediaController(c common.Client, uri string) (*MediaController, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var mediacontroller MediaController
-	err = json.NewDecoder(resp.Body).Decode(&mediacontroller)
-	if err != nil {
-		return nil, err
-	}
-
-	mediacontroller.SetClient(c)
-	return &mediacontroller, nil
+	return common.GetObject[MediaController](c, uri)
 }
 
 // ListReferencedMediaControllers gets the collection of MediaController from
 // a provided reference.
 func ListReferencedMediaControllers(c common.Client, link string) ([]*MediaController, error) {
-	return common.GetCollectionObjects(c, link, GetMediaController)
+	return common.GetCollectionObjects[MediaController](c, link)
 }

--- a/redfish/memory.go
+++ b/redfish/memory.go
@@ -589,14 +589,13 @@ func (memory *Memory) Update() error {
 
 // GetMemory will get a Memory instance from the service.
 func GetMemory(c common.Client, uri string) (*Memory, error) {
-	var memory Memory
-	return &memory, memory.Get(c, uri, &memory)
+	return common.GetObject[Memory](c, uri)
 }
 
 // ListReferencedMemorys gets the collection of Memory from
 // a provided reference.
 func ListReferencedMemorys(c common.Client, link string) ([]*Memory, error) {
-	return common.GetCollectionObjects(c, link, GetMemory)
+	return common.GetCollectionObjects[Memory](c, link)
 }
 
 // Assembly gets this memory's assembly.

--- a/redfish/memorychunks.go
+++ b/redfish/memorychunks.go
@@ -197,24 +197,11 @@ func (memorychunks *MemoryChunks) Update() error {
 
 // GetMemoryChunks will get a MemoryChunks instance from the service.
 func GetMemoryChunks(c common.Client, uri string) (*MemoryChunks, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var memorychunks MemoryChunks
-	err = json.NewDecoder(resp.Body).Decode(&memorychunks)
-	if err != nil {
-		return nil, err
-	}
-
-	memorychunks.SetClient(c)
-	return &memorychunks, nil
+	return common.GetObject[MemoryChunks](c, uri)
 }
 
 // ListReferencedMemoryChunks gets the collection of MemoryChunks from
 // a provided reference.
 func ListReferencedMemoryChunks(c common.Client, link string) ([]*MemoryChunks, error) {
-	return common.GetCollectionObjects(c, link, GetMemoryChunks)
+	return common.GetCollectionObjects[MemoryChunks](c, link)
 }

--- a/redfish/memorydomain.go
+++ b/redfish/memorydomain.go
@@ -199,14 +199,13 @@ func (memorydomain *MemoryDomain) PCIeFunctions() ([]*PCIeFunction, error) {
 
 // GetMemoryDomain will get a MemoryDomain instance from the service.
 func GetMemoryDomain(c common.Client, uri string) (*MemoryDomain, error) {
-	var memoryDomain MemoryDomain
-	return &memoryDomain, memoryDomain.Get(c, uri, &memoryDomain)
+	return common.GetObject[MemoryDomain](c, uri)
 }
 
 // ListReferencedMemoryDomains gets the collection of MemoryDomain from
 // a provided reference.
 func ListReferencedMemoryDomains(c common.Client, link string) ([]*MemoryDomain, error) {
-	return common.GetCollectionObjects(c, link, GetMemoryDomain)
+	return common.GetCollectionObjects[MemoryDomain](c, link)
 }
 
 // MemorySet shall represent the interleave sets for a memory chunk.

--- a/redfish/memorymetrics.go
+++ b/redfish/memorymetrics.go
@@ -206,12 +206,11 @@ func (memorymetrics *MemoryMetrics) ClearCurrentPeriod() error {
 
 // GetMemoryMetrics will get a MemoryMetrics instance from the service.
 func GetMemoryMetrics(c common.Client, uri string) (*MemoryMetrics, error) {
-	var memoryMetrics MemoryMetrics
-	return &memoryMetrics, memoryMetrics.Get(c, uri, &memoryMetrics)
+	return common.GetObject[MemoryMetrics](c, uri)
 }
 
 // ListReferencedMemoryMetricss gets the collection of MemoryMetrics from
 // a provided reference.
 func ListReferencedMemoryMetricss(c common.Client, link string) ([]*MemoryMetrics, error) {
-	return common.GetCollectionObjects(c, link, GetMemoryMetrics)
+	return common.GetCollectionObjects[MemoryMetrics](c, link)
 }

--- a/redfish/memoryregion.go
+++ b/redfish/memoryregion.go
@@ -167,24 +167,11 @@ func (memoryregion *MemoryRegion) Update() error {
 
 // GetMemoryRegion will get a MemoryRegion instance from the service.
 func GetMemoryRegion(c common.Client, uri string) (*MemoryRegion, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var memoryregion MemoryRegion
-	err = json.NewDecoder(resp.Body).Decode(&memoryregion)
-	if err != nil {
-		return nil, err
-	}
-
-	memoryregion.SetClient(c)
-	return &memoryregion, nil
+	return common.GetObject[MemoryRegion](c, uri)
 }
 
 // ListReferencedMemoryRegions gets the collection of MemoryRegion from
 // a provided reference.
 func ListReferencedMemoryRegions(c common.Client, link string) ([]*MemoryRegion, error) {
-	return common.GetCollectionObjects(c, link, GetMemoryRegion)
+	return common.GetCollectionObjects[MemoryRegion](c, link)
 }

--- a/redfish/messageregistry.go
+++ b/redfish/messageregistry.go
@@ -134,8 +134,7 @@ type MessageRegistry struct {
 
 // GetMessageRegistry will get a MessageRegistry instance from the Redfish service.
 func GetMessageRegistry(c common.Client, uri string) (*MessageRegistry, error) {
-	var messageRegistry MessageRegistry
-	return &messageRegistry, messageRegistry.Get(c, uri, &messageRegistry)
+	return common.GetObject[MessageRegistry](c, uri)
 }
 
 // ListReferencedMessageRegistries gets the collection of MessageRegistry.

--- a/redfish/messageregistryfile.go
+++ b/redfish/messageregistryfile.go
@@ -61,11 +61,10 @@ type MessageRegistryFile struct {
 // GetMessageRegistryFile will get a MessageRegistryFile
 // instance from the Redfish service.
 func GetMessageRegistryFile(c common.Client, uri string) (*MessageRegistryFile, error) {
-	var messageRegistryFile MessageRegistryFile
-	return &messageRegistryFile, messageRegistryFile.Get(c, uri, &messageRegistryFile)
+	return common.GetObject[MessageRegistryFile](c, uri)
 }
 
 // ListReferencedMessageRegistryFiles gets the collection of MessageRegistryFile.
 func ListReferencedMessageRegistryFiles(c common.Client, link string) ([]*MessageRegistryFile, error) {
-	return common.GetCollectionObjects(c, link, GetMessageRegistryFile)
+	return common.GetCollectionObjects[MessageRegistryFile](c, link)
 }

--- a/redfish/metricdefinition.go
+++ b/redfish/metricdefinition.go
@@ -213,26 +213,13 @@ func (metricdefinition *MetricDefinition) Update() error {
 
 // GetMetricDefinition will get a MetricDefinition instance from the service.
 func GetMetricDefinition(c common.Client, uri string) (*MetricDefinition, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var metricdefinition MetricDefinition
-	err = json.NewDecoder(resp.Body).Decode(&metricdefinition)
-	if err != nil {
-		return nil, err
-	}
-
-	metricdefinition.SetClient(c)
-	return &metricdefinition, nil
+	return common.GetObject[MetricDefinition](c, uri)
 }
 
 // ListReferencedMetricDefinitions gets the collection of MetricDefinition from
 // a provided reference.
 func ListReferencedMetricDefinitions(c common.Client, link string) ([]*MetricDefinition, error) {
-	return common.GetCollectionObjects(c, link, GetMetricDefinition)
+	return common.GetCollectionObjects[MetricDefinition](c, link)
 }
 
 // Wildcard shall contain a wildcard and its substitution values.

--- a/redfish/metricreport.go
+++ b/redfish/metricreport.go
@@ -69,26 +69,13 @@ func (metricreport *MetricReport) MetricReportDefinition() (*MetricReportDefinit
 
 // GetMetricReport will get a MetricReport instance from the service.
 func GetMetricReport(c common.Client, uri string) (*MetricReport, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var metricreport MetricReport
-	err = json.NewDecoder(resp.Body).Decode(&metricreport)
-	if err != nil {
-		return nil, err
-	}
-
-	metricreport.SetClient(c)
-	return &metricreport, nil
+	return common.GetObject[MetricReport](c, uri)
 }
 
 // ListReferencedMetricReports gets the collection of MetricReport from
 // a provided reference.
 func ListReferencedMetricReports(c common.Client, link string) ([]*MetricReport, error) {
-	return common.GetCollectionObjects(c, link, GetMetricReport)
+	return common.GetCollectionObjects[MetricReport](c, link)
 }
 
 // MetricValue shall contain properties that capture a metric value and other associated information.

--- a/redfish/metricreportdefinition.go
+++ b/redfish/metricreportdefinition.go
@@ -284,24 +284,11 @@ func (metricreportdefinition *MetricReportDefinition) Update() error {
 
 // GetMetricReportDefinition will get a MetricReportDefinition instance from the service.
 func GetMetricReportDefinition(c common.Client, uri string) (*MetricReportDefinition, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var metricreportdefinition MetricReportDefinition
-	err = json.NewDecoder(resp.Body).Decode(&metricreportdefinition)
-	if err != nil {
-		return nil, err
-	}
-
-	metricreportdefinition.SetClient(c)
-	return &metricreportdefinition, nil
+	return common.GetObject[MetricReportDefinition](c, uri)
 }
 
 // ListReferencedMetricReportDefinitions gets the collection of MetricReportDefinition from
 // a provided reference.
 func ListReferencedMetricReportDefinitions(c common.Client, link string) ([]*MetricReportDefinition, error) {
-	return common.GetCollectionObjects(c, link, GetMetricReportDefinition)
+	return common.GetCollectionObjects[MetricReportDefinition](c, link)
 }

--- a/redfish/networkadapter.go
+++ b/redfish/networkadapter.go
@@ -428,13 +428,12 @@ func (networkadapter *NetworkAdapter) Update() error {
 
 // GetNetworkAdapter will get a NetworkAdapter instance from the Redfish service.
 func GetNetworkAdapter(c common.Client, uri string) (*NetworkAdapter, error) {
-	var networkAdapter NetworkAdapter
-	return &networkAdapter, networkAdapter.Get(c, uri, &networkAdapter)
+	return common.GetObject[NetworkAdapter](c, uri)
 }
 
 // ListReferencedNetworkAdapter gets the collection of Chassis from a provided reference.
 func ListReferencedNetworkAdapter(c common.Client, link string) ([]*NetworkAdapter, error) {
-	return common.GetCollectionObjects(c, link, GetNetworkAdapter)
+	return common.GetCollectionObjects[NetworkAdapter](c, link)
 }
 
 // Assembly gets this adapter's assembly.

--- a/redfish/networkadaptermetrics.go
+++ b/redfish/networkadaptermetrics.go
@@ -63,24 +63,11 @@ type NetworkAdapterMetrics struct {
 
 // GetNetworkAdapterMetrics will get a NetworkAdapterMetrics instance from the service.
 func GetNetworkAdapterMetrics(c common.Client, uri string) (*NetworkAdapterMetrics, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var networkadaptermetrics NetworkAdapterMetrics
-	err = json.NewDecoder(resp.Body).Decode(&networkadaptermetrics)
-	if err != nil {
-		return nil, err
-	}
-
-	networkadaptermetrics.SetClient(c)
-	return &networkadaptermetrics, nil
+	return common.GetObject[NetworkAdapterMetrics](c, uri)
 }
 
 // ListReferencedNetworkAdapterMetrics gets the collection of NetworkAdapterMetrics from
 // a provided reference.
 func ListReferencedNetworkAdapterMetrics(c common.Client, link string) ([]*NetworkAdapterMetrics, error) {
-	return common.GetCollectionObjects(c, link, GetNetworkAdapterMetrics)
+	return common.GetCollectionObjects[NetworkAdapterMetrics](c, link)
 }

--- a/redfish/networkdevicefunction.go
+++ b/redfish/networkdevicefunction.go
@@ -559,14 +559,13 @@ func (networkdevicefunction *NetworkDeviceFunction) Update() error {
 
 // GetNetworkDeviceFunction will get a NetworkDeviceFunction instance from the service.
 func GetNetworkDeviceFunction(c common.Client, uri string) (*NetworkDeviceFunction, error) {
-	var networkDeviceFunction NetworkDeviceFunction
-	return &networkDeviceFunction, networkDeviceFunction.Get(c, uri, &networkDeviceFunction)
+	return common.GetObject[NetworkDeviceFunction](c, uri)
 }
 
 // ListReferencedNetworkDeviceFunctions gets the collection of NetworkDeviceFunction from
 // a provided reference.
 func ListReferencedNetworkDeviceFunctions(c common.Client, link string) ([]*NetworkDeviceFunction, error) {
-	return common.GetCollectionObjects(c, link, GetNetworkDeviceFunction)
+	return common.GetCollectionObjects[NetworkDeviceFunction](c, link)
 }
 
 // ISCSIBoot shall describe the iSCSI boot capabilities, status, and

--- a/redfish/networkdevicefunctionmetrics.go
+++ b/redfish/networkdevicefunctionmetrics.go
@@ -111,24 +111,11 @@ type NetworkDeviceFunctionMetrics struct {
 
 // GetNetworkDeviceFunctionMetrics will get a NetworkDeviceFunctionMetrics instance from the service.
 func GetNetworkDeviceFunctionMetrics(c common.Client, uri string) (*NetworkDeviceFunctionMetrics, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var networkdevicefunctionmetrics NetworkDeviceFunctionMetrics
-	err = json.NewDecoder(resp.Body).Decode(&networkdevicefunctionmetrics)
-	if err != nil {
-		return nil, err
-	}
-
-	networkdevicefunctionmetrics.SetClient(c)
-	return &networkdevicefunctionmetrics, nil
+	return common.GetObject[NetworkDeviceFunctionMetrics](c, uri)
 }
 
 // ListReferencedNetworkDeviceFunctionMetricss gets the collection of NetworkDeviceFunctionMetrics from
 // a provided reference.
 func ListReferencedNetworkDeviceFunctionMetricss(c common.Client, link string) ([]*NetworkDeviceFunctionMetrics, error) {
-	return common.GetCollectionObjects(c, link, GetNetworkDeviceFunctionMetrics)
+	return common.GetCollectionObjects[NetworkDeviceFunctionMetrics](c, link)
 }

--- a/redfish/networkinterface.go
+++ b/redfish/networkinterface.go
@@ -81,14 +81,13 @@ func (networkinterface *NetworkInterface) UnmarshalJSON(b []byte) error {
 
 // GetNetworkInterface will get a NetworkInterface instance from the service.
 func GetNetworkInterface(c common.Client, uri string) (*NetworkInterface, error) {
-	var networkInterface NetworkInterface
-	return &networkInterface, networkInterface.Get(c, uri, &networkInterface)
+	return common.GetObject[NetworkInterface](c, uri)
 }
 
 // ListReferencedNetworkInterfaces gets the collection of NetworkInterface from
 // a provided reference.
 func ListReferencedNetworkInterfaces(c common.Client, link string) ([]*NetworkInterface, error) {
-	return common.GetCollectionObjects(c, link, GetNetworkInterface)
+	return common.GetCollectionObjects[NetworkInterface](c, link)
 }
 
 // NetworkAdapter gets the NetworkAdapter for this interface.

--- a/redfish/networkport.go
+++ b/redfish/networkport.go
@@ -274,14 +274,13 @@ func (networkport *NetworkPort) Update() error {
 
 // GetNetworkPort will get a NetworkPort instance from the service.
 func GetNetworkPort(c common.Client, uri string) (*NetworkPort, error) {
-	var networkPort NetworkPort
-	return &networkPort, networkPort.Get(c, uri, &networkPort)
+	return common.GetObject[NetworkPort](c, uri)
 }
 
 // ListReferencedNetworkPorts gets the collection of NetworkPort from
 // a provided reference.
 func ListReferencedNetworkPorts(c common.Client, link string) ([]*NetworkPort, error) {
-	return common.GetCollectionObjects(c, link, GetNetworkPort)
+	return common.GetCollectionObjects[NetworkPort](c, link)
 }
 
 // SupportedLinkCapabilities shall describe the static capabilities of an

--- a/redfish/networkprotocol.go
+++ b/redfish/networkprotocol.go
@@ -287,6 +287,5 @@ func (networkProtocol *NetworkProtocolSettings) Update() error {
 }
 
 func GetNetworkProtocol(c common.Client, uri string) (*NetworkProtocolSettings, error) {
-	var networkProtocolSettings NetworkProtocolSettings
-	return &networkProtocolSettings, networkProtocolSettings.Get(c, uri, &networkProtocolSettings)
+	return common.GetObject[NetworkProtocolSettings](c, uri)
 }

--- a/redfish/operatingconfig.go
+++ b/redfish/operatingconfig.go
@@ -55,26 +55,13 @@ type OperatingConfig struct {
 
 // GetOperatingConfig will get a OperatingConfig instance from the service.
 func GetOperatingConfig(c common.Client, uri string) (*OperatingConfig, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var operatingconfig OperatingConfig
-	err = json.NewDecoder(resp.Body).Decode(&operatingconfig)
-	if err != nil {
-		return nil, err
-	}
-
-	operatingconfig.SetClient(c)
-	return &operatingconfig, nil
+	return common.GetObject[OperatingConfig](c, uri)
 }
 
 // ListReferencedOperatingConfigs gets the collection of OperatingConfig from
 // a provided reference.
 func ListReferencedOperatingConfigs(c common.Client, link string) ([]*OperatingConfig, error) {
-	return common.GetCollectionObjects(c, link, GetOperatingConfig)
+	return common.GetCollectionObjects[OperatingConfig](c, link)
 }
 
 // TurboProfileDatapoint shall specify the turbo profile for a set of active cores.

--- a/redfish/operatingsystem.go
+++ b/redfish/operatingsystem.go
@@ -214,26 +214,13 @@ func (operatingsystem *OperatingSystem) Containers() ([]*Container, error) {
 
 // GetOperatingSystem will get a OperatingSystem instance from the service.
 func GetOperatingSystem(c common.Client, uri string) (*OperatingSystem, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var operatingsystem OperatingSystem
-	err = json.NewDecoder(resp.Body).Decode(&operatingsystem)
-	if err != nil {
-		return nil, err
-	}
-
-	operatingsystem.SetClient(c)
-	return &operatingsystem, nil
+	return common.GetObject[OperatingSystem](c, uri)
 }
 
 // ListReferencedOperatingSystems gets the collection of OperatingSystem from
 // a provided reference.
 func ListReferencedOperatingSystems(c common.Client, link string) ([]*OperatingSystem, error) {
-	return common.GetCollectionObjects(c, link, GetOperatingSystem)
+	return common.GetCollectionObjects[OperatingSystem](c, link)
 }
 
 // VirtualMachineEngine shall contain a virtual machine engine running in an operating system.

--- a/redfish/outboundconnection.go
+++ b/redfish/outboundconnection.go
@@ -181,26 +181,13 @@ func (outboundconnection *OutboundConnection) Update() error {
 
 // GetOutboundConnection will get a OutboundConnection instance from the service.
 func GetOutboundConnection(c common.Client, uri string) (*OutboundConnection, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var outboundconnection OutboundConnection
-	err = json.NewDecoder(resp.Body).Decode(&outboundconnection)
-	if err != nil {
-		return nil, err
-	}
-
-	outboundconnection.SetClient(c)
-	return &outboundconnection, nil
+	return common.GetObject[OutboundConnection](c, uri)
 }
 
 // ListReferencedOutboundConnections gets the collection of OutboundConnection from
 // a provided reference.
 func ListReferencedOutboundConnections(c common.Client, link string) ([]*OutboundConnection, error) {
-	return common.GetCollectionObjects(c, link, GetOutboundConnection)
+	return common.GetCollectionObjects[OutboundConnection](c, link)
 }
 
 // RetryPolicyType shall contain the retry policy for an outbound connection.

--- a/redfish/outlet.go
+++ b/redfish/outlet.go
@@ -361,26 +361,13 @@ func (outlet *Outlet) Update() error {
 
 // GetOutlet will get a Outlet instance from the service.
 func GetOutlet(c common.Client, uri string) (*Outlet, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var outlet Outlet
-	err = json.NewDecoder(resp.Body).Decode(&outlet)
-	if err != nil {
-		return nil, err
-	}
-
-	outlet.SetClient(c)
-	return &outlet, nil
+	return common.GetObject[Outlet](c, uri)
 }
 
 // ListReferencedOutlets gets the collection of Outlet from
 // a provided reference.
 func ListReferencedOutlets(c common.Client, link string) ([]*Outlet, error) {
-	return common.GetCollectionObjects(c, link, GetOutlet)
+	return common.GetCollectionObjects[Outlet](c, link)
 }
 
 // VoltageSensors shall contain properties that describe voltage sensor readings for an outlet.

--- a/redfish/outletgroup.go
+++ b/redfish/outletgroup.go
@@ -180,24 +180,11 @@ func (outletgroup *OutletGroup) Update() error {
 
 // GetOutletGroup will get a OutletGroup instance from the service.
 func GetOutletGroup(c common.Client, uri string) (*OutletGroup, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var outletgroup OutletGroup
-	err = json.NewDecoder(resp.Body).Decode(&outletgroup)
-	if err != nil {
-		return nil, err
-	}
-
-	outletgroup.SetClient(c)
-	return &outletgroup, nil
+	return common.GetObject[OutletGroup](c, uri)
 }
 
 // ListReferencedOutletGroups gets the collection of OutletGroup from
 // a provided reference.
 func ListReferencedOutletGroups(c common.Client, link string) ([]*OutletGroup, error) {
-	return common.GetCollectionObjects(c, link, GetOutletGroup)
+	return common.GetCollectionObjects[OutletGroup](c, link)
 }

--- a/redfish/pciedevice.go
+++ b/redfish/pciedevice.go
@@ -356,14 +356,13 @@ func (pciedevice *PCIeDevice) Update() error {
 
 // GetPCIeDevice will get a PCIeDevice instance from the service.
 func GetPCIeDevice(c common.Client, uri string) (*PCIeDevice, error) {
-	var pcieDevice PCIeDevice
-	return &pcieDevice, pcieDevice.Get(c, uri, &pcieDevice)
+	return common.GetObject[PCIeDevice](c, uri)
 }
 
 // ListReferencedPCIeDevices gets the collection of PCIeDevice from
 // a provided reference.
 func ListReferencedPCIeDevices(c common.Client, link string) ([]*PCIeDevice, error) {
-	return common.GetCollectionObjects(c, link, GetPCIeDevice)
+	return common.GetCollectionObjects[PCIeDevice](c, link)
 }
 
 // PCIeInterface properties shall be the definition for a PCIe Interface for a

--- a/redfish/pciefunction.go
+++ b/redfish/pciefunction.go
@@ -214,14 +214,13 @@ func (pciefunction *PCIeFunction) UnmarshalJSON(b []byte) error {
 
 // GetPCIeFunction will get a PCIeFunction instance from the service.
 func GetPCIeFunction(c common.Client, uri string) (*PCIeFunction, error) {
-	var pcieFunction PCIeFunction
-	return &pcieFunction, pcieFunction.Get(c, uri, &pcieFunction)
+	return common.GetObject[PCIeFunction](c, uri)
 }
 
 // ListReferencedPCIeFunctions gets the collection of PCIeFunction from
 // a provided reference.
 func ListReferencedPCIeFunctions(c common.Client, link string) ([]*PCIeFunction, error) {
-	return common.GetCollectionObjects(c, link, GetPCIeFunction)
+	return common.GetCollectionObjects[PCIeFunction](c, link)
 }
 
 // CXLLogicalDevice gets the CXL logical device to which this PCIe function is assigned.

--- a/redfish/pcieslots.go
+++ b/redfish/pcieslots.go
@@ -185,6 +185,5 @@ func (pcieSlots *PCIeSlots) UnmarshalJSON(b []byte) error {
 
 // GetPCIeSlots will get a PCIeSlots instance from the chassis.
 func GetPCIeSlots(c common.Client, uri string) (*PCIeSlots, error) {
-	var pcieSlots PCIeSlots
-	return &pcieSlots, pcieSlots.Get(c, uri, &pcieSlots)
+	return common.GetObject[PCIeSlots](c, uri)
 }

--- a/redfish/port.go
+++ b/redfish/port.go
@@ -1127,14 +1127,13 @@ func (port *Port) Update() error {
 
 // GetPort will get a Port instance from the service.
 func GetPort(c common.Client, uri string) (*Port, error) {
-	var port Port
-	return &port, port.Get(c, uri, &port)
+	return common.GetObject[Port](c, uri)
 }
 
 // ListReferencedPorts gets the collection of Port from
 // a provided reference.
 func ListReferencedPorts(c common.Client, link string) ([]*Port, error) {
-	return common.GetCollectionObjects(c, link, GetPort)
+	return common.GetCollectionObjects[Port](c, link)
 }
 
 // ResetPort resets this port.

--- a/redfish/portmetrics.go
+++ b/redfish/portmetrics.go
@@ -221,26 +221,13 @@ type PortMetrics struct {
 
 // GetPortMetrics will get a PortMetrics instance from the service.
 func GetPortMetrics(c common.Client, uri string) (*PortMetrics, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var portmetrics PortMetrics
-	err = json.NewDecoder(resp.Body).Decode(&portmetrics)
-	if err != nil {
-		return nil, err
-	}
-
-	portmetrics.SetClient(c)
-	return &portmetrics, nil
+	return common.GetObject[PortMetrics](c, uri)
 }
 
 // ListReferencedPortMetricss gets the collection of PortMetrics from
 // a provided reference.
 func ListReferencedPortMetricss(c common.Client, link string) ([]*PortMetrics, error) {
-	return common.GetCollectionObjects(c, link, GetPortMetrics)
+	return common.GetCollectionObjects[PortMetrics](c, link)
 }
 
 // SASPortMetrics shall describe physical (phy) related metrics for Serial Attached SCSI (SAS).

--- a/redfish/power.go
+++ b/redfish/power.go
@@ -181,14 +181,13 @@ func (power *Power) PowerSupplyReset(memberID string, resetType ResetType) error
 
 // GetPower will get a Power instance from the service.
 func GetPower(c common.Client, uri string) (*Power, error) {
-	var power Power
-	return &power, power.Get(c, uri, &power)
+	return common.GetObject[Power](c, uri)
 }
 
 // ListReferencedPowers gets the collection of Power from
 // a provided reference.
 func ListReferencedPowers(c common.Client, link string) ([]*Power, error) {
-	return common.GetCollectionObjects(c, link, GetPower)
+	return common.GetCollectionObjects[Power](c, link)
 }
 
 type PowerControl struct {

--- a/redfish/powerdistribution.go
+++ b/redfish/powerdistribution.go
@@ -251,8 +251,7 @@ func (powerDistribution *PowerDistribution) UnmarshalJSON(b []byte) error {
 
 // GetPowerDistribution will get a PowerDistribution instance from the Redfish service.
 func GetPowerDistribution(c common.Client, uri string) (*PowerDistribution, error) {
-	var powerDistribution PowerDistribution
-	return &powerDistribution, powerDistribution.Get(c, uri, &powerDistribution)
+	return common.GetObject[PowerDistribution](c, uri)
 }
 
 // Update commits updates to this object's properties to the running system.
@@ -305,7 +304,7 @@ func (powerDistribution *PowerDistribution) TransferControl() error {
 // ListReferencedPowerDistribution gets the collection of PowerDistribution from
 // a provided reference.
 func ListReferencedPowerDistributionUnits(c common.Client, link string) ([]*PowerDistribution, error) {
-	return common.GetCollectionObjects(c, link, GetPowerDistribution)
+	return common.GetCollectionObjects[PowerDistribution](c, link)
 }
 
 // Deprecated: (v1.3) in favor of the Sensors link in the Chassis resource.

--- a/redfish/powerdistributionmetrics.go
+++ b/redfish/powerdistributionmetrics.go
@@ -78,8 +78,7 @@ func (metrics *PowerDistributionMetrics) UnmarshalJSON(b []byte) error {
 
 // GetPowerDistributionMetrics will get a PowerDistributionMetrics instance from the Redfish service.
 func GetPowerDistributionMetrics(c common.Client, uri string) (*PowerDistributionMetrics, error) {
-	var metrics PowerDistributionMetrics
-	return &metrics, metrics.Get(c, uri, &metrics)
+	return common.GetObject[PowerDistributionMetrics](c, uri)
 }
 
 // This action shall reset any time intervals or counted values for this equipment.

--- a/redfish/powerdomain.go
+++ b/redfish/powerdomain.go
@@ -254,24 +254,11 @@ func (powerdomain *PowerDomain) TransferSwitches() ([]*PowerDistribution, error)
 
 // GetPowerDomain will get a PowerDomain instance from the service.
 func GetPowerDomain(c common.Client, uri string) (*PowerDomain, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var powerdomain PowerDomain
-	err = json.NewDecoder(resp.Body).Decode(&powerdomain)
-	if err != nil {
-		return nil, err
-	}
-
-	powerdomain.SetClient(c)
-	return &powerdomain, nil
+	return common.GetObject[PowerDomain](c, uri)
 }
 
 // ListReferencedPowerDomains gets the collection of PowerDomain from
 // a provided reference.
 func ListReferencedPowerDomains(c common.Client, link string) ([]*PowerDomain, error) {
-	return common.GetCollectionObjects(c, link, GetPowerDomain)
+	return common.GetCollectionObjects[PowerDomain](c, link)
 }

--- a/redfish/powerequipment.go
+++ b/redfish/powerequipment.go
@@ -97,8 +97,7 @@ func (powerEquipment *PowerEquipment) UnmarshalJSON(b []byte) error {
 
 // GetPowerEquipment will get a PowerEquipment instance from the Redfish service.
 func GetPowerEquipment(c common.Client, uri string) (*PowerEquipment, error) {
-	var powerEquipment PowerEquipment
-	return &powerEquipment, powerEquipment.Get(c, uri, &powerEquipment)
+	return common.GetObject[PowerEquipment](c, uri)
 }
 
 // ManagedBy gets the collection of managers of this PowerEquipment

--- a/redfish/powersubsystem.go
+++ b/redfish/powersubsystem.go
@@ -98,24 +98,11 @@ func (powersubsystem *PowerSubsystem) PowerSupplies() ([]*PowerSupply, error) {
 
 // GetPowerSubsystem will get a PowerSubsystem instance from the service.
 func GetPowerSubsystem(c common.Client, uri string) (*PowerSubsystem, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var powersubsystem PowerSubsystem
-	err = json.NewDecoder(resp.Body).Decode(&powersubsystem)
-	if err != nil {
-		return nil, err
-	}
-
-	powersubsystem.SetClient(c)
-	return &powersubsystem, nil
+	return common.GetObject[PowerSubsystem](c, uri)
 }
 
 // ListReferencedPowerSubsystems gets the collection of PowerSubsystem from
 // a provided reference.
 func ListReferencedPowerSubsystems(c common.Client, link string) ([]*PowerSubsystem, error) {
-	return common.GetCollectionObjects(c, link, GetPowerSubsystem)
+	return common.GetCollectionObjects[PowerSubsystem](c, link)
 }

--- a/redfish/powersupplyunit.go
+++ b/redfish/powersupplyunit.go
@@ -231,14 +231,13 @@ func (powerSupplyUnit *PowerSupplyUnit) Update() error {
 
 // GetPowerSupplyUnit will get a PowerSupplyUnit instance from the Redfish service.
 func GetPowerSupplyUnit(c common.Client, uri string) (*PowerSupplyUnit, error) {
-	var powerSupplyUnit PowerSupplyUnit
-	return &powerSupplyUnit, powerSupplyUnit.Get(c, uri, &powerSupplyUnit)
+	return common.GetObject[PowerSupplyUnit](c, uri)
 }
 
 // ListReferencedPowerSupplyUnits gets the collection of PowerSupplies from
 // a provided reference.
 func ListReferencedPowerSupplyUnits(c common.Client, link string) ([]*PowerSupplyUnit, error) {
-	return common.GetCollectionObjects(c, link, GetPowerSupplyUnit)
+	return common.GetCollectionObjects[PowerSupplyUnit](c, link)
 }
 
 // This action shall reset a power supply. A GracefulRestart ResetType shall reset the power supply

--- a/redfish/powersupplyunitmetrics.go
+++ b/redfish/powersupplyunitmetrics.go
@@ -106,8 +106,7 @@ func (metrics *PowerSupplyUnitMetrics) UnmarshalJSON(b []byte) error {
 
 // GetPowerSupplyUnitMetrics will get a PowerSupplyMetrics instance from the Redfish service.
 func GetPowerSupplyUnitMetrics(c common.Client, uri string) (*PowerSupplyUnitMetrics, error) {
-	var metrics PowerSupplyUnitMetrics
-	return &metrics, metrics.Get(c, uri, &metrics)
+	return common.GetObject[PowerSupplyUnitMetrics](c, uri)
 }
 
 // This action resets the summary metrics related to this equipment.

--- a/redfish/privilegeregistry.go
+++ b/redfish/privilegeregistry.go
@@ -70,26 +70,13 @@ type PrivilegeRegistry struct {
 
 // GetPrivilegeRegistry will get a PrivilegeRegistry instance from the service.
 func GetPrivilegeRegistry(c common.Client, uri string) (*PrivilegeRegistry, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var privilegeregistry PrivilegeRegistry
-	err = json.NewDecoder(resp.Body).Decode(&privilegeregistry)
-	if err != nil {
-		return nil, err
-	}
-
-	privilegeregistry.SetClient(c)
-	return &privilegeregistry, nil
+	return common.GetObject[PrivilegeRegistry](c, uri)
 }
 
 // ListReferencedPrivilegeRegistrys gets the collection of PrivilegeRegistry from
 // a provided reference.
 func ListReferencedPrivilegeRegistrys(c common.Client, link string) ([]*PrivilegeRegistry, error) {
-	return common.GetCollectionObjects(c, link, GetPrivilegeRegistry)
+	return common.GetCollectionObjects[PrivilegeRegistry](c, link)
 }
 
 // TargetPrivilegeMap shall describe a mapping between one or more targets and the HTTP operations associated with

--- a/redfish/processor.go
+++ b/redfish/processor.go
@@ -1019,13 +1019,12 @@ func (processor *Processor) PCIeFunctions() ([]*PCIeFunction, error) {
 
 // GetProcessor will get a Processor instance from the system
 func GetProcessor(c common.Client, uri string) (*Processor, error) {
-	var processor Processor
-	return &processor, processor.Get(c, uri, &processor)
+	return common.GetObject[Processor](c, uri)
 }
 
 // ListReferencedProcessors gets the collection of Processor from a provided reference.
 func ListReferencedProcessors(c common.Client, link string) ([]*Processor, error) {
-	return common.GetCollectionObjects(c, link, GetProcessor)
+	return common.GetCollectionObjects[Processor](c, link)
 }
 
 // ProcessorID shall contain identification information for a processor.

--- a/redfish/processormetrics.go
+++ b/redfish/processormetrics.go
@@ -226,24 +226,11 @@ func (processormetrics *ProcessorMetrics) ClearCurrentPeriod() error {
 
 // GetProcessorMetrics will get a ProcessorMetrics instance from the service.
 func GetProcessorMetrics(c common.Client, uri string) (*ProcessorMetrics, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var processormetrics ProcessorMetrics
-	err = json.NewDecoder(resp.Body).Decode(&processormetrics)
-	if err != nil {
-		return nil, err
-	}
-
-	processormetrics.SetClient(c)
-	return &processormetrics, nil
+	return common.GetObject[ProcessorMetrics](c, uri)
 }
 
 // ListReferencedProcessorMetricss gets the collection of ProcessorMetrics from
 // a provided reference.
 func ListReferencedProcessorMetricss(c common.Client, link string) ([]*ProcessorMetrics, error) {
-	return common.GetCollectionObjects(c, link, GetProcessorMetrics)
+	return common.GetCollectionObjects[ProcessorMetrics](c, link)
 }

--- a/redfish/pump.go
+++ b/redfish/pump.go
@@ -162,24 +162,11 @@ func (pump *Pump) Update() error {
 
 // GetPump will get a Pump instance from the service.
 func GetPump(c common.Client, uri string) (*Pump, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var pump Pump
-	err = json.NewDecoder(resp.Body).Decode(&pump)
-	if err != nil {
-		return nil, err
-	}
-
-	pump.SetClient(c)
-	return &pump, nil
+	return common.GetObject[Pump](c, uri)
 }
 
 // ListReferencedPumps gets the collection of Pump from
 // a provided reference.
 func ListReferencedPumps(c common.Client, link string) ([]*Pump, error) {
-	return common.GetCollectionObjects(c, link, GetPump)
+	return common.GetCollectionObjects[Pump](c, link)
 }

--- a/redfish/redundancy.go
+++ b/redfish/redundancy.go
@@ -115,14 +115,13 @@ func (redundancy *Redundancy) Update() error {
 
 // GetRedundancy will get a Redundancy instance from the service.
 func GetRedundancy(c common.Client, uri string) (*Redundancy, error) {
-	var redundancy Redundancy
-	return &redundancy, redundancy.Get(c, uri, &redundancy)
+	return common.GetObject[Redundancy](c, uri)
 }
 
 // ListReferencedRedundancies gets the collection of Redundancy from
 // a provided reference.
 func ListReferencedRedundancies(c common.Client, link string) ([]*Redundancy, error) {
-	return common.GetCollectionObjects(c, link, GetRedundancy)
+	return common.GetCollectionObjects[Redundancy](c, link)
 }
 
 // The redundancy mode of the group.

--- a/redfish/registeredclient.go
+++ b/redfish/registeredclient.go
@@ -127,24 +127,11 @@ func (registeredclient *RegisteredClient) Update() error {
 
 // GetRegisteredClient will get a RegisteredClient instance from the service.
 func GetRegisteredClient(c common.Client, uri string) (*RegisteredClient, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var registeredclient RegisteredClient
-	err = json.NewDecoder(resp.Body).Decode(&registeredclient)
-	if err != nil {
-		return nil, err
-	}
-
-	registeredclient.SetClient(c)
-	return &registeredclient, nil
+	return common.GetObject[RegisteredClient](c, uri)
 }
 
 // ListReferencedRegisteredClients gets the collection of RegisteredClient from
 // a provided reference.
 func ListReferencedRegisteredClients(c common.Client, link string) ([]*RegisteredClient, error) {
-	return common.GetCollectionObjects(c, link, GetRegisteredClient)
+	return common.GetCollectionObjects[RegisteredClient](c, link)
 }

--- a/redfish/reservoir.go
+++ b/redfish/reservoir.go
@@ -164,24 +164,11 @@ func (reservoir *Reservoir) Update() error {
 
 // GetReservoir will get a Reservoir instance from the service.
 func GetReservoir(c common.Client, uri string) (*Reservoir, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var reservoir Reservoir
-	err = json.NewDecoder(resp.Body).Decode(&reservoir)
-	if err != nil {
-		return nil, err
-	}
-
-	reservoir.SetClient(c)
-	return &reservoir, nil
+	return common.GetObject[Reservoir](c, uri)
 }
 
 // ListReferencedReservoirs gets the collection of Reservoir from
 // a provided reference.
 func ListReferencedReservoirs(c common.Client, link string) ([]*Reservoir, error) {
-	return common.GetCollectionObjects(c, link, GetReservoir)
+	return common.GetCollectionObjects[Reservoir](c, link)
 }

--- a/redfish/resource.go
+++ b/redfish/resource.go
@@ -458,26 +458,13 @@ type Resource struct {
 
 // GetResource will get a Resource instance from the service.
 func GetResource(c common.Client, uri string) (*Resource, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var resource Resource
-	err = json.NewDecoder(resp.Body).Decode(&resource)
-	if err != nil {
-		return nil, err
-	}
-
-	resource.SetClient(c)
-	return &resource, nil
+	return common.GetObject[Resource](c, uri)
 }
 
 // ListReferencedResources gets the collection of Resource from
 // a provided reference.
 func ListReferencedResources(c common.Client, link string) ([]*Resource, error) {
-	return common.GetCollectionObjects(c, link, GetResource)
+	return common.GetCollectionObjects[Resource](c, link)
 }
 
 // ResourceCollection

--- a/redfish/resourceblock.go
+++ b/redfish/resourceblock.go
@@ -285,26 +285,13 @@ func (resourceblock *ResourceBlock) Update() error {
 
 // GetResourceBlock will get a ResourceBlock instance from the service.
 func GetResourceBlock(c common.Client, uri string) (*ResourceBlock, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var resourceblock ResourceBlock
-	err = json.NewDecoder(resp.Body).Decode(&resourceblock)
-	if err != nil {
-		return nil, err
-	}
-
-	resourceblock.SetClient(c)
-	return &resourceblock, nil
+	return common.GetObject[ResourceBlock](c, uri)
 }
 
 // ListReferencedResourceBlocks gets the collection of ResourceBlock from
 // a provided reference.
 func ListReferencedResourceBlocks(c common.Client, link string) ([]*ResourceBlock, error) {
-	return common.GetCollectionObjects(c, link, GetResourceBlock)
+	return common.GetCollectionObjects[ResourceBlock](c, link)
 }
 
 // ResourceBlockLimits shall specify the allowable quantities of types of resource blocks for a given composition

--- a/redfish/role.go
+++ b/redfish/role.go
@@ -125,12 +125,11 @@ func (role *Role) Update() error {
 
 // GetRole will get a Role instance from the service.
 func GetRole(c common.Client, uri string) (*Role, error) {
-	var role Role
-	return &role, role.Get(c, uri, &role)
+	return common.GetObject[Role](c, uri)
 }
 
 // ListReferencedRoles gets the collection of Role from
 // a provided reference.
 func ListReferencedRoles(c common.Client, link string) ([]*Role, error) {
-	return common.GetCollectionObjects(c, link, GetRole)
+	return common.GetCollectionObjects[Role](c, link)
 }

--- a/redfish/routeentry.go
+++ b/redfish/routeentry.go
@@ -84,24 +84,11 @@ func (routeentry *RouteEntry) Update() error {
 
 // GetRouteEntry will get a RouteEntry instance from the service.
 func GetRouteEntry(c common.Client, uri string) (*RouteEntry, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var routeentry RouteEntry
-	err = json.NewDecoder(resp.Body).Decode(&routeentry)
-	if err != nil {
-		return nil, err
-	}
-
-	routeentry.SetClient(c)
-	return &routeentry, nil
+	return common.GetObject[RouteEntry](c, uri)
 }
 
 // ListReferencedRouteEntrys gets the collection of RouteEntry from
 // a provided reference.
 func ListReferencedRouteEntrys(c common.Client, link string) ([]*RouteEntry, error) {
-	return common.GetCollectionObjects(c, link, GetRouteEntry)
+	return common.GetCollectionObjects[RouteEntry](c, link)
 }

--- a/redfish/routesetentry.go
+++ b/redfish/routesetentry.go
@@ -81,24 +81,11 @@ func (routesetentry *RouteSetEntry) Update() error {
 
 // GetRouteSetEntry will get a RouteSetEntry instance from the service.
 func GetRouteSetEntry(c common.Client, uri string) (*RouteSetEntry, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var routesetentry RouteSetEntry
-	err = json.NewDecoder(resp.Body).Decode(&routesetentry)
-	if err != nil {
-		return nil, err
-	}
-
-	routesetentry.SetClient(c)
-	return &routesetentry, nil
+	return common.GetObject[RouteSetEntry](c, uri)
 }
 
 // ListReferencedRouteSetEntrys gets the collection of RouteSetEntry from
 // a provided reference.
 func ListReferencedRouteSetEntrys(c common.Client, link string) ([]*RouteSetEntry, error) {
-	return common.GetCollectionObjects(c, link, GetRouteSetEntry)
+	return common.GetCollectionObjects[RouteSetEntry](c, link)
 }

--- a/redfish/schedule.go
+++ b/redfish/schedule.go
@@ -139,24 +139,11 @@ func (schedule *Schedule) Update() error {
 
 // GetSchedule will get a Schedule instance from the service.
 func GetSchedule(c common.Client, uri string) (*Schedule, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var schedule Schedule
-	err = json.NewDecoder(resp.Body).Decode(&schedule)
-	if err != nil {
-		return nil, err
-	}
-
-	schedule.SetClient(c)
-	return &schedule, nil
+	return common.GetObject[Schedule](c, uri)
 }
 
 // ListReferencedSchedules gets the collection of Schedule from
 // a provided reference.
 func ListReferencedSchedules(c common.Client, link string) ([]*Schedule, error) {
-	return common.GetCollectionObjects(c, link, GetSchedule)
+	return common.GetCollectionObjects[Schedule](c, link)
 }

--- a/redfish/secureboot.go
+++ b/redfish/secureboot.go
@@ -127,14 +127,13 @@ func (secureboot *SecureBoot) Update() error {
 
 // GetSecureBoot will get a SecureBoot instance from the service.
 func GetSecureBoot(c common.Client, uri string) (*SecureBoot, error) {
-	var secureBoot SecureBoot
-	return &secureBoot, secureBoot.Get(c, uri, &secureBoot)
+	return common.GetObject[SecureBoot](c, uri)
 }
 
 // ListReferencedSecureBoots gets the collection of SecureBoot from
 // a provided reference.
 func ListReferencedSecureBoots(c common.Client, link string) ([]*SecureBoot, error) {
-	return common.GetCollectionObjects(c, link, GetSecureBoot)
+	return common.GetCollectionObjects[SecureBoot](c, link)
 }
 
 // ResetKeys shall perform a reset of the Secure Boot key databases. The

--- a/redfish/securebootdatabase.go
+++ b/redfish/securebootdatabase.go
@@ -99,24 +99,11 @@ func (securebootdatabase *SecureBootDatabase) ResetKeys(resetType ResetKeysType)
 
 // GetSecureBootDatabase will get a SecureBootDatabase instance from the service.
 func GetSecureBootDatabase(c common.Client, uri string) (*SecureBootDatabase, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var securebootdatabase SecureBootDatabase
-	err = json.NewDecoder(resp.Body).Decode(&securebootdatabase)
-	if err != nil {
-		return nil, err
-	}
-
-	securebootdatabase.SetClient(c)
-	return &securebootdatabase, nil
+	return common.GetObject[SecureBootDatabase](c, uri)
 }
 
 // ListReferencedSecureBootDatabases gets the collection of SecureBootDatabase from
 // a provided reference.
 func ListReferencedSecureBootDatabases(c common.Client, link string) ([]*SecureBootDatabase, error) {
-	return common.GetCollectionObjects(c, link, GetSecureBootDatabase)
+	return common.GetCollectionObjects[SecureBootDatabase](c, link)
 }

--- a/redfish/securitypolicy.go
+++ b/redfish/securitypolicy.go
@@ -181,26 +181,13 @@ func (securitypolicy *SecurityPolicy) Update() error {
 
 // GetSecurityPolicy will get a SecurityPolicy instance from the service.
 func GetSecurityPolicy(c common.Client, uri string) (*SecurityPolicy, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var securitypolicy SecurityPolicy
-	err = json.NewDecoder(resp.Body).Decode(&securitypolicy)
-	if err != nil {
-		return nil, err
-	}
-
-	securitypolicy.SetClient(c)
-	return &securitypolicy, nil
+	return common.GetObject[SecurityPolicy](c, uri)
 }
 
 // ListReferencedSecurityPolicys gets the collection of SecurityPolicy from
 // a provided reference.
 func ListReferencedSecurityPolicys(c common.Client, link string) ([]*SecurityPolicy, error) {
-	return common.GetCollectionObjects(c, link, GetSecurityPolicy)
+	return common.GetCollectionObjects[SecurityPolicy](c, link)
 }
 
 // TLSAlgorithmSet shall contain TLS algorithm settings.

--- a/redfish/sensor.go
+++ b/redfish/sensor.go
@@ -483,13 +483,12 @@ func (sensor *Sensor) UnmarshalJSON(b []byte) error {
 
 // GetSensor will get a Sensor instance from the Redfish service.
 func GetSensor(c common.Client, uri string) (*Sensor, error) {
-	var sensor Sensor
-	return &sensor, sensor.Get(c, uri, &sensor)
+	return common.GetObject[Sensor](c, uri)
 }
 
 // ListReferencedSensor gets the Sensor collection.
 func ListReferencedSensors(c common.Client, link string) ([]*Sensor, error) {
-	return common.GetCollectionObjects(c, link, GetSensor)
+	return common.GetCollectionObjects[Sensor](c, link)
 }
 
 func (sensor *Sensor) ResetMetrics() error {

--- a/redfish/serialinterface.go
+++ b/redfish/serialinterface.go
@@ -215,12 +215,11 @@ func (serialInterface *SerialInterface) Update() error {
 
 // GetSerialInterface will get a SerialInterface instance from the service.
 func GetSerialInterface(c common.Client, uri string) (*SerialInterface, error) {
-	var serialInterface SerialInterface
-	return &serialInterface, serialInterface.Get(c, uri, &serialInterface)
+	return common.GetObject[SerialInterface](c, uri)
 }
 
 // ListReferencedSerialInterfaces gets the collection of SerialInterface from
 // a provided reference.
 func ListReferencedSerialInterfaces(c common.Client, link string) ([]*SerialInterface, error) {
-	return common.GetCollectionObjects(c, link, GetSerialInterface)
+	return common.GetCollectionObjects[SerialInterface](c, link)
 }

--- a/redfish/serviceconditions.go
+++ b/redfish/serviceconditions.go
@@ -35,24 +35,11 @@ type ServiceConditions struct {
 
 // GetServiceConditions will get a ServiceConditions instance from the service.
 func GetServiceConditions(c common.Client, uri string) (*ServiceConditions, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var serviceconditions ServiceConditions
-	err = json.NewDecoder(resp.Body).Decode(&serviceconditions)
-	if err != nil {
-		return nil, err
-	}
-
-	serviceconditions.SetClient(c)
-	return &serviceconditions, nil
+	return common.GetObject[ServiceConditions](c, uri)
 }
 
 // ListReferencedServiceConditionss gets the collection of ServiceConditions from
 // a provided reference.
 func ListReferencedServiceConditionss(c common.Client, link string) ([]*ServiceConditions, error) {
-	return common.GetCollectionObjects(c, link, GetServiceConditions)
+	return common.GetCollectionObjects[ServiceConditions](c, link)
 }

--- a/redfish/session.go
+++ b/redfish/session.go
@@ -170,11 +170,10 @@ func DeleteSession(c common.Client, sessionURL string) (err error) {
 
 // GetSession will get a Session instance from the Redfish service.
 func GetSession(c common.Client, uri string) (*Session, error) {
-	var session Session
-	return &session, session.Get(c, uri, &session)
+	return common.GetObject[Session](c, uri)
 }
 
 // ListReferencedSessions gets the collection of Sessions
 func ListReferencedSessions(c common.Client, link string) ([]*Session, error) {
-	return common.GetCollectionObjects(c, link, GetSession)
+	return common.GetCollectionObjects[Session](c, link)
 }

--- a/redfish/sessionservice.go
+++ b/redfish/sessionservice.go
@@ -90,24 +90,11 @@ func (sessionservice *SessionService) Update() error {
 
 // GetSessionService will get a SessionService instance from the service.
 func GetSessionService(c common.Client, uri string) (*SessionService, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var sessionservice SessionService
-	err = json.NewDecoder(resp.Body).Decode(&sessionservice)
-	if err != nil {
-		return nil, err
-	}
-
-	sessionservice.SetClient(c)
-	return &sessionservice, nil
+	return common.GetObject[SessionService](c, uri)
 }
 
 // ListReferencedSessionServices gets the collection of SessionService from
 // a provided reference.
 func ListReferencedSessionServices(c common.Client, link string) ([]*SessionService, error) {
-	return common.GetCollectionObjects(c, link, GetSessionService)
+	return common.GetCollectionObjects[SessionService](c, link)
 }

--- a/redfish/signature.go
+++ b/redfish/signature.go
@@ -48,24 +48,11 @@ type Signature struct {
 
 // GetSignature will get a Signature instance from the service.
 func GetSignature(c common.Client, uri string) (*Signature, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var signature Signature
-	err = json.NewDecoder(resp.Body).Decode(&signature)
-	if err != nil {
-		return nil, err
-	}
-
-	signature.SetClient(c)
-	return &signature, nil
+	return common.GetObject[Signature](c, uri)
 }
 
 // ListReferencedSignatures gets the collection of Signature from
 // a provided reference.
 func ListReferencedSignatures(c common.Client, link string) ([]*Signature, error) {
-	return common.GetCollectionObjects(c, link, GetSignature)
+	return common.GetCollectionObjects[Signature](c, link)
 }

--- a/redfish/simplestorage.go
+++ b/redfish/simplestorage.go
@@ -84,14 +84,13 @@ func (simplestorage *SimpleStorage) UnmarshalJSON(b []byte) error {
 
 // GetSimpleStorage will get a SimpleStorage instance from the service.
 func GetSimpleStorage(c common.Client, uri string) (*SimpleStorage, error) {
-	var simpleStorage SimpleStorage
-	return &simpleStorage, simpleStorage.Get(c, uri, &simpleStorage)
+	return common.GetObject[SimpleStorage](c, uri)
 }
 
 // ListReferencedSimpleStorages gets the collection of SimpleStorage from
 // a provided reference.
 func ListReferencedSimpleStorages(c common.Client, link string) ([]*SimpleStorage, error) {
-	return common.GetCollectionObjects(c, link, GetSimpleStorage)
+	return common.GetCollectionObjects[SimpleStorage](c, link)
 }
 
 // Chassis gets the chassis containing this storage service.

--- a/redfish/softwareinventory.go
+++ b/redfish/softwareinventory.go
@@ -171,12 +171,11 @@ func (softwareinventory *SoftwareInventory) Update() error {
 
 // GetSoftwareInventory will get a SoftwareInventory instance from the service.
 func GetSoftwareInventory(c common.Client, uri string) (*SoftwareInventory, error) {
-	var softwareInventory SoftwareInventory
-	return &softwareInventory, softwareInventory.Get(c, uri, &softwareInventory)
+	return common.GetObject[SoftwareInventory](c, uri)
 }
 
 // ListReferencedSoftwareInventories gets the collection of SoftwareInventory from
 // a provided reference.
 func ListReferencedSoftwareInventories(c common.Client, link string) ([]*SoftwareInventory, error) {
-	return common.GetCollectionObjects(c, link, GetSoftwareInventory)
+	return common.GetCollectionObjects[SoftwareInventory](c, link)
 }

--- a/redfish/storage.go
+++ b/redfish/storage.go
@@ -451,14 +451,13 @@ func (storage *Storage) Update() error {
 
 // GetStorage will get a Storage instance from the service.
 func GetStorage(c common.Client, uri string) (*Storage, error) {
-	var storage Storage
-	return &storage, storage.Get(c, uri, &storage)
+	return common.GetObject[Storage](c, uri)
 }
 
 // ListReferencedStorages gets the collection of Storage from a provided
 // reference.
 func ListReferencedStorages(c common.Client, link string) ([]*Storage, error) {
-	return common.GetCollectionObjects(c, link, GetStorage)
+	return common.GetCollectionObjects[Storage](c, link)
 }
 
 // GetOperationApplyTimeValues returns the OperationApplyTime values applicable for this storage

--- a/redfish/storagecontroller.go
+++ b/redfish/storagecontroller.go
@@ -530,12 +530,11 @@ func (storagecontroller *StorageController) Update() error {
 
 // GetStorageController will get a Storage controller instance from the service.
 func GetStorageController(c common.Client, uri string) (*StorageController, error) {
-	var storageController StorageController
-	return &storageController, storageController.Get(c, uri, &storageController)
+	return common.GetObject[StorageController](c, uri)
 }
 
 // ListReferencedStorageControllers gets the collection of StorageControllers
 // from a provided reference.
 func ListReferencedStorageControllers(c common.Client, link string) ([]*StorageController, error) {
-	return common.GetCollectionObjects(c, link, GetStorageController)
+	return common.GetCollectionObjects[StorageController](c, link)
 }

--- a/redfish/storagecontrollermetrics.go
+++ b/redfish/storagecontrollermetrics.go
@@ -5,8 +5,6 @@
 package redfish
 
 import (
-	"encoding/json"
-
 	"github.com/stmcginnis/gofish/common"
 )
 
@@ -143,24 +141,11 @@ type StorageControllerMetrics struct {
 
 // GetStorageControllerMetrics will get a StorageControllerMetrics instance from the service.
 func GetStorageControllerMetrics(c common.Client, uri string) (*StorageControllerMetrics, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var storagecontrollermetrics StorageControllerMetrics
-	err = json.NewDecoder(resp.Body).Decode(&storagecontrollermetrics)
-	if err != nil {
-		return nil, err
-	}
-
-	storagecontrollermetrics.SetClient(c)
-	return &storagecontrollermetrics, nil
+	return common.GetObject[StorageControllerMetrics](c, uri)
 }
 
 // ListReferencedStorageControllerMetrics gets the collection of StorageControllerMetrics from
 // a provided reference.
 func ListReferencedStorageControllerMetrics(c common.Client, link string) ([]*StorageControllerMetrics, error) {
-	return common.GetCollectionObjects(c, link, GetStorageControllerMetrics)
+	return common.GetCollectionObjects[StorageControllerMetrics](c, link)
 }

--- a/redfish/switch.go
+++ b/redfish/switch.go
@@ -285,26 +285,13 @@ func (sw *Switch) Update() error {
 
 // GetSwitch will get a Switch instance from the service.
 func GetSwitch(c common.Client, uri string) (*Switch, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var sw Switch
-	err = json.NewDecoder(resp.Body).Decode(&sw)
-	if err != nil {
-		return nil, err
-	}
-
-	sw.SetClient(c)
-	return &sw, nil
+	return common.GetObject[Switch](c, uri)
 }
 
 // ListReferencedSwitches gets the collection of Switch from
 // a provided reference.
 func ListReferencedSwitches(c common.Client, link string) ([]*Switch, error) {
-	return common.GetCollectionObjects(c, link, GetSwitch)
+	return common.GetCollectionObjects[Switch](c, link)
 }
 
 // VCSSwitch shall contain Virtual CXL Switch (VCS) properties for a switch.

--- a/redfish/switchmetrics.go
+++ b/redfish/switchmetrics.go
@@ -92,24 +92,11 @@ func (switchmetrics *SwitchMetrics) ClearCurrentPeriod() error {
 
 // GetSwitchMetrics will get a SwitchMetrics instance from the service.
 func GetSwitchMetrics(c common.Client, uri string) (*SwitchMetrics, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var switchmetrics SwitchMetrics
-	err = json.NewDecoder(resp.Body).Decode(&switchmetrics)
-	if err != nil {
-		return nil, err
-	}
-
-	switchmetrics.SetClient(c)
-	return &switchmetrics, nil
+	return common.GetObject[SwitchMetrics](c, uri)
 }
 
 // ListReferencedSwitchMetricss gets the collection of SwitchMetrics from
 // a provided reference.
 func ListReferencedSwitchMetricss(c common.Client, link string) ([]*SwitchMetrics, error) {
-	return common.GetCollectionObjects(c, link, GetSwitchMetrics)
+	return common.GetCollectionObjects[SwitchMetrics](c, link)
 }

--- a/redfish/task.go
+++ b/redfish/task.go
@@ -185,12 +185,11 @@ func (task *Task) SubTasks() ([]*Task, error) {
 
 // GetTask will get a Task instance from the service.
 func GetTask(c common.Client, uri string) (*Task, error) {
-	var task Task
-	return &task, task.Get(c, uri, &task)
+	return common.GetObject[Task](c, uri)
 }
 
 // ListReferencedTasks gets the collection of Task from
 // a provided reference.
 func ListReferencedTasks(c common.Client, link string) ([]*Task, error) {
-	return common.GetCollectionObjects(c, link, GetTask)
+	return common.GetCollectionObjects[Task](c, link)
 }

--- a/redfish/taskervice.go
+++ b/redfish/taskervice.go
@@ -101,6 +101,5 @@ func (taskService *TaskService) Update() error {
 
 // GetTaskService will get a TaskService instance from the service.
 func GetTaskService(c common.Client, uri string) (*TaskService, error) {
-	var taskService TaskService
-	return &taskService, taskService.Get(c, uri, &taskService)
+	return common.GetObject[TaskService](c, uri)
 }

--- a/redfish/telemetryservice.go
+++ b/redfish/telemetryservice.go
@@ -213,24 +213,11 @@ func (telemetryservice *TelemetryService) Update() error {
 
 // GetTelemetryService will get a TelemetryService instance from the service.
 func GetTelemetryService(c common.Client, uri string) (*TelemetryService, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var telemetryservice TelemetryService
-	err = json.NewDecoder(resp.Body).Decode(&telemetryservice)
-	if err != nil {
-		return nil, err
-	}
-
-	telemetryservice.SetClient(c)
-	return &telemetryservice, nil
+	return common.GetObject[TelemetryService](c, uri)
 }
 
 // ListReferencedTelemetryServices gets the collection of TelemetryService from
 // a provided reference.
 func ListReferencedTelemetryServices(c common.Client, link string) ([]*TelemetryService, error) {
-	return common.GetCollectionObjects(c, link, GetTelemetryService)
+	return common.GetCollectionObjects[TelemetryService](c, link)
 }

--- a/redfish/thermal.go
+++ b/redfish/thermal.go
@@ -369,11 +369,10 @@ func (thermal *Thermal) Update() error {
 
 // GetThermal will get a Thermal instance from the service.
 func GetThermal(c common.Client, uri string) (*Thermal, error) {
-	var thermal Thermal
-	return &thermal, thermal.Get(c, uri, &thermal)
+	return common.GetObject[Thermal](c, uri)
 }
 
 // ListReferencedThermals gets the collection of Thermal from a provided reference.
 func ListReferencedThermals(c common.Client, link string) ([]*Thermal, error) {
-	return common.GetCollectionObjects(c, link, GetThermal)
+	return common.GetCollectionObjects[Thermal](c, link)
 }

--- a/redfish/thermalequipment.go
+++ b/redfish/thermalequipment.go
@@ -92,24 +92,11 @@ func (thermalequipment *ThermalEquipment) ImmersionUnits() ([]*CoolingUnit, erro
 
 // GetThermalEquipment will get a ThermalEquipment instance from the service.
 func GetThermalEquipment(c common.Client, uri string) (*ThermalEquipment, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var thermalequipment ThermalEquipment
-	err = json.NewDecoder(resp.Body).Decode(&thermalequipment)
-	if err != nil {
-		return nil, err
-	}
-
-	thermalequipment.SetClient(c)
-	return &thermalequipment, nil
+	return common.GetObject[ThermalEquipment](c, uri)
 }
 
 // ListReferencedThermalEquipments gets the collection of ThermalEquipment from
 // a provided reference.
 func ListReferencedThermalEquipments(c common.Client, link string) ([]*ThermalEquipment, error) {
-	return common.GetCollectionObjects(c, link, GetThermalEquipment)
+	return common.GetCollectionObjects[ThermalEquipment](c, link)
 }

--- a/redfish/thermalmetrics.go
+++ b/redfish/thermalmetrics.go
@@ -118,24 +118,11 @@ func (thermalmetrics *ThermalMetrics) ResetMetrics() error {
 
 // GetThermalMetrics will get a ThermalMetrics instance from the service.
 func GetThermalMetrics(c common.Client, uri string) (*ThermalMetrics, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var thermalmetrics ThermalMetrics
-	err = json.NewDecoder(resp.Body).Decode(&thermalmetrics)
-	if err != nil {
-		return nil, err
-	}
-
-	thermalmetrics.SetClient(c)
-	return &thermalmetrics, nil
+	return common.GetObject[ThermalMetrics](c, uri)
 }
 
 // ListReferencedThermalMetricss gets the collection of ThermalMetrics from
 // a provided reference.
 func ListReferencedThermalMetrics(c common.Client, link string) ([]*ThermalMetrics, error) {
-	return common.GetCollectionObjects(c, link, GetThermalMetrics)
+	return common.GetCollectionObjects[ThermalMetrics](c, link)
 }

--- a/redfish/thermalsubsystem.go
+++ b/redfish/thermalsubsystem.go
@@ -113,24 +113,11 @@ func (thermalsubsystem *ThermalSubsystem) ThermalMetrics() (*ThermalMetrics, err
 
 // GetThermalSubsystem will get a ThermalSubsystem instance from the service.
 func GetThermalSubsystem(c common.Client, uri string) (*ThermalSubsystem, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var thermalsubsystem ThermalSubsystem
-	err = json.NewDecoder(resp.Body).Decode(&thermalsubsystem)
-	if err != nil {
-		return nil, err
-	}
-
-	thermalsubsystem.SetClient(c)
-	return &thermalsubsystem, nil
+	return common.GetObject[ThermalSubsystem](c, uri)
 }
 
 // ListReferencedThermalSubsystems gets the collection of ThermalSubsystem from
 // a provided reference.
 func ListReferencedThermalSubsystems(c common.Client, link string) ([]*ThermalSubsystem, error) {
-	return common.GetCollectionObjects(c, link, GetThermalSubsystem)
+	return common.GetCollectionObjects[ThermalSubsystem](c, link)
 }

--- a/redfish/triggers.go
+++ b/redfish/triggers.go
@@ -265,24 +265,11 @@ func (triggers *Triggers) Update() error {
 
 // GetTriggers will get a Triggers instance from the service.
 func GetTriggers(c common.Client, uri string) (*Triggers, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var triggers Triggers
-	err = json.NewDecoder(resp.Body).Decode(&triggers)
-	if err != nil {
-		return nil, err
-	}
-
-	triggers.SetClient(c)
-	return &triggers, nil
+	return common.GetObject[Triggers](c, uri)
 }
 
 // ListReferencedTriggerss gets the collection of Triggers from
 // a provided reference.
 func ListReferencedTriggerss(c common.Client, link string) ([]*Triggers, error) {
-	return common.GetCollectionObjects(c, link, GetTriggers)
+	return common.GetCollectionObjects[Triggers](c, link)
 }

--- a/redfish/trustedcomponent.go
+++ b/redfish/trustedcomponent.go
@@ -242,24 +242,11 @@ func (trustedcomponent *TrustedComponent) TPMGetEventLog() (*TPMGetEventLogRespo
 
 // GetTrustedComponent will get a TrustedComponent instance from the service.
 func GetTrustedComponent(c common.Client, uri string) (*TrustedComponent, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var trustedcomponent TrustedComponent
-	err = json.NewDecoder(resp.Body).Decode(&trustedcomponent)
-	if err != nil {
-		return nil, err
-	}
-
-	trustedcomponent.SetClient(c)
-	return &trustedcomponent, nil
+	return common.GetObject[TrustedComponent](c, uri)
 }
 
 // ListReferencedTrustedComponents gets the collection of TrustedComponent from
 // a provided reference.
 func ListReferencedTrustedComponents(c common.Client, link string) ([]*TrustedComponent, error) {
-	return common.GetCollectionObjects(c, link, GetTrustedComponent)
+	return common.GetCollectionObjects[TrustedComponent](c, link)
 }

--- a/redfish/updateservice.go
+++ b/redfish/updateservice.go
@@ -392,6 +392,5 @@ func (updateService *UpdateService) SoftwareInventories() ([]*SoftwareInventory,
 
 // GetUpdateService will get a UpdateService instance from the service.
 func GetUpdateService(c common.Client, uri string) (*UpdateService, error) {
-	var updateService UpdateService
-	return &updateService, updateService.Get(c, uri, &updateService)
+	return common.GetObject[UpdateService](c, uri)
 }

--- a/redfish/usbcontroller.go
+++ b/redfish/usbcontroller.go
@@ -113,24 +113,11 @@ func (usbcontroller *USBController) Ports() ([]*Port, error) {
 
 // GetUSBController will get a USBController instance from the service.
 func GetUSBController(c common.Client, uri string) (*USBController, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var usbcontroller USBController
-	err = json.NewDecoder(resp.Body).Decode(&usbcontroller)
-	if err != nil {
-		return nil, err
-	}
-
-	usbcontroller.SetClient(c)
-	return &usbcontroller, nil
+	return common.GetObject[USBController](c, uri)
 }
 
 // ListReferencedUSBControllers gets the collection of USBController from
 // a provided reference.
 func ListReferencedUSBControllers(c common.Client, link string) ([]*USBController, error) {
-	return common.GetCollectionObjects(c, link, GetUSBController)
+	return common.GetCollectionObjects[USBController](c, link)
 }

--- a/redfish/vcatentry.go
+++ b/redfish/vcatentry.go
@@ -76,26 +76,13 @@ func (vcatentry *VCATEntry) Update() error {
 
 // GetVCATEntry will get a VCATEntry instance from the service.
 func GetVCATEntry(c common.Client, uri string) (*VCATEntry, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var vcatentry VCATEntry
-	err = json.NewDecoder(resp.Body).Decode(&vcatentry)
-	if err != nil {
-		return nil, err
-	}
-
-	vcatentry.SetClient(c)
-	return &vcatentry, nil
+	return common.GetObject[VCATEntry](c, uri)
 }
 
 // ListReferencedVCATEntries gets the collection of VCATEntry from
 // a provided reference.
 func ListReferencedVCATEntries(c common.Client, link string) ([]*VCATEntry, error) {
-	return common.GetCollectionObjects(c, link, GetVCATEntry)
+	return common.GetCollectionObjects[VCATEntry](c, link)
 }
 
 // VCATableEntry shall contain a Virtual Channel entry definition that describes a specific Virtual Channel.

--- a/redfish/virtualmedia.go
+++ b/redfish/virtualmedia.go
@@ -342,12 +342,11 @@ func (virtualmedia *VirtualMedia) InsertMediaConfig(config VirtualMediaConfig) e
 
 // GetVirtualMedia will get a VirtualMedia instance from the service.
 func GetVirtualMedia(c common.Client, uri string) (*VirtualMedia, error) {
-	var virtualMedia VirtualMedia
-	return &virtualMedia, virtualMedia.Get(c, uri, &virtualMedia)
+	return common.GetObject[VirtualMedia](c, uri)
 }
 
 // ListReferencedVirtualMedias gets the collection of VirtualMedia from
 // a provided reference.
 func ListReferencedVirtualMedias(c common.Client, link string) ([]*VirtualMedia, error) {
-	return common.GetCollectionObjects(c, link, GetVirtualMedia)
+	return common.GetCollectionObjects[VirtualMedia](c, link)
 }

--- a/redfish/vlannetworkinterface.go
+++ b/redfish/vlannetworkinterface.go
@@ -89,12 +89,11 @@ func (vlannetworkinterface *VLanNetworkInterface) Update() error {
 
 // GetVLanNetworkInterface will get a VLanNetworkInterface instance from the service.
 func GetVLanNetworkInterface(c common.Client, uri string) (*VLanNetworkInterface, error) {
-	var vLanNetworkInterface VLanNetworkInterface
-	return &vLanNetworkInterface, vLanNetworkInterface.Get(c, uri, &vLanNetworkInterface)
+	return common.GetObject[VLanNetworkInterface](c, uri)
 }
 
 // ListReferencedVLanNetworkInterfaces gets the collection of VLanNetworkInterface from
 // a provided reference.
 func ListReferencedVLanNetworkInterfaces(c common.Client, link string) ([]*VLanNetworkInterface, error) {
-	return common.GetCollectionObjects(c, link, GetVLanNetworkInterface)
+	return common.GetCollectionObjects[VLanNetworkInterface](c, link)
 }

--- a/redfish/volume.go
+++ b/redfish/volume.go
@@ -1053,13 +1053,12 @@ func (volume *Volume) Update() error {
 
 // GetVolume will get a Volume instance from the service.
 func GetVolume(c common.Client, uri string) (*Volume, error) {
-	var volume Volume
-	return &volume, volume.Get(c, uri, &volume)
+	return common.GetObject[Volume](c, uri)
 }
 
 // ListReferencedVolumes gets the collection of Volumes from a provided reference.
 func ListReferencedVolumes(c common.Client, link string) ([]*Volume, error) {
-	return common.GetCollectionObjects(c, link, GetVolume)
+	return common.GetCollectionObjects[Volume](c, link)
 }
 
 // AllowedVolumesUpdateApplyTimes returns the set of allowed apply times to request when setting the volumes values

--- a/redfish/zone.go
+++ b/redfish/zone.go
@@ -370,24 +370,11 @@ func (zone *Zone) Update() error {
 
 // GetZone will get a Zone instance from the service.
 func GetZone(c common.Client, uri string) (*Zone, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var zone Zone
-	err = json.NewDecoder(resp.Body).Decode(&zone)
-	if err != nil {
-		return nil, err
-	}
-
-	zone.SetClient(c)
-	return &zone, nil
+	return common.GetObject[Zone](c, uri)
 }
 
 // ListReferencedZones gets the collection of Zone from
 // a provided reference.
 func ListReferencedZones(c common.Client, link string) ([]*Zone, error) {
-	return common.GetCollectionObjects(c, link, GetZone)
+	return common.GetCollectionObjects[Zone](c, link)
 }

--- a/serviceroot.go
+++ b/serviceroot.go
@@ -356,7 +356,7 @@ func (serviceroot *Service) Fabrics() ([]*redfish.Fabric, error) {
 
 // Facilities gets a collection of facilities.
 func (serviceroot *Service) Facilities() ([]*redfish.Facility, error) {
-	return redfish.ListReferencedFacilitys(serviceroot.GetClient(), serviceroot.facilities)
+	return redfish.ListReferencedFacilities(serviceroot.GetClient(), serviceroot.facilities)
 }
 
 // JobService gets the job service instance

--- a/swordfish/capacity.go
+++ b/swordfish/capacity.go
@@ -118,14 +118,13 @@ func (capacitysource *CapacitySource) UnmarshalJSON(b []byte) error {
 
 // GetCapacitySource will get a CapacitySource instance from the service.
 func GetCapacitySource(c common.Client, uri string) (*CapacitySource, error) {
-	var capacitySource CapacitySource
-	return &capacitySource, capacitySource.Get(c, uri, &capacitySource)
+	return common.GetObject[CapacitySource](c, uri)
 }
 
 // ListReferencedCapacitySources gets the collection of CapacitySources from
 // a provided reference.
 func ListReferencedCapacitySources(c common.Client, link string) ([]*CapacitySource, error) {
-	return common.GetCollectionObjects(c, link, GetCapacitySource)
+	return common.GetCollectionObjects[CapacitySource](c, link)
 }
 
 // ProvidedClassOfService gets the ClassOfService from the ProvidingDrives,

--- a/swordfish/classofservice.go
+++ b/swordfish/classofservice.go
@@ -87,14 +87,13 @@ func (classofservice *ClassOfService) UnmarshalJSON(b []byte) error {
 
 // GetClassOfService will get a ClassOfService instance from the service.
 func GetClassOfService(c common.Client, uri string) (*ClassOfService, error) {
-	var classOfService ClassOfService
-	return &classOfService, classOfService.Get(c, uri, &classOfService)
+	return common.GetObject[ClassOfService](c, uri)
 }
 
 // ListReferencedClassOfServices gets the collection of ClassOfService from
 // a provided reference.
 func ListReferencedClassOfServices(c common.Client, link string) ([]*ClassOfService, error) {
-	return common.GetCollectionObjects(c, link, GetClassOfService)
+	return common.GetCollectionObjects[ClassOfService](c, link)
 }
 
 // DataProtectionLinesOfServices gets the DataProtectionLinesOfService that are

--- a/swordfish/consistencygroup.go
+++ b/swordfish/consistencygroup.go
@@ -304,24 +304,11 @@ func (consistencygroup *ConsistencyGroup) Update() error {
 
 // GetConsistencyGroup will get a ConsistencyGroup instance from the service.
 func GetConsistencyGroup(c common.Client, uri string) (*ConsistencyGroup, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var consistencygroup ConsistencyGroup
-	err = json.NewDecoder(resp.Body).Decode(&consistencygroup)
-	if err != nil {
-		return nil, err
-	}
-
-	consistencygroup.SetClient(c)
-	return &consistencygroup, nil
+	return common.GetObject[ConsistencyGroup](c, uri)
 }
 
 // ListReferencedConsistencyGroups gets the collection of ConsistencyGroup from
 // a provided reference.
 func ListReferencedConsistencyGroups(c common.Client, link string) ([]*ConsistencyGroup, error) {
-	return common.GetCollectionObjects(c, link, GetConsistencyGroup)
+	return common.GetCollectionObjects[ConsistencyGroup](c, link)
 }

--- a/swordfish/dataprotectionlineofservice.go
+++ b/swordfish/dataprotectionlineofservice.go
@@ -59,14 +59,13 @@ type DataProtectionLineOfService struct {
 
 // GetDataProtectionLineOfService will get a DataProtectionLineOfService instance from the service.
 func GetDataProtectionLineOfService(c common.Client, uri string) (*DataProtectionLineOfService, error) {
-	var dataProtectionLineOfService DataProtectionLineOfService
-	return &dataProtectionLineOfService, dataProtectionLineOfService.Get(c, uri, &dataProtectionLineOfService)
+	return common.GetObject[DataProtectionLineOfService](c, uri)
 }
 
 // ListReferencedDataProtectionLineOfServices gets the collection of DataProtectionLineOfService from
 // a provided reference.
 func ListReferencedDataProtectionLineOfServices(c common.Client, link string) ([]*DataProtectionLineOfService, error) {
-	return common.GetCollectionObjects(c, link, GetDataProtectionLineOfService)
+	return common.GetCollectionObjects[DataProtectionLineOfService](c, link)
 }
 
 // ReplicaRequest is a request for a replica.

--- a/swordfish/dataprotectionloscapabilities.go
+++ b/swordfish/dataprotectionloscapabilities.go
@@ -177,14 +177,13 @@ func (dataprotectionloscapabilities *DataProtectionLoSCapabilities) Update() err
 
 // GetDataProtectionLoSCapabilities will get a DataProtectionLoSCapabilities instance from the service.
 func GetDataProtectionLoSCapabilities(c common.Client, uri string) (*DataProtectionLoSCapabilities, error) {
-	var dataProtectionLoSCapabilities DataProtectionLoSCapabilities
-	return &dataProtectionLoSCapabilities, dataProtectionLoSCapabilities.Get(c, uri, &dataProtectionLoSCapabilities)
+	return common.GetObject[DataProtectionLoSCapabilities](c, uri)
 }
 
 // ListReferencedDataProtectionLoSCapabilities gets the collection of DataProtectionLoSCapabilities from
 // a provided reference.
 func ListReferencedDataProtectionLoSCapabilities(c common.Client, link string) ([]*DataProtectionLoSCapabilities, error) {
-	return common.GetCollectionObjects(c, link, GetDataProtectionLoSCapabilities)
+	return common.GetCollectionObjects[DataProtectionLoSCapabilities](c, link)
 }
 
 // SupportedReplicaOptions gets the support replica ClassesOfService.

--- a/swordfish/datasecuritylineofservice.go
+++ b/swordfish/datasecuritylineofservice.go
@@ -45,12 +45,11 @@ type DataSecurityLineOfService struct {
 
 // GetDataSecurityLineOfService will get a DataSecurityLineOfService instance from the service.
 func GetDataSecurityLineOfService(c common.Client, uri string) (*DataSecurityLineOfService, error) {
-	var dataSecurityLineOfService DataSecurityLineOfService
-	return &dataSecurityLineOfService, dataSecurityLineOfService.Get(c, uri, &dataSecurityLineOfService)
+	return common.GetObject[DataSecurityLineOfService](c, uri)
 }
 
 // ListReferencedDataSecurityLineOfServices gets the collection of DataSecurityLineOfService from
 // a provided reference.
 func ListReferencedDataSecurityLineOfServices(c common.Client, link string) ([]*DataSecurityLineOfService, error) {
-	return common.GetCollectionObjects(c, link, GetDataSecurityLineOfService)
+	return common.GetCollectionObjects[DataSecurityLineOfService](c, link)
 }

--- a/swordfish/datasecurityloscapabilities.go
+++ b/swordfish/datasecurityloscapabilities.go
@@ -199,12 +199,11 @@ type DataSecurityLoSCapabilities struct {
 
 // GetDataSecurityLoSCapabilities will get a DataSecurityLoSCapabilities instance from the service.
 func GetDataSecurityLoSCapabilities(c common.Client, uri string) (*DataSecurityLoSCapabilities, error) {
-	var dataSecurityLoSCapabilities DataSecurityLoSCapabilities
-	return &dataSecurityLoSCapabilities, dataSecurityLoSCapabilities.Get(c, uri, &dataSecurityLoSCapabilities)
+	return common.GetObject[DataSecurityLoSCapabilities](c, uri)
 }
 
 // ListReferencedDataSecurityLoSCapabilities gets the collection of DataSecurityLoSCapabilities from
 // a provided reference.
 func ListReferencedDataSecurityLoSCapabilities(c common.Client, link string) ([]*DataSecurityLoSCapabilities, error) {
-	return common.GetCollectionObjects(c, link, GetDataSecurityLoSCapabilities)
+	return common.GetCollectionObjects[DataSecurityLoSCapabilities](c, link)
 }

--- a/swordfish/datastoragelineofservice.go
+++ b/swordfish/datastoragelineofservice.go
@@ -94,12 +94,11 @@ func (datastoragelineofservice *DataStorageLineOfService) Update() error {
 
 // GetDataStorageLineOfService will get a DataStorageLineOfService instance from the service.
 func GetDataStorageLineOfService(c common.Client, uri string) (*DataStorageLineOfService, error) {
-	var dataStorageLineOfService DataStorageLineOfService
-	return &dataStorageLineOfService, dataStorageLineOfService.Get(c, uri, &dataStorageLineOfService)
+	return common.GetObject[DataStorageLineOfService](c, uri)
 }
 
 // ListReferencedDataStorageLineOfServices gets the collection of DataStorageLineOfService from
 // a provided reference.
 func ListReferencedDataStorageLineOfServices(c common.Client, link string) ([]*DataStorageLineOfService, error) {
-	return common.GetCollectionObjects(c, link, GetDataStorageLineOfService)
+	return common.GetCollectionObjects[DataStorageLineOfService](c, link)
 }

--- a/swordfish/datastorageloscapabilities.go
+++ b/swordfish/datastorageloscapabilities.go
@@ -130,12 +130,11 @@ func (datastorageloscapabilities *DataStorageLoSCapabilities) Update() error {
 
 // GetDataStorageLoSCapabilities will get a DataStorageLoSCapabilities instance from the service.
 func GetDataStorageLoSCapabilities(c common.Client, uri string) (*DataStorageLoSCapabilities, error) {
-	var dataStorageLoSCapabilities DataStorageLoSCapabilities
-	return &dataStorageLoSCapabilities, dataStorageLoSCapabilities.Get(c, uri, &dataStorageLoSCapabilities)
+	return common.GetObject[DataStorageLoSCapabilities](c, uri)
 }
 
 // ListReferencedDataStorageLoSCapabilities gets the collection of DataStorageLoSCapabilities from
 // a provided reference.
 func ListReferencedDataStorageLoSCapabilities(c common.Client, link string) ([]*DataStorageLoSCapabilities, error) {
-	return common.GetCollectionObjects(c, link, GetDataStorageLoSCapabilities)
+	return common.GetCollectionObjects[DataStorageLoSCapabilities](c, link)
 }

--- a/swordfish/endpointgroup.go
+++ b/swordfish/endpointgroup.go
@@ -130,14 +130,13 @@ func (endpointgroup *EndpointGroup) Update() error {
 
 // GetEndpointGroup will get a EndpointGroup instance from the service.
 func GetEndpointGroup(c common.Client, uri string) (*EndpointGroup, error) {
-	var endpointGroup EndpointGroup
-	return &endpointGroup, endpointGroup.Get(c, uri, &endpointGroup)
+	return common.GetObject[EndpointGroup](c, uri)
 }
 
 // ListReferencedEndpointGroups gets the collection of EndpointGroup from
 // a provided reference.
 func ListReferencedEndpointGroups(c common.Client, link string) ([]*EndpointGroup, error) {
-	return common.GetCollectionObjects(c, link, GetEndpointGroup)
+	return common.GetCollectionObjects[EndpointGroup](c, link)
 }
 
 // Endpoints gets the group's endpoints.

--- a/swordfish/featuresregistry.go
+++ b/swordfish/featuresregistry.go
@@ -41,26 +41,13 @@ type FeaturesRegistry struct {
 
 // GetFeaturesRegistry will get a FeaturesRegistry instance from the service.
 func GetFeaturesRegistry(c common.Client, uri string) (*FeaturesRegistry, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var featuresregistry FeaturesRegistry
-	err = json.NewDecoder(resp.Body).Decode(&featuresregistry)
-	if err != nil {
-		return nil, err
-	}
-
-	featuresregistry.SetClient(c)
-	return &featuresregistry, nil
+	return common.GetObject[FeaturesRegistry](c, uri)
 }
 
 // ListReferencedFeaturesRegistrys gets the collection of FeaturesRegistry from
 // a provided reference.
 func ListReferencedFeaturesRegistrys(c common.Client, link string) ([]*FeaturesRegistry, error) {
-	return common.GetCollectionObjects(c, link, GetFeaturesRegistry)
+	return common.GetCollectionObjects[FeaturesRegistry](c, link)
 }
 
 // FeaturesRegistryProperty shall represent the suffix to be used in the Feature and shall be unique within this

--- a/swordfish/fileshare.go
+++ b/swordfish/fileshare.go
@@ -163,14 +163,13 @@ func (fileshare *FileShare) Update() error {
 
 // GetFileShare will get a FileShare instance from the service.
 func GetFileShare(c common.Client, uri string) (*FileShare, error) {
-	var fileShare FileShare
-	return &fileShare, fileShare.Get(c, uri, &fileShare)
+	return common.GetObject[FileShare](c, uri)
 }
 
 // ListReferencedFileShares gets the collection of FileShare from a provided
 // reference.
 func ListReferencedFileShares(c common.Client, link string) ([]*FileShare, error) {
-	return common.GetCollectionObjects(c, link, GetFileShare)
+	return common.GetCollectionObjects[FileShare](c, link)
 }
 
 // ClassOfService gets the file share's class of service.

--- a/swordfish/filesystem.go
+++ b/swordfish/filesystem.go
@@ -271,14 +271,13 @@ func (filesystem *FileSystem) Update() error {
 
 // GetFileSystem will get a FileSystem instance from the service.
 func GetFileSystem(c common.Client, uri string) (*FileSystem, error) {
-	var fileSystem FileSystem
-	return &fileSystem, fileSystem.Get(c, uri, &fileSystem)
+	return common.GetObject[FileSystem](c, uri)
 }
 
 // ListReferencedFileSystems gets the collection of FileSystem from
 // a provided reference.
 func ListReferencedFileSystems(c common.Client, link string) ([]*FileSystem, error) {
-	return common.GetCollectionObjects(c, link, GetFileSystem)
+	return common.GetCollectionObjects[FileSystem](c, link)
 }
 
 // ExportedShares gets the exported file shares for this file system.

--- a/swordfish/filesystemmetrics.go
+++ b/swordfish/filesystemmetrics.go
@@ -30,24 +30,11 @@ type FileSystemMetrics struct {
 
 // GetFileSystemMetrics will get a FileSystemMetrics instance from the service.
 func GetFileSystemMetrics(c common.Client, uri string) (*FileSystemMetrics, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var filesystemmetrics FileSystemMetrics
-	err = json.NewDecoder(resp.Body).Decode(&filesystemmetrics)
-	if err != nil {
-		return nil, err
-	}
-
-	filesystemmetrics.SetClient(c)
-	return &filesystemmetrics, nil
+	return common.GetObject[FileSystemMetrics](c, uri)
 }
 
-// ListReferencedFileSystemMetricss gets the collection of FileSystemMetrics from
+// ListReferencedFileSystemMetricses gets the collection of FileSystemMetrics from
 // a provided reference.
-func ListReferencedFileSystemMetricss(c common.Client, link string) ([]*FileSystemMetrics, error) {
-	return common.GetCollectionObjects(c, link, GetFileSystemMetrics)
+func ListReferencedFileSystemMetricses(c common.Client, link string) ([]*FileSystemMetrics, error) {
+	return common.GetCollectionObjects[FileSystemMetrics](c, link)
 }

--- a/swordfish/ioconnectivitylineofservice.go
+++ b/swordfish/ioconnectivitylineofservice.go
@@ -84,12 +84,11 @@ func (ioconnectivitylineofservice *IOConnectivityLineOfService) Update() error {
 
 // GetIOConnectivityLineOfService will get a IOConnectivityLineOfService instance from the service.
 func GetIOConnectivityLineOfService(c common.Client, uri string) (*IOConnectivityLineOfService, error) {
-	var ioConnectivityLineOfService IOConnectivityLineOfService
-	return &ioConnectivityLineOfService, ioConnectivityLineOfService.Get(c, uri, &ioConnectivityLineOfService)
+	return common.GetObject[IOConnectivityLineOfService](c, uri)
 }
 
 // ListReferencedIOConnectivityLineOfServices gets the collection of IOConnectivityLineOfService from
 // a provided reference.
 func ListReferencedIOConnectivityLineOfServices(c common.Client, link string) ([]*IOConnectivityLineOfService, error) {
-	return common.GetCollectionObjects(c, link, GetIOConnectivityLineOfService)
+	return common.GetCollectionObjects[IOConnectivityLineOfService](c, link)
 }

--- a/swordfish/ioconnectivityloscapabilities.go
+++ b/swordfish/ioconnectivityloscapabilities.go
@@ -93,12 +93,11 @@ func (ioconnectivityloscapabilities *IOConnectivityLoSCapabilities) Update() err
 // GetIOConnectivityLoSCapabilities will get a IOConnectivityLoSCapabilities
 // instance from the service.
 func GetIOConnectivityLoSCapabilities(c common.Client, uri string) (*IOConnectivityLoSCapabilities, error) {
-	var ioConnectivityLoSCapabilities IOConnectivityLoSCapabilities
-	return &ioConnectivityLoSCapabilities, ioConnectivityLoSCapabilities.Get(c, uri, &ioConnectivityLoSCapabilities)
+	return common.GetObject[IOConnectivityLoSCapabilities](c, uri)
 }
 
 // ListReferencedIOConnectivityLoSCapabilitiess gets the collection of
 // IOConnectivityLoSCapabilities from a provided reference.
 func ListReferencedIOConnectivityLoSCapabilitiess(c common.Client, link string) ([]*IOConnectivityLoSCapabilities, error) {
-	return common.GetCollectionObjects(c, link, GetIOConnectivityLoSCapabilities)
+	return common.GetCollectionObjects[IOConnectivityLoSCapabilities](c, link)
 }

--- a/swordfish/ioperformancelineofservice.go
+++ b/swordfish/ioperformancelineofservice.go
@@ -96,12 +96,11 @@ func (ioperformancelineofservice *IOPerformanceLineOfService) Update() error {
 
 // GetIOPerformanceLineOfService will get a IOPerformanceLineOfService instance from the service.
 func GetIOPerformanceLineOfService(c common.Client, uri string) (*IOPerformanceLineOfService, error) {
-	var ioPerformanceLineOfService IOPerformanceLineOfService
-	return &ioPerformanceLineOfService, ioPerformanceLineOfService.Get(c, uri, &ioPerformanceLineOfService)
+	return common.GetObject[IOPerformanceLineOfService](c, uri)
 }
 
 // ListReferencedIOPerformanceLineOfServices gets the collection of IOPerformanceLineOfService from
 // a provided reference.
 func ListReferencedIOPerformanceLineOfServices(c common.Client, link string) ([]*IOPerformanceLineOfService, error) {
-	return common.GetCollectionObjects(c, link, GetIOPerformanceLineOfService)
+	return common.GetCollectionObjects[IOPerformanceLineOfService](c, link)
 }

--- a/swordfish/ioperformanceloscapabilities.go
+++ b/swordfish/ioperformanceloscapabilities.go
@@ -121,14 +121,13 @@ func (ioperformanceloscapabilities *IOPerformanceLoSCapabilities) Update() error
 
 // GetIOPerformanceLoSCapabilities will get a IOPerformanceLoSCapabilities instance from the service.
 func GetIOPerformanceLoSCapabilities(c common.Client, uri string) (*IOPerformanceLoSCapabilities, error) {
-	var ioPerformanceLoSCapabilities IOPerformanceLoSCapabilities
-	return &ioPerformanceLoSCapabilities, ioPerformanceLoSCapabilities.Get(c, uri, &ioPerformanceLoSCapabilities)
+	return common.GetObject[IOPerformanceLoSCapabilities](c, uri)
 }
 
 // ListReferencedIOPerformanceLoSCapabilitiess gets the collection of IOPerformanceLoSCapabilities from
 // a provided reference.
 func ListReferencedIOPerformanceLoSCapabilitiess(c common.Client, link string) ([]*IOPerformanceLoSCapabilities, error) {
-	return common.GetCollectionObjects(c, link, GetIOPerformanceLoSCapabilities)
+	return common.GetCollectionObjects[IOPerformanceLoSCapabilities](c, link)
 }
 
 // IOWorkload is used to describe an IO Workload.

--- a/swordfish/lineofservice.go
+++ b/swordfish/lineofservice.go
@@ -29,24 +29,11 @@ type LineOfService struct {
 
 // GetLineOfService will get a LineOfService instance from the service.
 func GetLineOfService(c common.Client, uri string) (*LineOfService, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var lineofservice LineOfService
-	err = json.NewDecoder(resp.Body).Decode(&lineofservice)
-	if err != nil {
-		return nil, err
-	}
-
-	lineofservice.SetClient(c)
-	return &lineofservice, nil
+	return common.GetObject[LineOfService](c, uri)
 }
 
 // ListReferencedLineOfServices gets the collection of LineOfService from
 // a provided reference.
 func ListReferencedLineOfServices(c common.Client, link string) ([]*LineOfService, error) {
-	return common.GetCollectionObjects(c, link, GetLineOfService)
+	return common.GetCollectionObjects[LineOfService](c, link)
 }

--- a/swordfish/nvmedomain.go
+++ b/swordfish/nvmedomain.go
@@ -169,24 +169,11 @@ func (nvmedomain *NVMeDomain) Update() error {
 
 // GetNVMeDomain will get a NVMeDomain instance from the service.
 func GetNVMeDomain(c common.Client, uri string) (*NVMeDomain, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var nvmedomain NVMeDomain
-	err = json.NewDecoder(resp.Body).Decode(&nvmedomain)
-	if err != nil {
-		return nil, err
-	}
-
-	nvmedomain.SetClient(c)
-	return &nvmedomain, nil
+	return common.GetObject[NVMeDomain](c, uri)
 }
 
 // ListReferencedNVMeDomains gets the collection of NVMeDomain from
 // a provided reference.
 func ListReferencedNVMeDomains(c common.Client, link string) ([]*NVMeDomain, error) {
-	return common.GetCollectionObjects(c, link, GetNVMeDomain)
+	return common.GetCollectionObjects[NVMeDomain](c, link)
 }

--- a/swordfish/nvmefirmwareimage.go
+++ b/swordfish/nvmefirmwareimage.go
@@ -49,24 +49,11 @@ type NVMeFirmwareImage struct {
 
 // GetNVMeFirmwareImage will get a NVMeFirmwareImage instance from the service.
 func GetNVMeFirmwareImage(c common.Client, uri string) (*NVMeFirmwareImage, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var nvmefirmwareimage NVMeFirmwareImage
-	err = json.NewDecoder(resp.Body).Decode(&nvmefirmwareimage)
-	if err != nil {
-		return nil, err
-	}
-
-	nvmefirmwareimage.SetClient(c)
-	return &nvmefirmwareimage, nil
+	return common.GetObject[NVMeFirmwareImage](c, uri)
 }
 
 // ListReferencedNVMeFirmwareImages gets the collection of NVMeFirmwareImage from
 // a provided reference.
 func ListReferencedNVMeFirmwareImages(c common.Client, link string) ([]*NVMeFirmwareImage, error) {
-	return common.GetCollectionObjects(c, link, GetNVMeFirmwareImage)
+	return common.GetCollectionObjects[NVMeFirmwareImage](c, link)
 }

--- a/swordfish/spareresourceset.go
+++ b/swordfish/spareresourceset.go
@@ -108,14 +108,13 @@ func (spareresourceset *SpareResourceSet) Update() error {
 
 // GetSpareResourceSet will get a SpareResourceSet instance from the service.
 func GetSpareResourceSet(c common.Client, uri string) (*SpareResourceSet, error) {
-	var spareResourceSet SpareResourceSet
-	return &spareResourceSet, spareResourceSet.Get(c, uri, &spareResourceSet)
+	return common.GetObject[SpareResourceSet](c, uri)
 }
 
 // ListReferencedSpareResourceSets gets the collection of SpareResourceSet from
 // a provided reference.
 func ListReferencedSpareResourceSets(c common.Client, link string) ([]*SpareResourceSet, error) {
-	return common.GetCollectionObjects(c, link, GetSpareResourceSet)
+	return common.GetCollectionObjects[SpareResourceSet](c, link)
 }
 
 // ReplacementSpareSets gets other spare sets that can be utilized to replenish

--- a/swordfish/storagegroup.go
+++ b/swordfish/storagegroup.go
@@ -219,14 +219,13 @@ func (storagegroup *StorageGroup) Update() error {
 
 // GetStorageGroup will get a StorageGroup instance from the service.
 func GetStorageGroup(c common.Client, uri string) (*StorageGroup, error) {
-	var storageGroup StorageGroup
-	return &storageGroup, storageGroup.Get(c, uri, &storageGroup)
+	return common.GetObject[StorageGroup](c, uri)
 }
 
 // ListReferencedStorageGroups gets the collection of StorageGroup from
 // a provided reference.
 func ListReferencedStorageGroups(c common.Client, link string) ([]*StorageGroup, error) {
-	return common.GetCollectionObjects(c, link, GetStorageGroup)
+	return common.GetCollectionObjects[StorageGroup](c, link)
 }
 
 // ChildStorageGroups gets child groups of this group.

--- a/swordfish/storagepool.go
+++ b/swordfish/storagepool.go
@@ -343,14 +343,13 @@ func (storagepool *StoragePool) Update() error {
 
 // GetStoragePool will get a StoragePool instance from the service.
 func GetStoragePool(c common.Client, uri string) (*StoragePool, error) {
-	var storagePool StoragePool
-	return &storagePool, storagePool.Get(c, uri, &storagePool)
+	return common.GetObject[StoragePool](c, uri)
 }
 
 // ListReferencedStoragePools gets the collection of StoragePool from
 // a provided reference.
 func ListReferencedStoragePools(c common.Client, link string) ([]*StoragePool, error) {
-	return common.GetCollectionObjects(c, link, GetStoragePool)
+	return common.GetCollectionObjects[StoragePool](c, link)
 }
 
 // DedicatedSpareDrives gets the Drive entities which are currently assigned as

--- a/swordfish/storagepoolmetrics.go
+++ b/swordfish/storagepoolmetrics.go
@@ -49,24 +49,11 @@ type StoragePoolMetrics struct {
 
 // GetStoragePoolMetrics will get a StoragePoolMetrics instance from the service.
 func GetStoragePoolMetrics(c common.Client, uri string) (*StoragePoolMetrics, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var storagepoolmetrics StoragePoolMetrics
-	err = json.NewDecoder(resp.Body).Decode(&storagepoolmetrics)
-	if err != nil {
-		return nil, err
-	}
-
-	storagepoolmetrics.SetClient(c)
-	return &storagepoolmetrics, nil
+	return common.GetObject[StoragePoolMetrics](c, uri)
 }
 
 // ListReferencedStoragePoolMetricss gets the collection of StoragePoolMetrics from
 // a provided reference.
 func ListReferencedStoragePoolMetricss(c common.Client, link string) ([]*StoragePoolMetrics, error) {
-	return common.GetCollectionObjects(c, link, GetStoragePoolMetrics)
+	return common.GetCollectionObjects[StoragePoolMetrics](c, link)
 }

--- a/swordfish/storagereplicainfo.go
+++ b/swordfish/storagereplicainfo.go
@@ -464,12 +464,11 @@ type StorageReplicaInfo struct {
 
 // GetStorageReplicaInfo will get a StorageReplicaInfo instance from the service.
 func GetStorageReplicaInfo(c common.Client, uri string) (*StorageReplicaInfo, error) {
-	var storageReplicaInfo StorageReplicaInfo
-	return &storageReplicaInfo, storageReplicaInfo.Get(c, uri, &storageReplicaInfo)
+	return common.GetObject[StorageReplicaInfo](c, uri)
 }
 
 // ListReferencedStorageReplicaInfos gets the collection of StorageReplicaInfo from
 // a provided reference.
 func ListReferencedStorageReplicaInfos(c common.Client, link string) ([]*StorageReplicaInfo, error) {
-	return common.GetCollectionObjects(c, link, GetStorageReplicaInfo)
+	return common.GetCollectionObjects[StorageReplicaInfo](c, link)
 }

--- a/swordfish/storageservice.go
+++ b/swordfish/storageservice.go
@@ -213,14 +213,13 @@ func (storageservice *StorageService) Update() error {
 
 // GetStorageService will get a StorageService instance from the service.
 func GetStorageService(c common.Client, uri string) (*StorageService, error) {
-	var storageService StorageService
-	return &storageService, storageService.Get(c, uri, &storageService)
+	return common.GetObject[StorageService](c, uri)
 }
 
 // ListReferencedStorageServices gets the collection of StorageService from
 // a provided reference.
 func ListReferencedStorageServices(c common.Client, link string) ([]*StorageService, error) {
-	return common.GetCollectionObjects(c, link, GetStorageService)
+	return common.GetCollectionObjects[StorageService](c, link)
 }
 
 // ClassesOfService gets the storage service's classes of service.

--- a/swordfish/storageservicemetrics.go
+++ b/swordfish/storageservicemetrics.go
@@ -31,24 +31,11 @@ type StorageServiceMetrics struct {
 
 // GetStorageServiceMetrics will get a StorageServiceMetrics instance from the service.
 func GetStorageServiceMetrics(c common.Client, uri string) (*StorageServiceMetrics, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var storageservicemetrics StorageServiceMetrics
-	err = json.NewDecoder(resp.Body).Decode(&storageservicemetrics)
-	if err != nil {
-		return nil, err
-	}
-
-	storageservicemetrics.SetClient(c)
-	return &storageservicemetrics, nil
+	return common.GetObject[StorageServiceMetrics](c, uri)
 }
 
 // ListReferencedStorageServiceMetricss gets the collection of StorageServiceMetrics from
 // a provided reference.
 func ListReferencedStorageServiceMetricss(c common.Client, link string) ([]*StorageServiceMetrics, error) {
-	return common.GetCollectionObjects(c, link, GetStorageServiceMetrics)
+	return common.GetCollectionObjects[StorageServiceMetrics](c, link)
 }

--- a/swordfish/storagesystem.go
+++ b/swordfish/storagesystem.go
@@ -16,11 +16,10 @@ type StorageSystem struct {
 
 // GetStorageSystem will get a StorageSystem instance from the Swordfish service.
 func GetStorageSystem(c common.Client, uri string) (*StorageSystem, error) {
-	var storageSystem StorageSystem
-	return &storageSystem, storageSystem.Get(c, uri, &storageSystem)
+	return common.GetObject[StorageSystem](c, uri)
 }
 
 // ListReferencedStorageSystems gets the collection of StorageSystems.
 func ListReferencedStorageSystems(c common.Client, link string) ([]*StorageSystem, error) {
-	return common.GetCollectionObjects(c, link, GetStorageSystem)
+	return common.GetCollectionObjects[StorageSystem](c, link)
 }

--- a/swordfish/volume.go
+++ b/swordfish/volume.go
@@ -795,13 +795,12 @@ func (volume *Volume) Update() error {
 
 // GetVolume will get a Volume instance from the service.
 func GetVolume(c common.Client, uri string) (*Volume, error) {
-	var volume Volume
-	return &volume, volume.Get(c, uri, &volume)
+	return common.GetObject[Volume](c, uri)
 }
 
 // ListReferencedVolumes gets the collection of Volume from a provided reference.
 func ListReferencedVolumes(c common.Client, link string) ([]*Volume, error) {
-	return common.GetCollectionObjects(c, link, GetVolume)
+	return common.GetCollectionObjects[Volume](c, link)
 }
 
 // CacheDataVolumes gets the data volumes this volume serves as a cache volume.

--- a/swordfish/volumemetrics.go
+++ b/swordfish/volumemetrics.go
@@ -50,24 +50,11 @@ type VolumeMetrics struct {
 
 // GetVolumeMetrics will get a VolumeMetrics instance from the service.
 func GetVolumeMetrics(c common.Client, uri string) (*VolumeMetrics, error) {
-	resp, err := c.Get(uri)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var volumemetrics VolumeMetrics
-	err = json.NewDecoder(resp.Body).Decode(&volumemetrics)
-	if err != nil {
-		return nil, err
-	}
-
-	volumemetrics.SetClient(c)
-	return &volumemetrics, nil
+	return common.GetObject[VolumeMetrics](c, uri)
 }
 
 // ListReferencedVolumeMetricss gets the collection of VolumeMetrics from
 // a provided reference.
 func ListReferencedVolumeMetricss(c common.Client, link string) ([]*VolumeMetrics, error) {
-	return common.GetCollectionObjects(c, link, GetVolumeMetrics)
+	return common.GetCollectionObjects[VolumeMetrics](c, link)
 }

--- a/tools/source.tmpl
+++ b/tools/source.tmpl
@@ -88,26 +88,13 @@ func ({{ class.name|lower }} *{{ class.name }}) Update() error {
 {% if class.name == object_name %}
 // Get{{ class.name }} will get a {{ class.name }} instance from the service.
 func Get{{ class.name }}(c common.Client, uri string) (*{{ class.name }}, error) {
-    resp, err := c.Get(uri)
-    if err != nil {
-        return nil, err
-    }
-    defer resp.Body.Close()
-
-    var {{ class.name|lower }} {{ class.name }}
-    err = json.NewDecoder(resp.Body).Decode(&{{ class.name|lower }})
-    if err != nil {
-        return nil, err
-    }
-
-    {{ class.name|lower }}.SetClient(c)
-    return &{{ class.name|lower }}, nil
+	common.GetObject[{{ class.name }}](c, uri)
 }
 
 // ListReferenced{{ class.name }}s gets the collection of {{ class.name }} from
 // a provided reference.
 func ListReferenced{{ class.name }}s(c common.Client, link string) ([]*{{ class.name }}, error) {
-	return common.GetCollectionObjects(c, link, Get{{ class.name }})
+	return common.GetCollectionObjects[{{ class.name }}](c, link)
 }
 
 {% endif %}


### PR DESCRIPTION
Now that we've moved to Go 1.18 as a minimum we can use generics. This consolidates a lot of the GetXXX calls to use common code to retrieve API objects.

Also cleans up some other code and fixes a couple small bugs.