### PR TITLE
Add common concurrent function to get list of objects

### DIFF
--- a/redfish/accelerationfunction.go
+++ b/redfish/accelerationfunction.go
@@ -114,42 +114,10 @@ func ListReferencedAccelerationFunctions(c common.Client, link string) ([]*Accel
 
 // Endpoints gets the endpoints connected to this accelerator.
 func (accelerationfunction *AccelerationFunction) Endpoints() ([]*Endpoint, error) {
-	var result []*Endpoint
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range accelerationfunction.endpoints {
-		endpoint, err := GetEndpoint(accelerationfunction.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, endpoint)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Endpoint](accelerationfunction.GetClient(), accelerationfunction.endpoints)
 }
 
 // PCIeFunctions gets the PCIe functions associated with this accelerator.
 func (accelerationfunction *AccelerationFunction) PCIeFunctions() ([]*PCIeFunction, error) {
-	var result []*PCIeFunction
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range accelerationfunction.pcieFunctions {
-		function, err := GetPCIeFunction(accelerationfunction.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, function)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[PCIeFunction](accelerationfunction.GetClient(), accelerationfunction.pcieFunctions)
 }

--- a/redfish/addresspool.go
+++ b/redfish/addresspool.go
@@ -90,44 +90,12 @@ func ListReferencedAddressPools(c common.Client, link string) ([]*AddressPool, e
 
 // Endpoints gets the endpoints connected to this address pool.
 func (addresspool *AddressPool) Endpoints() ([]*Endpoint, error) {
-	var result []*Endpoint
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range addresspool.endpoints {
-		endpoint, err := GetEndpoint(addresspool.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, endpoint)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Endpoint](addresspool.GetClient(), addresspool.endpoints)
 }
 
 // Zones gets the zones associated with this address pool.
 func (addresspool *AddressPool) Zones() ([]*Zone, error) {
-	var result []*Zone
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range addresspool.zones {
-		endpoint, err := GetZone(addresspool.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, endpoint)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Zone](addresspool.GetClient(), addresspool.zones)
 }
 
 // BFDSingleHopOnly shall contain the BFD-related properties for an Ethernet fabric that uses Bidirectional

--- a/redfish/aggregate.go
+++ b/redfish/aggregate.go
@@ -70,23 +70,7 @@ func (aggregate *Aggregate) UnmarshalJSON(b []byte) error {
 
 // Elements get the elements of this aggregate.
 func (aggregate *Aggregate) Elements() ([]*Resource, error) {
-	var result []*Resource
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range aggregate.elements {
-		endpoint, err := GetResource(aggregate.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, endpoint)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Resource](aggregate.GetClient(), aggregate.elements)
 }
 
 // AddElements adds one or more resources to the aggregate.

--- a/redfish/battery.go
+++ b/redfish/battery.go
@@ -215,44 +215,12 @@ func (battery *Battery) BatteryMetrics() (*BatteryMetrics, error) {
 
 // Memory returns a collection of Memory devices associated with this Battery.
 func (battery *Battery) Memory() ([]*Memory, error) {
-	var result []*Memory
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range battery.memory {
-		memory, err := GetMemory(battery.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, memory)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Memory](battery.GetClient(), battery.memory)
 }
 
 // StorageControllers returns a collection of StorageControllers associated with this Battery.
 func (battery *Battery) StorageControllers() ([]*StorageController, error) {
-	var result []*StorageController
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range battery.storageControllers {
-		sc, err := GetStorageController(battery.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, sc)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[StorageController](battery.GetClient(), battery.storageControllers)
 }
 
 // Calibrate performs a self-calibration, or learn cycle, of the battery.

--- a/redfish/cable.go
+++ b/redfish/cable.go
@@ -230,86 +230,22 @@ func (cable *Cable) UnmarshalJSON(b []byte) error {
 
 // DownstreamChassis gets the physical downstream containers connected to this cable.
 func (cable *Cable) DownstreamChassis() ([]*Chassis, error) {
-	var result []*Chassis
-
-	collectionError := common.NewCollectionError()
-	for _, ethLink := range cable.downstreamChassis {
-		eth, err := GetChassis(cable.GetClient(), ethLink)
-		if err != nil {
-			collectionError.Failures[ethLink] = err
-		} else {
-			result = append(result, eth)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Chassis](cable.GetClient(), cable.downstreamChassis)
 }
 
 // DownstreamPorts gets the physical downstream connections connected to this cable.
 func (cable *Cable) DownstreamPorts() ([]*Port, error) {
-	var result []*Port
-
-	collectionError := common.NewCollectionError()
-	for _, ethLink := range cable.downstreamPorts {
-		eth, err := GetPort(cable.GetClient(), ethLink)
-		if err != nil {
-			collectionError.Failures[ethLink] = err
-		} else {
-			result = append(result, eth)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Port](cable.GetClient(), cable.downstreamPorts)
 }
 
 // UpstreamChassis gets the physical upstream containers connected to this cable.
 func (cable *Cable) UpstreamChassis() ([]*Chassis, error) {
-	var result []*Chassis
-
-	collectionError := common.NewCollectionError()
-	for _, ethLink := range cable.upstreamChassis {
-		eth, err := GetChassis(cable.GetClient(), ethLink)
-		if err != nil {
-			collectionError.Failures[ethLink] = err
-		} else {
-			result = append(result, eth)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Chassis](cable.GetClient(), cable.upstreamChassis)
 }
 
 // UpstreamPorts gets the physical upstream connections connected to this cable.
 func (cable *Cable) UptreamPorts() ([]*Port, error) {
-	var result []*Port
-
-	collectionError := common.NewCollectionError()
-	for _, ethLink := range cable.upstreamPorts {
-		eth, err := GetPort(cable.GetClient(), ethLink)
-		if err != nil {
-			collectionError.Failures[ethLink] = err
-		} else {
-			result = append(result, eth)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Port](cable.GetClient(), cable.upstreamPorts)
 }
 
 // Update commits updates to this object's properties to the running system.

--- a/redfish/certificatelocations.go
+++ b/redfish/certificatelocations.go
@@ -69,21 +69,5 @@ func ListReferencedCertificateLocations(c common.Client, link string) ([]*Certif
 
 // Certificates retrieves a collection of the Certificates installed on the system.
 func (certificatelocations *CertificateLocations) Certificates() ([]*Certificate, error) {
-	var result []*Certificate
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range certificatelocations.certificates {
-		cert, err := GetCertificate(certificatelocations.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, cert)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Certificate](certificatelocations.GetClient(), certificatelocations.certificates)
 }

--- a/redfish/circuit.go
+++ b/redfish/circuit.go
@@ -530,23 +530,7 @@ func (circuit *Circuit) SourceCircuit() (*Circuit, error) {
 
 // DistributionCircuits gets the collection that contains the circuits powered by this circuit.
 func (circuit *Circuit) DistributionCircuits() ([]*Circuit, error) {
-	var result []*Circuit
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range circuit.distributionCircuits {
-		ct, err := GetCircuit(circuit.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, ct)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Circuit](circuit.GetClient(), circuit.distributionCircuits)
 }
 
 // TODO: outlets, power outlet

--- a/redfish/compositionreservation.go
+++ b/redfish/compositionreservation.go
@@ -75,21 +75,7 @@ func ListReferencedCompositionReservations(c common.Client, link string) ([]*Com
 // Upon deletion of the reservation or when the reservation is applied, the
 // Reserved property in the referenced resource blocks shall change to 'false'.
 func (compositionreservation *CompositionReservation) ReservedResourceBlocks() ([]*ResourceBlock, error) {
-	var result []*ResourceBlock
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range compositionreservation.reservedResourceBlocks {
-		rb, err := GetResourceBlock(compositionreservation.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, rb)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[ResourceBlock](
+		compositionreservation.GetClient(),
+		compositionreservation.reservedResourceBlocks)
 }

--- a/redfish/connection.go
+++ b/redfish/connection.go
@@ -167,86 +167,22 @@ func ListReferencedConnections(c common.Client, link string) ([]*Connection, err
 
 // InitiatorEndpointGroups get the initiator endpoint groups associated with this connection.
 func (connection *Connection) InitiatorEndpointGroups() ([]*EndpointGroup, error) {
-	var result []*EndpointGroup
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range connection.initiatorEndpointGroups {
-		rb, err := GetEndpointGroup(connection.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, rb)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[EndpointGroup](connection.GetClient(), connection.initiatorEndpointGroups)
 }
 
 // InitiatorEndpoints get the initiator endpoint associated with this connection.
 func (connection *Connection) InitiatorEndpoints() ([]*Endpoint, error) {
-	var result []*Endpoint
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range connection.initiatorEndpoints {
-		rb, err := GetEndpoint(connection.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, rb)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Endpoint](connection.GetClient(), connection.initiatorEndpoints)
 }
 
 // TargetEndpointGroups get the target endpoint groups associated with this connection.
 func (connection *Connection) TargetEndpointGroups() ([]*EndpointGroup, error) {
-	var result []*EndpointGroup
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range connection.targetEndpointGroups {
-		rb, err := GetEndpointGroup(connection.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, rb)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[EndpointGroup](connection.GetClient(), connection.targetEndpointGroups)
 }
 
 // TargetEndpoints get the target endpoint associated with this connection.
 func (connection *Connection) TargetEndpoints() ([]*Endpoint, error) {
-	var result []*Endpoint
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range connection.targetEndpoints {
-		rb, err := GetEndpoint(connection.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, rb)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Endpoint](connection.GetClient(), connection.targetEndpoints)
 }
 
 // ConnectionKey shall contain the permission key information required to access the target resources for a

--- a/redfish/connectionmethod.go
+++ b/redfish/connectionmethod.go
@@ -103,21 +103,5 @@ func ListReferencedConnectionMethods(c common.Client, link string) ([]*Connectio
 
 // AggregationSources gets the access points using this connection method.
 func (connectionmethod *ConnectionMethod) AggregationSources() ([]*AggregationSource, error) {
-	var result []*AggregationSource
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range connectionmethod.aggregationSources {
-		rb, err := GetAggregationSource(connectionmethod.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, rb)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[AggregationSource](connectionmethod.GetClient(), connectionmethod.aggregationSources)
 }

--- a/redfish/containerimage.go
+++ b/redfish/containerimage.go
@@ -97,21 +97,5 @@ func ListReferencedContainerImages(c common.Client, link string) ([]*ContainerIm
 
 // Containers get the container instances using this container image.
 func (containerimage *ContainerImage) Containers() ([]*Container, error) {
-	var result []*Container
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range containerimage.containers {
-		rb, err := GetContainer(containerimage.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, rb)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Container](containerimage.GetClient(), containerimage.containers)
 }

--- a/redfish/coolantconnector.go
+++ b/redfish/coolantconnector.go
@@ -176,23 +176,7 @@ func ListReferencedCoolantConnectors(c common.Client, link string) ([]*CoolantCo
 
 // ConnectedChassis retrieves a collection of the Chassis at the other end of the connection.
 func (coolantconnector *CoolantConnector) ConnectedChassis() ([]*Chassis, error) {
-	var result []*Chassis
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range coolantconnector.connectedChassis {
-		c, err := GetChassis(coolantconnector.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, c)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Chassis](coolantconnector.GetClient(), coolantconnector.connectedChassis)
 }
 
 // ConnectedCoolingLoop gets the cooling loop at the other end of the connection.

--- a/redfish/coolingloop.go
+++ b/redfish/coolingloop.go
@@ -197,21 +197,5 @@ func (coolingloop *CoolingLoop) Facility() (*Facility, error) {
 
 // ManagedBy gets the collection of managers of this equipment.
 func (coolingloop *CoolingLoop) ManagedBy() ([]*Manager, error) {
-	var result []*Manager
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range coolingloop.managedBy {
-		manager, err := GetManager(coolingloop.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, manager)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Manager](coolingloop.GetClient(), coolingloop.managedBy)
 }

--- a/redfish/cxllogicaldevice.go
+++ b/redfish/cxllogicaldevice.go
@@ -128,86 +128,22 @@ func (cxllogicaldevice *CXLLogicalDevice) Log() (*LogService, error) {
 
 // Endpoints get the endpoints associated with this CXL logical device.
 func (cxllogicaldevice *CXLLogicalDevice) Endpoints() ([]*Endpoint, error) {
-	var result []*Endpoint
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range cxllogicaldevice.endpoints {
-		rb, err := GetEndpoint(cxllogicaldevice.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, rb)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Endpoint](cxllogicaldevice.GetClient(), cxllogicaldevice.endpoints)
 }
 
 // MemoryChunks get the memory chunks associated with this CXL logical device.
 func (cxllogicaldevice *CXLLogicalDevice) MemoryChunks() ([]*MemoryChunks, error) {
-	var result []*MemoryChunks
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range cxllogicaldevice.memoryChunks {
-		rb, err := GetMemoryChunks(cxllogicaldevice.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, rb)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[MemoryChunks](cxllogicaldevice.GetClient(), cxllogicaldevice.memoryChunks)
 }
 
 // MemoryDomains get the memory domains associated with this CXL logical device.
 func (cxllogicaldevice *CXLLogicalDevice) MemoryDomains() ([]*MemoryDomain, error) {
-	var result []*MemoryDomain
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range cxllogicaldevice.memoryDomains {
-		rb, err := GetMemoryDomain(cxllogicaldevice.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, rb)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[MemoryDomain](cxllogicaldevice.GetClient(), cxllogicaldevice.memoryDomains)
 }
 
-// PCIeFunctions get the PCIe devices associated with this CXL logical device.
-func (cxllogicaldevice *CXLLogicalDevice) PCIeFunctions() ([]*PCIeDevice, error) {
-	var result []*PCIeDevice
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range cxllogicaldevice.pcieFunctions {
-		rb, err := GetPCIeDevice(cxllogicaldevice.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, rb)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+// PCIeFunctions get the PCIe functions associated with this CXL logical device.
+func (cxllogicaldevice *CXLLogicalDevice) PCIeFunctions() ([]*PCIeFunction, error) {
+	return common.GetObjects[PCIeFunction](cxllogicaldevice.GetClient(), cxllogicaldevice.pcieFunctions)
 }
 
 // GetCXLLogicalDevice will get a CXLLogicalDevice instance from the service.

--- a/redfish/drive.go
+++ b/redfish/drive.go
@@ -466,80 +466,22 @@ func (drive *Drive) Chassis() (*Chassis, error) {
 
 // Endpoints references the Endpoints that this drive is associated with.
 func (drive *Drive) Endpoints() ([]*Endpoint, error) {
-	var result []*Endpoint
-
-	collectionError := common.NewCollectionError()
-	for _, endpointLink := range drive.endpoints {
-		endpoint, err := GetEndpoint(drive.GetClient(), endpointLink)
-		if err != nil {
-			collectionError.Failures[endpointLink] = err
-		} else {
-			result = append(result, endpoint)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Endpoint](drive.GetClient(), drive.endpoints)
 }
 
 // Volumes references the Volumes that this drive is associated with.
 func (drive *Drive) Volumes() ([]*Volume, error) {
-	var result []*Volume
-
-	collectionError := common.NewCollectionError()
-	for _, volumeLink := range drive.volumes {
-		volume, err := GetVolume(drive.GetClient(), volumeLink)
-		if err != nil {
-			collectionError.Failures[volumeLink] = err
-		} else {
-			result = append(result, volume)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Volume](drive.GetClient(), drive.volumes)
 }
 
 // PCIeFunctions references the PCIeFunctions that this drive is associated with.
 func (drive *Drive) PCIeFunctions() ([]*PCIeFunction, error) {
-	var result []*PCIeFunction
-
-	collectionError := common.NewCollectionError()
-	for _, pcieFunctionLink := range drive.pcieFunctions {
-		pcieFunction, err := GetPCIeFunction(drive.GetClient(), pcieFunctionLink)
-		if err != nil {
-			collectionError.Failures[pcieFunctionLink] = err
-		} else {
-			result = append(result, pcieFunction)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[PCIeFunction](drive.GetClient(), drive.pcieFunctions)
 }
 
 // // StoragePools references the StoragePools that this drive is associated with.
 // func (drive *Drive) StoragePools() ([]*StoragePools, error) {
-// 	var result []*StoragePools
-
-// 	for _, storagePoolLink := range drive.storagePools {
-// 		storagePool, err := GetStoragePools(drive.Client, storagePoolLink)
-// 		if err != nil {
-// 			return result, err
-// 		}
-// 		result = append(result, storagePool)
-// 	}
-
-// 	return result, nil
+//	return common.GetObjects[StoragePools](drive.GetClient(), drive.storagePools)
 // }
 
 // SecureErase shall perform a secure erase of the drive.

--- a/redfish/endpointgroup.go
+++ b/redfish/endpointgroup.go
@@ -135,42 +135,10 @@ func ListReferencedEndpointGroups(c common.Client, link string) ([]*EndpointGrou
 
 // Endpoints get the endpoints associated with this endpoint group.
 func (endpointgroup *EndpointGroup) Endpoints() ([]*Endpoint, error) {
-	var result []*Endpoint
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range endpointgroup.endpoints {
-		rb, err := GetEndpoint(endpointgroup.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, rb)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Endpoint](endpointgroup.GetClient(), endpointgroup.endpoints)
 }
 
 // Connections get the connections associated with this endpoint group.
 func (endpointgroup *EndpointGroup) Connections() ([]*Connection, error) {
-	var result []*Connection
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range endpointgroup.connections {
-		rb, err := GetConnection(endpointgroup.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, rb)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Connection](endpointgroup.GetClient(), endpointgroup.connections)
 }

--- a/redfish/ethernetinterface.go
+++ b/redfish/ethernetinterface.go
@@ -442,26 +442,7 @@ func (ethernetinterface *EthernetInterface) VLANs() ([]*VLanNetworkInterface, er
 
 // AffiliatedInterfaces gets any ethernet interfaces that are affiliated with this interface.
 func (ethernetinterface *EthernetInterface) AffiliatedInterfaces() ([]*EthernetInterface, error) {
-	var result []*EthernetInterface
-	if len(ethernetinterface.affiliatedInterfaces) == 0 {
-		return result, nil
-	}
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range ethernetinterface.affiliatedInterfaces {
-		rb, err := GetEthernetInterface(ethernetinterface.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, rb)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[EthernetInterface](ethernetinterface.GetClient(), ethernetinterface.affiliatedInterfaces)
 }
 
 // Chassis gets the containing chassis.
@@ -475,26 +456,7 @@ func (ethernetinterface *EthernetInterface) Chassis() (*Chassis, error) {
 
 // Endpoints gets any endpoints associated with this interface.
 func (ethernetinterface *EthernetInterface) Endpoints() ([]*Endpoint, error) {
-	var result []*Endpoint
-	if len(ethernetinterface.endpoints) == 0 {
-		return result, nil
-	}
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range ethernetinterface.endpoints {
-		rb, err := GetEndpoint(ethernetinterface.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, rb)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Endpoint](ethernetinterface.GetClient(), ethernetinterface.endpoints)
 }
 
 // HostInterface gets the associated host interface.
@@ -508,48 +470,10 @@ func (ethernetinterface *EthernetInterface) HostInterface() (*HostInterface, err
 
 // NetworkDeviceFunctions gets any device functions associated with this interface.
 func (ethernetinterface *EthernetInterface) NetworkDeviceFunctions() ([]*NetworkDeviceFunction, error) {
-	var result []*NetworkDeviceFunction
-	if len(ethernetinterface.networkDeviceFunctions) == 0 {
-		return result, nil
-	}
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range ethernetinterface.networkDeviceFunctions {
-		rb, err := GetNetworkDeviceFunction(ethernetinterface.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, rb)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[NetworkDeviceFunction](ethernetinterface.GetClient(), ethernetinterface.networkDeviceFunctions)
 }
 
 // Ports gets any ports associated with this interface.
 func (ethernetinterface *EthernetInterface) Ports() ([]*Port, error) {
-	var result []*Port
-	if len(ethernetinterface.ports) == 0 {
-		return result, nil
-	}
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range ethernetinterface.ports {
-		rb, err := GetPort(ethernetinterface.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, rb)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Port](ethernetinterface.GetClient(), ethernetinterface.ports)
 }

--- a/redfish/fabricadapter.go
+++ b/redfish/fabricadapter.go
@@ -149,86 +149,22 @@ func (fabricadapter *FabricAdapter) Ports() ([]*Port, error) {
 
 // Endpoints gets the endpoints connected to this interface.
 func (fabricadapter *FabricAdapter) Endpoints() ([]*Endpoint, error) {
-	var result []*Endpoint
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range fabricadapter.endpoints {
-		endpoint, err := GetEndpoint(fabricadapter.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, endpoint)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Endpoint](fabricadapter.GetClient(), fabricadapter.endpoints)
 }
 
 // MemoryDomains gets the MemoryDomains associated to this interface.
 func (fabricadapter *FabricAdapter) MemoryDomains() ([]*MemoryDomain, error) {
-	var result []*MemoryDomain
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range fabricadapter.memoryDomains {
-		endpoint, err := GetMemoryDomain(fabricadapter.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, endpoint)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[MemoryDomain](fabricadapter.GetClient(), fabricadapter.memoryDomains)
 }
 
 // PCIeDevices gets the PCIe devices associated to this interface.
 func (fabricadapter *FabricAdapter) PCIeDevices() ([]*PCIeDevice, error) {
-	var result []*PCIeDevice
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range fabricadapter.pcieDevices {
-		endpoint, err := GetPCIeDevice(fabricadapter.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, endpoint)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[PCIeDevice](fabricadapter.GetClient(), fabricadapter.pcieDevices)
 }
 
 // Processors gets the processors associated to this interface.
 func (fabricadapter *FabricAdapter) Processors() ([]*Processor, error) {
-	var result []*Processor
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range fabricadapter.processors {
-		endpoint, err := GetProcessor(fabricadapter.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, endpoint)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Processor](fabricadapter.GetClient(), fabricadapter.processors)
 }
 
 // Update commits updates to this object's properties to the running system.

--- a/redfish/facility.go
+++ b/redfish/facility.go
@@ -235,23 +235,7 @@ func (facility *Facility) UnmarshalJSON(b []byte) error {
 
 // CDUs get the cooling distribution units associated with this facility.
 func (facility *Facility) CDUs() ([]*CoolingUnit, error) {
-	var result []*CoolingUnit
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range facility.cdus {
-		unit, err := GetCoolingUnit(facility.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[CoolingUnit](facility.GetClient(), facility.cdus)
 }
 
 // ContainedByFacility get facility that contains this facility.
@@ -264,233 +248,57 @@ func (facility *Facility) ContainedByFacility() (*Facility, error) {
 
 // ContainsChassis get the chassis within this facility.
 func (facility *Facility) ContainsChassis() ([]*Chassis, error) {
-	var result []*Chassis
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range facility.containsChassis {
-		unit, err := GetChassis(facility.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Chassis](facility.GetClient(), facility.containsChassis)
 }
 
 // ContainsFacilities get facilities within this facility.
 func (facility *Facility) ContainsFacilities() ([]*Facility, error) {
-	var result []*Facility
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range facility.containsFacilities {
-		unit, err := GetFacility(facility.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Facility](facility.GetClient(), facility.containsFacilities)
 }
 
 // CoolingLoops get cooling loops within this facility.
 func (facility *Facility) CoolingLoops() ([]*CoolingLoop, error) {
-	var result []*CoolingLoop
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range facility.coolingLoops {
-		unit, err := GetCoolingLoop(facility.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[CoolingLoop](facility.GetClient(), facility.coolingLoops)
 }
 
 // ElectricalBuses get electrical buses within this facility.
 func (facility *Facility) ElectricalBuses() ([]*PowerDistribution, error) {
-	var result []*PowerDistribution
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range facility.electricalBuses {
-		unit, err := GetPowerDistribution(facility.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[PowerDistribution](facility.GetClient(), facility.electricalBuses)
 }
 
 // FloorPDUs get floor power distribution units within this facility.
 func (facility *Facility) FloorPDUs() ([]*PowerDistribution, error) {
-	var result []*PowerDistribution
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range facility.floorPDUs {
-		unit, err := GetPowerDistribution(facility.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[PowerDistribution](facility.GetClient(), facility.floorPDUs)
 }
 
 // ImmersionUnits get immersion cooling units within this facility.
 func (facility *Facility) ImmersionUnits() ([]*CoolingUnit, error) {
-	var result []*CoolingUnit
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range facility.immersionUnits {
-		unit, err := GetCoolingUnit(facility.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[CoolingUnit](facility.GetClient(), facility.immersionUnits)
 }
 
 // ManagedBy gets the managers of this facility.
 func (facility *Facility) ManagedBy() ([]*Manager, error) {
-	var result []*Manager
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range facility.managedBy {
-		cl, err := GetManager(facility.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, cl)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Manager](facility.GetClient(), facility.managedBy)
 }
 
 // PowerShelves get power shelves within this facility.
 func (facility *Facility) PowerShelves() ([]*PowerDistribution, error) {
-	var result []*PowerDistribution
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range facility.powerShelves {
-		unit, err := GetPowerDistribution(facility.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[PowerDistribution](facility.GetClient(), facility.powerShelves)
 }
 
 // RackPDUs get rack power distribution units within this facility.
 func (facility *Facility) RackPDUs() ([]*PowerDistribution, error) {
-	var result []*PowerDistribution
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range facility.rackPDUs {
-		unit, err := GetPowerDistribution(facility.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[PowerDistribution](facility.GetClient(), facility.rackPDUs)
 }
 
 // Switchgear get switchgear power distribution units within this facility.
 func (facility *Facility) Switchgear() ([]*PowerDistribution, error) {
-	var result []*PowerDistribution
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range facility.switchgear {
-		unit, err := GetPowerDistribution(facility.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[PowerDistribution](facility.GetClient(), facility.switchgear)
 }
 
 // TransferSwitches get transfer switches within this facility.
 func (facility *Facility) TransferSwitches() ([]*PowerDistribution, error) {
-	var result []*PowerDistribution
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range facility.transferSwitches {
-		unit, err := GetPowerDistribution(facility.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[PowerDistribution](facility.GetClient(), facility.transferSwitches)
 }
 
 // GetFacility will get a Facility instance from the service.

--- a/redfish/fan.go
+++ b/redfish/fan.go
@@ -132,23 +132,7 @@ func (fan *Fan) Assembly() (*Assembly, error) {
 
 // CoolingChassis get the cooling chassis related to this fan.
 func (fan *Fan) CoolingChassis() ([]*Chassis, error) {
-	var result []*Chassis
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range fan.coolingChassis {
-		unit, err := GetChassis(fan.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Chassis](fan.GetClient(), fan.coolingChassis)
 }
 
 // Update commits updates to this object's properties to the running system.

--- a/redfish/graphicscontroller.go
+++ b/redfish/graphicscontroller.go
@@ -113,23 +113,7 @@ func (graphicscontroller *GraphicsController) PCIeDevice() (*PCIeDevice, error) 
 
 // Processors gets this graphics controllers processors.
 func (graphicscontroller *GraphicsController) Processors() ([]*Processor, error) {
-	var result []*Processor
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range graphicscontroller.processors {
-		unit, err := GetProcessor(graphicscontroller.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Processor](graphicscontroller.GetClient(), graphicscontroller.processors)
 }
 
 // Update commits updates to this object's properties to the running system.

--- a/redfish/heater.go
+++ b/redfish/heater.go
@@ -143,107 +143,27 @@ func (heater *Heater) Assembly() (*Assembly, error) {
 
 // Managers gets the managers for this heater.
 func (heater *Heater) Managers() ([]*Manager, error) {
-	var result []*Manager
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range heater.managers {
-		unit, err := GetManager(heater.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Manager](heater.GetClient(), heater.managers)
 }
 
 // Memory gets the memory associated with this heater.
 func (heater *Heater) Memory() ([]*Memory, error) {
-	var result []*Memory
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range heater.memory {
-		unit, err := GetMemory(heater.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Memory](heater.GetClient(), heater.memory)
 }
 
 // NetworkAdapters gets the network adapters associated with this heater.
 func (heater *Heater) NetworkAdapters() ([]*NetworkAdapter, error) {
-	var result []*NetworkAdapter
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range heater.networkAdapters {
-		unit, err := GetNetworkAdapter(heater.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[NetworkAdapter](heater.GetClient(), heater.networkAdapters)
 }
 
 // Processors gets this heater's processors.
 func (heater *Heater) Processors() ([]*Processor, error) {
-	var result []*Processor
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range heater.processors {
-		unit, err := GetProcessor(heater.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Processor](heater.GetClient(), heater.processors)
 }
 
 // StorageControllers gets the storage controllers associated with this heater.
 func (heater *Heater) StorageControllers() ([]*StorageController, error) {
-	var result []*StorageController
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range heater.storageControllers {
-		unit, err := GetStorageController(heater.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[StorageController](heater.GetClient(), heater.storageControllers)
 }
 
 // Metrics gets the heater metrics for this heater.

--- a/redfish/hostinterface.go
+++ b/redfish/hostinterface.go
@@ -220,23 +220,7 @@ func ListReferencedHostInterfaces(c common.Client, link string) ([]*HostInterfac
 
 // ComputerSystems references the ComputerSystems that this host interface is associated with.
 func (hostinterface *HostInterface) ComputerSystems() ([]*ComputerSystem, error) {
-	var result []*ComputerSystem
-
-	collectionError := common.NewCollectionError()
-	for _, computerSystemLink := range hostinterface.computerSystems {
-		computerSystem, err := GetComputerSystem(hostinterface.GetClient(), computerSystemLink)
-		if err != nil {
-			collectionError.Failures[computerSystemLink] = err
-		} else {
-			result = append(result, computerSystem)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[ComputerSystem](hostinterface.GetClient(), hostinterface.computerSystems)
 }
 
 // HostEthernetInterfaces gets the network interface controllers or cards (NICs)

--- a/redfish/license.go
+++ b/redfish/license.go
@@ -178,23 +178,7 @@ func (license *License) UnmarshalJSON(b []byte) error {
 // TargetServices gets a set of Manager objects that represent the services where
 // the license is installed, such as remote Redfish services.
 func (license *License) TargetServices() ([]*Manager, error) {
-	var result []*Manager
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range license.targetServices {
-		unit, err := GetManager(license.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Manager](license.GetClient(), license.targetServices)
 }
 
 // GetLicense will get a License instance from the service.

--- a/redfish/logentry.go
+++ b/redfish/logentry.go
@@ -565,23 +565,7 @@ func (logentry *LogEntry) UnmarshalJSON(b []byte) error {
 
 // RelatedLogEntries gets the set of LogEntry in this or other log services that are related to this log entry.
 func (logentry *LogEntry) RelatedLogEntries() ([]*LogEntry, error) {
-	var result []*LogEntry
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range logentry.relatedLogEntries {
-		unit, err := GetLogEntry(logentry.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[LogEntry](logentry.GetClient(), logentry.relatedLogEntries)
 }
 
 // Update commits updates to this object's properties to the running system.

--- a/redfish/manager.go
+++ b/redfish/manager.go
@@ -655,107 +655,27 @@ func (manager *Manager) ActiveSoftwareImage() (*SoftwareInventory, error) {
 
 // ManagedBy gets the managers responsible for managing this manager.
 func (manager *Manager) ManagedBy() ([]*Manager, error) {
-	var result []*Manager
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range manager.managedBy {
-		mgr, err := GetManager(manager.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, mgr)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Manager](manager.GetClient(), manager.managedBy)
 }
 
 // ManagedForChassis gets the the chassis this manager controls.
 func (manager *Manager) ManagedForChassis() ([]*Chassis, error) {
-	var result []*Chassis
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range manager.managerForChassis {
-		chassis, err := GetChassis(manager.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, chassis)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Chassis](manager.GetClient(), manager.managerForChassis)
 }
 
 // ManagerForManagers gets the managers that are managed by this manager.
 func (manager *Manager) ManagerForManagers() ([]*Manager, error) {
-	var result []*Manager
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range manager.managerForManagers {
-		mgr, err := GetManager(manager.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, mgr)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Manager](manager.GetClient(), manager.managerForManagers)
 }
 
 // ManagerForServers gets the systems that this manager controls.
 func (manager *Manager) ManagerForServers() ([]*ComputerSystem, error) {
-	var result []*ComputerSystem
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range manager.managerForServers {
-		mgr, err := GetComputerSystem(manager.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, mgr)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[ComputerSystem](manager.GetClient(), manager.managerForServers)
 }
 
 // ManagerForSwitches gets the switches that this manager controls.
 func (manager *Manager) ManagerForSwitches() ([]*Switch, error) {
-	var result []*Switch
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range manager.managerForSwitches {
-		mgr, err := GetSwitch(manager.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, mgr)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Switch](manager.GetClient(), manager.managerForSwitches)
 }
 
 // SelectedNetworkPort gets the current network port used by this manager.
@@ -768,21 +688,5 @@ func (manager *Manager) SelectedNetworkPort() (*Port, error) {
 
 // SoftwareImages gets the firmware images that apply to this manager.
 func (manager *Manager) SoftwareImages() ([]*SoftwareInventory, error) {
-	var result []*SoftwareInventory
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range manager.softwareImages {
-		mgr, err := GetSoftwareInventory(manager.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, mgr)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[SoftwareInventory](manager.GetClient(), manager.softwareImages)
 }

--- a/redfish/manageraccount.go
+++ b/redfish/manageraccount.go
@@ -173,44 +173,12 @@ func (manageraccount *ManagerAccount) Role() (*Role, error) {
 
 // Certificates gets the user identity certificates for this account.
 func (manageraccount *ManagerAccount) Certificates() ([]*Certificate, error) {
-	var result []*Certificate
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range manageraccount.certificates {
-		unit, err := GetCertificate(manageraccount.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Certificate](manageraccount.GetClient(), manageraccount.certificates)
 }
 
 // Keys gets the keys that can be used to authenticate this account.
 func (manageraccount *ManagerAccount) Keys() ([]*Key, error) {
-	var result []*Key
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range manageraccount.keys {
-		unit, err := GetKey(manageraccount.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Key](manageraccount.GetClient(), manageraccount.keys)
 }
 
 // ChangePassword changes the account password while requiring password for the current session.

--- a/redfish/mediacontroller.go
+++ b/redfish/mediacontroller.go
@@ -132,44 +132,12 @@ func (mediacontroller *MediaController) Ports() ([]*Port, error) {
 
 // Endpoints get the Endpoints with which this media controller is associated.
 func (mediacontroller *MediaController) Endpoints() ([]*Endpoint, error) {
-	var result []*Endpoint
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range mediacontroller.endpoints {
-		unit, err := GetEndpoint(mediacontroller.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Endpoint](mediacontroller.GetClient(), mediacontroller.endpoints)
 }
 
 // MemoryDomains get the memory domains associated with this memory controller.
 func (mediacontroller *MediaController) MemoryDomains() ([]*MemoryDomain, error) {
-	var result []*MemoryDomain
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range mediacontroller.memoryDomains {
-		unit, err := GetMemoryDomain(mediacontroller.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[MemoryDomain](mediacontroller.GetClient(), mediacontroller.memoryDomains)
 }
 
 // GetMediaController will get a MediaController instance from the service.

--- a/redfish/memory.go
+++ b/redfish/memory.go
@@ -608,23 +608,7 @@ func (memory *Memory) Assembly() (*Assembly, error) {
 
 // Certificates gets certificates for device identity and attestation.
 func (memory *Memory) Certificates() ([]*Certificate, error) {
-	var result []*Certificate
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range memory.certificates {
-		unit, err := GetCertificate(memory.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Certificate](memory.GetClient(), memory.certificates)
 }
 
 // EnvironmentMetrics gets the environment metrics for this memory.
@@ -654,23 +638,7 @@ func (memory *Memory) Metrics() (*MemoryMetrics, error) {
 // Batteries gets the batteries that provide power to this memory device during
 // a power-loss event, such as with battery-backed NVDIMMs.
 func (memory *Memory) Batteries() ([]*Battery, error) {
-	var result []*Battery
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range memory.batteries {
-		unit, err := GetBattery(memory.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Battery](memory.GetClient(), memory.batteries)
 }
 
 // Chassis gets the containing chassis of this memory.
@@ -683,86 +651,22 @@ func (memory *Memory) Chassis() (*Chassis, error) {
 
 // Endpoints gets the endpoints associated with this memory.
 func (memory *Memory) Endpoints() ([]*Endpoint, error) {
-	var result []*Endpoint
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range memory.endpoints {
-		unit, err := GetEndpoint(memory.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Endpoint](memory.GetClient(), memory.endpoints)
 }
 
 // MemoryMediaSources gets the memory chunks providing media for this memory.
 func (memory *Memory) MemoryMediaSources() ([]*MemoryChunks, error) {
-	var result []*MemoryChunks
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range memory.memoryMediaSources {
-		unit, err := GetMemoryChunks(memory.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[MemoryChunks](memory.GetClient(), memory.memoryMediaSources)
 }
 
 // MemoryRegionMediaSources gets the memory regions providing media for this memory.
 func (memory *Memory) MemoryRegionMediaSources() ([]*MemoryRegion, error) {
-	var result []*MemoryRegion
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range memory.memoryRegionMediaSources {
-		unit, err := GetMemoryRegion(memory.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[MemoryRegion](memory.GetClient(), memory.memoryRegionMediaSources)
 }
 
 // Processors gets the processors associated with this memory device.
 func (memory *Memory) Processors() ([]*Processor, error) {
-	var result []*Processor
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range memory.processors {
-		unit, err := GetProcessor(memory.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Processor](memory.GetClient(), memory.processors)
 }
 
 // DisalbeMasterPassphrase will disable the master passphrase on the supplied

--- a/redfish/memorydomain.go
+++ b/redfish/memorydomain.go
@@ -114,87 +114,23 @@ func (memorydomain *MemoryDomain) UnmarshalJSON(b []byte) error {
 // CXLLogicalDevices gets the CXLLogicalDevice that represent the CXL logical devices
 // that are associated with this memory domain.
 func (memorydomain *MemoryDomain) CXLLogicalDevices() ([]*CXLLogicalDevice, error) {
-	var result []*CXLLogicalDevice
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range memorydomain.cxlLogicalDevices {
-		unit, err := GetCXLLogicalDevice(memorydomain.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[CXLLogicalDevice](memorydomain.GetClient(), memorydomain.cxlLogicalDevices)
 }
 
 // FabricAdapters gets the fabric adapters that present this memory domain to a fabric.
 func (memorydomain *MemoryDomain) FabricAdapters() ([]*FabricAdapter, error) {
-	var result []*FabricAdapter
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range memorydomain.fabricAdapters {
-		unit, err := GetFabricAdapter(memorydomain.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[FabricAdapter](memorydomain.GetClient(), memorydomain.fabricAdapters)
 }
 
 // MediaControllers gets the media controllers for this memory domain.
 // This property has been deprecated in favor of the FabricAdapters property.
 func (memorydomain *MemoryDomain) MediaControllers() ([]*MediaController, error) {
-	var result []*MediaController
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range memorydomain.mediaControllers {
-		unit, err := GetMediaController(memorydomain.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[MediaController](memorydomain.GetClient(), memorydomain.mediaControllers)
 }
 
 // PCIeFunctions gets the PCIe functions representing this memory domain.
 func (memorydomain *MemoryDomain) PCIeFunctions() ([]*PCIeFunction, error) {
-	var result []*PCIeFunction
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range memorydomain.pcieFunctions {
-		unit, err := GetPCIeFunction(memorydomain.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[PCIeFunction](memorydomain.GetClient(), memorydomain.pcieFunctions)
 }
 
 // GetMemoryDomain will get a MemoryDomain instance from the service.
@@ -238,21 +174,5 @@ func (memoryset *MemorySet) UnmarshalJSON(b []byte) error {
 
 // MemorySet gets the Memory objects that are part of this set.
 func (memoryset *MemorySet) MemorySet(c common.Client) ([]*Memory, error) {
-	var result []*Memory
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range memoryset.memorySet {
-		unit, err := GetMemory(c, uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Memory](c, memoryset.memorySet)
 }

--- a/redfish/metricreportdefinition.go
+++ b/redfish/metricreportdefinition.go
@@ -239,23 +239,7 @@ func (metricreportdefinition *MetricReportDefinition) UnmarshalJSON(b []byte) er
 
 // Triggers get the associated triggers.
 func (metricreportdefinition *MetricReportDefinition) Triggers() ([]*Triggers, error) {
-	var result []*Triggers
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range metricreportdefinition.triggers {
-		unit, err := GetTriggers(metricreportdefinition.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Triggers](metricreportdefinition.GetClient(), metricreportdefinition.triggers)
 }
 
 // Update commits updates to this object's properties to the running system.

--- a/redfish/networkadapter.go
+++ b/redfish/networkadapter.go
@@ -177,107 +177,27 @@ func (controllers *Controllers) ActiveSoftwareImage(c common.Client) (*SoftwareI
 
 // NetworkDeviceFunctions gets the collection of NetworkDeviceFunctions of this network controller.
 func (controllers *Controllers) NetworkDeviceFunctions(c common.Client) ([]*NetworkDeviceFunction, error) {
-	var result []*NetworkDeviceFunction
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range controllers.networkDeviceFunctions {
-		unit, err := GetNetworkDeviceFunction(c, uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[NetworkDeviceFunction](c, controllers.networkDeviceFunctions)
 }
 
 // NetworkPorts gets the collection of NetworkPorts for this network controller.
 func (controllers *Controllers) NetworkPorts(c common.Client) ([]*NetworkPort, error) {
-	var result []*NetworkPort
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range controllers.networkPorts {
-		unit, err := GetNetworkPort(c, uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[NetworkPort](c, controllers.networkPorts)
 }
 
 // PCIeDevices gets the PCIe devices associated with this network controller.
 func (controllers *Controllers) PCIeDevices(c common.Client) ([]*PCIeDevice, error) {
-	var result []*PCIeDevice
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range controllers.pcieDevices {
-		unit, err := GetPCIeDevice(c, uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[PCIeDevice](c, controllers.pcieDevices)
 }
 
 // Ports gets the ports associated with this network controller.
 func (controllers *Controllers) Ports(c common.Client) ([]*Port, error) {
-	var result []*Port
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range controllers.ports {
-		unit, err := GetPort(c, uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Port](c, controllers.ports)
 }
 
 // SoftwareImages gets the firmware images that apply to this controller.
 func (controllers *Controllers) SoftwareImages(c common.Client) ([]*SoftwareInventory, error) {
-	var result []*SoftwareInventory
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range controllers.softwareImages {
-		unit, err := GetSoftwareInventory(c, uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[SoftwareInventory](c, controllers.softwareImages)
 }
 
 // DataCenterBridging shall describe the capability, status,

--- a/redfish/networkdevicefunction.go
+++ b/redfish/networkdevicefunction.go
@@ -435,67 +435,19 @@ func (networkdevicefunction *NetworkDeviceFunction) UnmarshalJSON(b []byte) erro
 
 // Endpoints gets the endpoints that are associated with this network device function.
 func (networkdevicefunction *NetworkDeviceFunction) Endpoints() ([]*Endpoint, error) {
-	var result []*Endpoint
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range networkdevicefunction.endpoints {
-		unit, err := GetEndpoint(networkdevicefunction.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Endpoint](networkdevicefunction.GetClient(), networkdevicefunction.endpoints)
 }
 
 // EthernetInterfaces gets the virtual interfaces that were created when one of the network device function VLANs is
 // represented as a virtual NIC for the purpose of showing the IP address associated with that VLAN.
 func (networkdevicefunction *NetworkDeviceFunction) EthernetInterfaces() ([]*EthernetInterface, error) {
-	var result []*EthernetInterface
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range networkdevicefunction.ethernetInterfaces {
-		unit, err := GetEthernetInterface(networkdevicefunction.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[EthernetInterface](networkdevicefunction.GetClient(), networkdevicefunction.ethernetInterfaces)
 }
 
 // OffloadProcessors gets the processors that performs offload computation for this network function, such as
 // with a SmartNIC. This property shall not be present if OffloadSystem is present.
 func (networkdevicefunction *NetworkDeviceFunction) OffloadProcessors() ([]*Processor, error) {
-	var result []*Processor
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range networkdevicefunction.offloadProcessors {
-		unit, err := GetProcessor(networkdevicefunction.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Processor](networkdevicefunction.GetClient(), networkdevicefunction.offloadProcessors)
 }
 
 // OffloadSystem shall contain a link to a resource of type ComputerSystem that represents the system that performs

--- a/redfish/networkinterface.go
+++ b/redfish/networkinterface.go
@@ -101,64 +101,16 @@ func (networkinterface *NetworkInterface) NetworkAdapter() (*NetworkAdapter, err
 
 // NetworkDeviceFunctions gets the collection of NetworkDeviceFunctions of this network interface
 func (networkinterface *NetworkInterface) NetworkDeviceFunctions() ([]*NetworkDeviceFunction, error) {
-	var result []*NetworkDeviceFunction
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range networkinterface.networkDeviceFunctions {
-		unit, err := GetNetworkDeviceFunction(networkinterface.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[NetworkDeviceFunction](networkinterface.GetClient(), networkinterface.networkDeviceFunctions)
 }
 
 // NetworkPorts gets the collection of NetworkPorts of this network interface
 // This property has been deprecated in favor of the Ports property.
 func (networkinterface *NetworkInterface) NetworkPorts() ([]*NetworkPort, error) {
-	var result []*NetworkPort
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range networkinterface.networkPorts {
-		unit, err := GetNetworkPort(networkinterface.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[NetworkPort](networkinterface.GetClient(), networkinterface.networkPorts)
 }
 
 // Ports gets the ports associated with this network interface.
 func (networkinterface *NetworkInterface) Ports() ([]*Port, error) {
-	var result []*Port
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range networkinterface.ports {
-		unit, err := GetPort(networkinterface.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Port](networkinterface.GetClient(), networkinterface.ports)
 }

--- a/redfish/outlet.go
+++ b/redfish/outlet.go
@@ -272,65 +272,17 @@ func (outlet *Outlet) BranchCircuit() (*Circuit, error) {
 
 // Chassis gets the chassis connected to this outlet.
 func (outlet *Outlet) Chassis() ([]*Chassis, error) {
-	var result []*Chassis
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range outlet.chassis {
-		unit, err := GetChassis(outlet.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Chassis](outlet.GetClient(), outlet.chassis)
 }
 
 // DistributionCircuits gets the circuits powered by this outlet.
 func (outlet *Outlet) DistributionCircuits() ([]*Circuit, error) {
-	var result []*Circuit
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range outlet.distributionCircuits {
-		unit, err := GetCircuit(outlet.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Circuit](outlet.GetClient(), outlet.distributionCircuits)
 }
 
 // PowerSupplies gets the power supplies connected to this outlet.
 func (outlet *Outlet) PowerSupplies() ([]*PowerSupply, error) {
-	var result []*PowerSupply
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range outlet.powerSupplies {
-		unit, err := GetPowerSupply(outlet.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[PowerSupply](outlet.GetClient(), outlet.powerSupplies)
 }
 
 // Update commits updates to this object's properties to the running system.

--- a/redfish/outletgroup.go
+++ b/redfish/outletgroup.go
@@ -135,23 +135,7 @@ func (outletgroup *OutletGroup) ResetMetrics() error {
 
 // Outlets get the outlets that are in this outlet group.
 func (outletgroup *OutletGroup) Outlets() ([]*Outlet, error) {
-	var result []*Outlet
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range outletgroup.outlets {
-		unit, err := GetOutlet(outletgroup.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, unit)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Outlet](outletgroup.GetClient(), outletgroup.outlets)
 }
 
 // Update commits updates to this object's properties to the running system.

--- a/redfish/pciedevice.go
+++ b/redfish/pciedevice.go
@@ -397,44 +397,13 @@ func (pciedevice *PCIeDevice) CXLLogicalDevices() ([]*CXLLogicalDevice, error) {
 
 // Chassis gets the chassis in which the PCIe device is contained.
 func (pciedevice *PCIeDevice) Chassis() ([]*Chassis, error) {
-	var result []*Chassis
-
-	collectionError := common.NewCollectionError()
-	for _, chassisLink := range pciedevice.chassis {
-		chassis, err := GetChassis(pciedevice.GetClient(), chassisLink)
-		if err != nil {
-			collectionError.Failures[chassisLink] = err
-		} else {
-			result = append(result, chassis)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Chassis](pciedevice.GetClient(), pciedevice.chassis)
 }
 
 // PCIeFunctions get the PCIe functions that this device exposes.
 func (pciedevice *PCIeDevice) PCIeFunctions() ([]*PCIeFunction, error) {
 	if len(pciedevice.pcieFunctionsArray) > 0 {
-		var result []*PCIeFunction
-
-		collectionError := common.NewCollectionError()
-		for _, funcLink := range pciedevice.pcieFunctionsArray {
-			pciefunction, err := GetPCIeFunction(pciedevice.GetClient(), funcLink)
-			if err != nil {
-				collectionError.Failures[funcLink] = err
-			} else {
-				result = append(result, pciefunction)
-			}
-		}
-		if collectionError.Empty() {
-			return result, nil
-		}
-
-		return result, collectionError
+		return common.GetObjects[PCIeFunction](pciedevice.GetClient(), pciedevice.pcieFunctionsArray)
 	}
 	return ListReferencedPCIeFunctions(pciedevice.GetClient(), pciedevice.pcieFunctions)
 }
@@ -449,21 +418,5 @@ func (pciedevice *PCIeDevice) Switch() (*Switch, error) {
 
 // Processors gets the processors that are directly connected or directly bridged to this PCIe device.
 func (pciedevice *PCIeDevice) Processors() ([]*Processor, error) {
-	var result []*Processor
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range pciedevice.processors {
-		processor, err := GetProcessor(pciedevice.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, processor)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Processor](pciedevice.GetClient(), pciedevice.processors)
 }

--- a/redfish/pciefunction.go
+++ b/redfish/pciefunction.go
@@ -233,86 +233,22 @@ func (pciefunction *PCIeFunction) CXLLogicalDevice() (*CXLLogicalDevice, error) 
 
 // Drives gets the PCIe function's drives.
 func (pciefunction *PCIeFunction) Drives() ([]*Drive, error) {
-	var result []*Drive
-
-	collectionError := common.NewCollectionError()
-	for _, driveLink := range pciefunction.drives {
-		drive, err := GetDrive(pciefunction.GetClient(), driveLink)
-		if err != nil {
-			collectionError.Failures[driveLink] = err
-		} else {
-			result = append(result, drive)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Drive](pciefunction.GetClient(), pciefunction.drives)
 }
 
 // EthernetInterfaces gets the PCIe function's ethernet interfaces.
 func (pciefunction *PCIeFunction) EthernetInterfaces() ([]*EthernetInterface, error) {
-	var result []*EthernetInterface
-
-	collectionError := common.NewCollectionError()
-	for _, ethLink := range pciefunction.ethernetInterfaces {
-		eth, err := GetEthernetInterface(pciefunction.GetClient(), ethLink)
-		if err != nil {
-			collectionError.Failures[ethLink] = err
-		} else {
-			result = append(result, eth)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[EthernetInterface](pciefunction.GetClient(), pciefunction.ethernetInterfaces)
 }
 
 // MemoryDomains gets the memory domains associated with this PCIe function.
 func (pciefunction *PCIeFunction) MemoryDomains() ([]*MemoryDomain, error) {
-	var result []*MemoryDomain
-
-	collectionError := common.NewCollectionError()
-	for _, netLink := range pciefunction.memoryDomains {
-		net, err := GetMemoryDomain(pciefunction.GetClient(), netLink)
-		if err != nil {
-			collectionError.Failures[netLink] = err
-		} else {
-			result = append(result, net)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[MemoryDomain](pciefunction.GetClient(), pciefunction.memoryDomains)
 }
 
 // NetworkDeviceFunctions gets the PCIe function's ethernet interfaces.
 func (pciefunction *PCIeFunction) NetworkDeviceFunctions() ([]*NetworkDeviceFunction, error) {
-	var result []*NetworkDeviceFunction
-
-	collectionError := common.NewCollectionError()
-	for _, netLink := range pciefunction.networkDeviceFunctions {
-		net, err := GetNetworkDeviceFunction(pciefunction.GetClient(), netLink)
-		if err != nil {
-			collectionError.Failures[netLink] = err
-		} else {
-			result = append(result, net)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[NetworkDeviceFunction](pciefunction.GetClient(), pciefunction.networkDeviceFunctions)
 }
 
 // PCIeDevice gets the associated PCIe device for this function.
@@ -333,21 +269,5 @@ func (pciefunction *PCIeFunction) Processor() (*Processor, error) {
 
 // StorageControllers gets the associated storage controllers.
 func (pciefunction *PCIeFunction) StorageControllers() ([]*StorageController, error) {
-	var result []*StorageController
-
-	collectionError := common.NewCollectionError()
-	for _, scLink := range pciefunction.storageControllers {
-		sc, err := GetStorageController(pciefunction.GetClient(), scLink)
-		if err != nil {
-			collectionError.Failures[scLink] = err
-		} else {
-			result = append(result, sc)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[StorageController](pciefunction.GetClient(), pciefunction.storageControllers)
 }

--- a/redfish/pcieslots.go
+++ b/redfish/pcieslots.go
@@ -100,44 +100,12 @@ func (slot *PCIeSlot) UnmarshalJSON(b []byte) error {
 
 // PCIeDevices gets the PCIe devices contained in this slot.
 func (slot *PCIeSlot) PCIeDevice(c common.Client) ([]*PCIeDevice, error) {
-	var result []*PCIeDevice
-
-	collectionError := common.NewCollectionError()
-	for _, ethLink := range slot.pcieDevice {
-		eth, err := GetPCIeDevice(c, ethLink)
-		if err != nil {
-			collectionError.Failures[ethLink] = err
-		} else {
-			result = append(result, eth)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[PCIeDevice](c, slot.pcieDevice)
 }
 
 // Processors gets the processors that are directly connected or directly bridged to this PCIe slot.
 func (slot *PCIeSlot) Processors(c common.Client) ([]*Processor, error) {
-	var result []*Processor
-
-	collectionError := common.NewCollectionError()
-	for _, ethLink := range slot.processors {
-		eth, err := GetProcessor(c, ethLink)
-		if err != nil {
-			collectionError.Failures[ethLink] = err
-		} else {
-			result = append(result, eth)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Processor](c, slot.processors)
 }
 
 // PCIeSlots is used to represent a PCIeSlots resource for a Redfish implementation.

--- a/redfish/port.go
+++ b/redfish/port.go
@@ -888,191 +888,47 @@ func (port *Port) Metrics() (*PortMetrics, error) {
 
 // AssociatedEndpoints gets the endpoints at the other end of the link.
 func (port *Port) AssociatedEndpoints() ([]*Endpoint, error) {
-	var result []*Endpoint
-
-	collectionError := common.NewCollectionError()
-	for _, ethLink := range port.associatedEndpoints {
-		eth, err := GetEndpoint(port.GetClient(), ethLink)
-		if err != nil {
-			collectionError.Failures[ethLink] = err
-		} else {
-			result = append(result, eth)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Endpoint](port.GetClient(), port.associatedEndpoints)
 }
 
 // Cables gets the cables connected to this port.
 func (port *Port) Cables() ([]*Cable, error) {
-	var result []*Cable
-
-	collectionError := common.NewCollectionError()
-	for _, ethLink := range port.cables {
-		eth, err := GetCable(port.GetClient(), ethLink)
-		if err != nil {
-			collectionError.Failures[ethLink] = err
-		} else {
-			result = append(result, eth)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Cable](port.GetClient(), port.cables)
 }
 
 // ConnectedPorts gets the remote device ports connected to the other end of the link.
 func (port *Port) ConnectedPorts() ([]*Port, error) {
-	var result []*Port
-
-	collectionError := common.NewCollectionError()
-	for _, ethLink := range port.connectedPorts {
-		eth, err := GetPort(port.GetClient(), ethLink)
-		if err != nil {
-			collectionError.Failures[ethLink] = err
-		} else {
-			result = append(result, eth)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Port](port.GetClient(), port.connectedPorts)
 }
 
 // ConnectedSwitchPorts gets the switch ports connected to the other end of the link.
 func (port *Port) ConnectedSwitchPorts() ([]*Port, error) {
-	var result []*Port
-
-	collectionError := common.NewCollectionError()
-	for _, ethLink := range port.connectedSwitchPorts {
-		eth, err := GetPort(port.GetClient(), ethLink)
-		if err != nil {
-			collectionError.Failures[ethLink] = err
-		} else {
-			result = append(result, eth)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Port](port.GetClient(), port.connectedSwitchPorts)
 }
 
 // ConnectedSwitches gets the switches connected to the other end of the link.
 func (port *Port) ConnectedSwitches() ([]*Switch, error) {
-	var result []*Switch
-
-	collectionError := common.NewCollectionError()
-	for _, ethLink := range port.connectedSwitches {
-		eth, err := GetSwitch(port.GetClient(), ethLink)
-		if err != nil {
-			collectionError.Failures[ethLink] = err
-		} else {
-			result = append(result, eth)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Switch](port.GetClient(), port.connectedSwitches)
 }
 
 // EthernetInterfaces gets the Ethernet interfaces this port provides.
 func (port *Port) EthernetInterfaces() ([]*EthernetInterface, error) {
-	var result []*EthernetInterface
-
-	collectionError := common.NewCollectionError()
-	for _, ethLink := range port.ethernetInterfaces {
-		eth, err := GetEthernetInterface(port.GetClient(), ethLink)
-		if err != nil {
-			collectionError.Failures[ethLink] = err
-		} else {
-			result = append(result, eth)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[EthernetInterface](port.GetClient(), port.ethernetInterfaces)
 }
 
 // GenZLPRT gets the Gen-Z Core Specification-defined Linear Packet Relay Table for this port.
 func (port *Port) GenZLPRT() ([]*RouteEntry, error) {
-	var result []*RouteEntry
-
-	collectionError := common.NewCollectionError()
-	for _, ethLink := range port.genZLPRT {
-		eth, err := GetRouteEntry(port.GetClient(), ethLink)
-		if err != nil {
-			collectionError.Failures[ethLink] = err
-		} else {
-			result = append(result, eth)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[RouteEntry](port.GetClient(), port.genZLPRT)
 }
 
 // GenZMPRT gets the Gen-Z Core Specification-defined Multi-subnet Packet Relay Table for this port.
 func (port *Port) GenZMPRT() ([]*RouteEntry, error) {
-	var result []*RouteEntry
-
-	collectionError := common.NewCollectionError()
-	for _, ethLink := range port.genZMPRT {
-		eth, err := GetRouteEntry(port.GetClient(), ethLink)
-		if err != nil {
-			collectionError.Failures[ethLink] = err
-		} else {
-			result = append(result, eth)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[RouteEntry](port.GetClient(), port.genZMPRT)
 }
 
 // GenZVCAT gets the Gen-Z Virtual Channel Action Table for the port.
 func (port *Port) GenZVCAT() ([]*VCATEntry, error) {
-	var result []*VCATEntry
-
-	collectionError := common.NewCollectionError()
-	for _, ethLink := range port.genZVCAT {
-		eth, err := GetVCATEntry(port.GetClient(), ethLink)
-		if err != nil {
-			collectionError.Failures[ethLink] = err
-		} else {
-			result = append(result, eth)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[VCATEntry](port.GetClient(), port.genZVCAT)
 }
 
 // Update commits updates to this object's properties to the running system.

--- a/redfish/powerdistribution.go
+++ b/redfish/powerdistribution.go
@@ -319,44 +319,12 @@ func (powerDistribution *PowerDistribution) PowerSupplies() ([]*PowerSupplyUnit,
 
 // ManagedBy gets the collection of managers for this equipment.
 func (powerDistribution *PowerDistribution) ManagedBy() ([]*Manager, error) {
-	var result []*Manager
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range powerDistribution.managedBy {
-		manager, err := GetManager(powerDistribution.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, manager)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Manager](powerDistribution.GetClient(), powerDistribution.managedBy)
 }
 
 // Chassis gets the collection of chassis for this equipment.
 func (powerDistribution *PowerDistribution) Chassis() ([]*Chassis, error) {
-	var result []*Chassis
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range powerDistribution.chassis {
-		chassis, err := GetChassis(powerDistribution.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, chassis)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Chassis](powerDistribution.GetClient(), powerDistribution.chassis)
 }
 
 // Branches gets the collection that contains the branch circuits for this equipment.

--- a/redfish/powerdomain.go
+++ b/redfish/powerdomain.go
@@ -107,149 +107,37 @@ func (powerdomain *PowerDomain) UnmarshalJSON(b []byte) error {
 
 // ElectricalBuses gets the electrical buses in this power domain.
 func (powerdomain *PowerDomain) ElectricalBuses() ([]*PowerDistribution, error) {
-	var result []*PowerDistribution
-
-	collectionError := common.NewCollectionError()
-	for _, ethLink := range powerdomain.electricalBuses {
-		eth, err := GetPowerDistribution(powerdomain.GetClient(), ethLink)
-		if err != nil {
-			collectionError.Failures[ethLink] = err
-		} else {
-			result = append(result, eth)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[PowerDistribution](powerdomain.GetClient(), powerdomain.electricalBuses)
 }
 
 // FloorPDUs gets the floor power distribution units in this power domain.
 func (powerdomain *PowerDomain) FloorPDUs() ([]*PowerDistribution, error) {
-	var result []*PowerDistribution
-
-	collectionError := common.NewCollectionError()
-	for _, ethLink := range powerdomain.floorPDUs {
-		eth, err := GetPowerDistribution(powerdomain.GetClient(), ethLink)
-		if err != nil {
-			collectionError.Failures[ethLink] = err
-		} else {
-			result = append(result, eth)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[PowerDistribution](powerdomain.GetClient(), powerdomain.floorPDUs)
 }
 
 // ManagedBy gets the managers that manage this power domain.
 func (powerdomain *PowerDomain) ManagedBy() ([]*Manager, error) {
-	var result []*Manager
-
-	collectionError := common.NewCollectionError()
-	for _, ethLink := range powerdomain.managedBy {
-		eth, err := GetManager(powerdomain.GetClient(), ethLink)
-		if err != nil {
-			collectionError.Failures[ethLink] = err
-		} else {
-			result = append(result, eth)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Manager](powerdomain.GetClient(), powerdomain.managedBy)
 }
 
 // PowerShelves gets the power shelves in this power domain.
 func (powerdomain *PowerDomain) PowerShelves() ([]*PowerDistribution, error) {
-	var result []*PowerDistribution
-
-	collectionError := common.NewCollectionError()
-	for _, ethLink := range powerdomain.powerShelves {
-		eth, err := GetPowerDistribution(powerdomain.GetClient(), ethLink)
-		if err != nil {
-			collectionError.Failures[ethLink] = err
-		} else {
-			result = append(result, eth)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[PowerDistribution](powerdomain.GetClient(), powerdomain.powerShelves)
 }
 
 // RackPDUs gets the rack-level power distribution units in this power domain.
 func (powerdomain *PowerDomain) RackPDUs() ([]*PowerDistribution, error) {
-	var result []*PowerDistribution
-
-	collectionError := common.NewCollectionError()
-	for _, ethLink := range powerdomain.rackPDUs {
-		eth, err := GetPowerDistribution(powerdomain.GetClient(), ethLink)
-		if err != nil {
-			collectionError.Failures[ethLink] = err
-		} else {
-			result = append(result, eth)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[PowerDistribution](powerdomain.GetClient(), powerdomain.rackPDUs)
 }
 
 // Switchgear gets the switchgear in this power domain.
 func (powerdomain *PowerDomain) Switchgear() ([]*PowerDistribution, error) {
-	var result []*PowerDistribution
-
-	collectionError := common.NewCollectionError()
-	for _, ethLink := range powerdomain.switchgear {
-		eth, err := GetPowerDistribution(powerdomain.GetClient(), ethLink)
-		if err != nil {
-			collectionError.Failures[ethLink] = err
-		} else {
-			result = append(result, eth)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[PowerDistribution](powerdomain.GetClient(), powerdomain.switchgear)
 }
 
 // TransferSwitches gets the transfer switches in this power domain.
 func (powerdomain *PowerDomain) TransferSwitches() ([]*PowerDistribution, error) {
-	var result []*PowerDistribution
-
-	collectionError := common.NewCollectionError()
-	for _, ethLink := range powerdomain.transferSwitches {
-		eth, err := GetPowerDistribution(powerdomain.GetClient(), ethLink)
-		if err != nil {
-			collectionError.Failures[ethLink] = err
-		} else {
-			result = append(result, eth)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[PowerDistribution](powerdomain.GetClient(), powerdomain.transferSwitches)
 }
 
 // GetPowerDomain will get a PowerDomain instance from the service.

--- a/redfish/powerequipment.go
+++ b/redfish/powerequipment.go
@@ -102,23 +102,7 @@ func GetPowerEquipment(c common.Client, uri string) (*PowerEquipment, error) {
 
 // ManagedBy gets the collection of managers of this PowerEquipment
 func (powerEquipment *PowerEquipment) ManagedBy() ([]*Manager, error) {
-	var result []*Manager
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range powerEquipment.managedBy {
-		manager, err := GetManager(powerEquipment.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, manager)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Manager](powerEquipment.GetClient(), powerEquipment.managedBy)
 }
 
 // ElectricalBuses gets the collection that contains a set of electrical bus units.

--- a/redfish/powersupplyunit.go
+++ b/redfish/powersupplyunit.go
@@ -281,42 +281,10 @@ func (powerSupplyUnit *PowerSupplyUnit) Outlet() (*Outlet, error) {
 
 // PowerOutlets gets the outlets that supply power to this power supply.
 func (powerSupplyUnit *PowerSupplyUnit) PowerOutlets() ([]*Outlet, error) {
-	var result []*Outlet
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range powerSupplyUnit.powerOutlets {
-		chassis, err := GetOutlet(powerSupplyUnit.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, chassis)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Outlet](powerSupplyUnit.GetClient(), powerSupplyUnit.powerOutlets)
 }
 
 // PoweringChassis gets the collection of the chassis directly powered by this power supply.
 func (powerSupplyUnit *PowerSupplyUnit) PoweringChassis() ([]*Chassis, error) {
-	var result []*Chassis
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range powerSupplyUnit.poweringChassis {
-		chassis, err := GetChassis(powerSupplyUnit.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, chassis)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Chassis](powerSupplyUnit.GetClient(), powerSupplyUnit.poweringChassis)
 }

--- a/redfish/processor.go
+++ b/redfish/processor.go
@@ -729,23 +729,7 @@ func (processor *Processor) ResetToDefaults() error {
 
 // AccelerationFunctions gets acceleration functions associated with this processor.
 func (processor *Processor) AcclerationFunctions() ([]*AccelerationFunction, error) {
-	var result []*AccelerationFunction
-
-	collectionError := common.NewCollectionError()
-	for _, ethLink := range processor.accelerationFunctions {
-		eth, err := GetAccelerationFunction(processor.GetClient(), ethLink)
-		if err != nil {
-			collectionError.Failures[ethLink] = err
-		} else {
-			result = append(result, eth)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[AccelerationFunction](processor.GetClient(), processor.accelerationFunctions)
 }
 
 // AppliedOperatingConfig gets the operating configuration that is applied to this processor.
@@ -766,23 +750,7 @@ func (processor *Processor) Assembly() (*Assembly, error) {
 
 // Certificates gets the certificates for device identity and attestation.
 func (processor *Processor) Certificates() ([]*Certificate, error) {
-	var result []*Certificate
-
-	collectionError := common.NewCollectionError()
-	for _, ethLink := range processor.certificates {
-		eth, err := GetCertificate(processor.GetClient(), ethLink)
-		if err != nil {
-			collectionError.Failures[ethLink] = err
-		} else {
-			result = append(result, eth)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Certificate](processor.GetClient(), processor.certificates)
 }
 
 // EnvironmentMetrics gets the environment metrics for this processor.
@@ -803,68 +771,20 @@ func (processor *Processor) Metrics() (*ProcessorMetrics, error) {
 
 // OperatingConfigs gets acceleration functions associated with this processor.
 func (processor *Processor) OperatingConfigs() ([]*OperatingConfig, error) {
-	var result []*OperatingConfig
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range processor.operatingConfigs {
-		item, err := GetOperatingConfig(processor.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[OperatingConfig](processor.GetClient(), processor.operatingConfigs)
 }
 
 // Ports gets the interconnect and fabric ports of this processor. It shall not
 // contain ports for GraphicsController resources, USBController resources, or
 // other local adapter-related types of resources.
 func (processor *Processor) Ports() ([]*Port, error) {
-	var result []*Port
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range processor.ports {
-		item, err := GetPort(processor.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Port](processor.GetClient(), processor.ports)
 }
 
 // SubProcessors gets the sub-processors associated with this processor, such as
 // cores or threads, that are part of a processor.
 func (processor *Processor) SubProcessors() ([]*Processor, error) {
-	var result []*Processor
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range processor.subProcessors {
-		item, err := GetProcessor(processor.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Processor](processor.GetClient(), processor.subProcessors)
 }
 
 // Chassis gets the physical container associated with this processor.
@@ -877,65 +797,17 @@ func (processor *Processor) Chassis() (*Chassis, error) {
 
 // ConnectedProcessors gets the processors that are directly connected to this processor.
 func (processor *Processor) ConnectedProcessors() ([]*Processor, error) {
-	var result []*Processor
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range processor.connectedProcessors {
-		item, err := GetProcessor(processor.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Processor](processor.GetClient(), processor.connectedProcessors)
 }
 
 // Endpoints gets the endpoints associated with this processor.
 func (processor *Processor) Endpoints() ([]*Endpoint, error) {
-	var result []*Endpoint
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range processor.endpoints {
-		item, err := GetEndpoint(processor.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Endpoint](processor.GetClient(), processor.endpoints)
 }
 
 // FabricAdapters gets the fabric adapters that present this processor to a fabric.
 func (processor *Processor) FabricAdapters() ([]*FabricAdapter, error) {
-	var result []*FabricAdapter
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range processor.fabricAdapters {
-		item, err := GetFabricAdapter(processor.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[FabricAdapter](processor.GetClient(), processor.fabricAdapters)
 }
 
 // GraphicsController gets a graphics controller associated with this processor.
@@ -948,44 +820,12 @@ func (processor *Processor) GraphicsController() (*GraphicsController, error) {
 
 // Memory gets the memory objects that are associated with this processor.
 func (processor *Processor) Memory() ([]*Memory, error) {
-	var result []*Memory
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range processor.memory {
-		item, err := GetMemory(processor.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Memory](processor.GetClient(), processor.memory)
 }
 
 // NetworkDeviceFunctions gets the memory objects that are associated with this processor.
 func (processor *Processor) NetworkDeviceFunctions() ([]*NetworkDeviceFunction, error) {
-	var result []*NetworkDeviceFunction
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range processor.networkDeviceFunctions {
-		item, err := GetNetworkDeviceFunction(processor.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[NetworkDeviceFunction](processor.GetClient(), processor.networkDeviceFunctions)
 }
 
 // PCIeDevice gets the PCIe device associated with this processor.
@@ -998,23 +838,7 @@ func (processor *Processor) PCIeDevice() (*PCIeDevice, error) {
 
 // PCIeFunctions gets the PCIeFunctions associated with this processor.
 func (processor *Processor) PCIeFunctions() ([]*PCIeFunction, error) {
-	var result []*PCIeFunction
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range processor.pcieFunctions {
-		item, err := GetPCIeFunction(processor.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[PCIeFunction](processor.GetClient(), processor.pcieFunctions)
 }
 
 // GetProcessor will get a Processor instance from the system

--- a/redfish/pump.go
+++ b/redfish/pump.go
@@ -121,23 +121,7 @@ func (pump *Pump) Assembly() (*Assembly, error) {
 
 // Filters gets a collection of filters.
 func (pump *Pump) Filters() ([]*Filter, error) {
-	var result []*Filter
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range pump.filters {
-		item, err := GetFilter(pump.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Filter](pump.GetClient(), pump.filters)
 }
 
 // Update commits updates to this object's properties to the running system.

--- a/redfish/reservoir.go
+++ b/redfish/reservoir.go
@@ -125,23 +125,7 @@ func (reservoir *Reservoir) Assembly() (*Assembly, error) {
 
 // Filters gets a collection of filters.
 func (reservoir *Reservoir) Filters() ([]*Filter, error) {
-	var result []*Filter
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range reservoir.filters {
-		item, err := GetFilter(reservoir.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Filter](reservoir.GetClient(), reservoir.filters)
 }
 
 // Update commits updates to this object's properties to the running system.

--- a/redfish/storage.go
+++ b/redfish/storage.go
@@ -271,23 +271,7 @@ func (storage *Storage) Controllers() ([]*StorageController, error) {
 // Drives gets the drives attached to the storage controllers that this
 // resource represents.
 func (storage *Storage) Drives() ([]*Drive, error) {
-	var result []*Drive
-
-	collectionError := common.NewCollectionError()
-	for _, driveLink := range storage.drives {
-		drive, err := GetDrive(storage.GetClient(), driveLink)
-		if err != nil {
-			collectionError.Failures[driveLink] = err
-		} else {
-			result = append(result, drive)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Drive](storage.GetClient(), storage.drives)
 }
 
 // EndpointGroups gets the set of endpoints that are used for a common purpose such as an ACL
@@ -308,65 +292,17 @@ func (storage *Storage) Volumes() ([]*Volume, error) {
 
 // Enclosures gets the physical containers attached to this resource.
 func (storage *Storage) Enclosures() ([]*Chassis, error) {
-	var result []*Chassis
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range storage.enclosures {
-		item, err := GetChassis(storage.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Chassis](storage.GetClient(), storage.enclosures)
 }
 
 // HostingStorageSystems gets the storage systems that host this storage subsystem.
 func (storage *Storage) HostingStorageSystems() ([]*ComputerSystem, error) {
-	var result []*ComputerSystem
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range storage.hostingStorageSystems {
-		item, err := GetComputerSystem(storage.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[ComputerSystem](storage.GetClient(), storage.hostingStorageSystems)
 }
 
 // NVMeoFDiscoverySubsystems gets the discovery subsystems that discovered this subsystem in an NVMe-oF environment.
 func (storage *Storage) NVMeoFDiscoverySubsystems() ([]*Storage, error) {
-	var result []*Storage
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range storage.hostingStorageSystems {
-		item, err := GetStorage(storage.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Storage](storage.GetClient(), storage.nvmeoFDiscoverySubsystems)
 }
 
 // SimpleStorage gets the simple storage instance that corresponds to this storage.
@@ -379,23 +315,7 @@ func (storage *Storage) SimpleStorage() (*SimpleStorage, error) {
 
 // // StorageServices gets the storage services that connect to this storage subsystem.
 // func (storage *Storage) StorageServices() ([]*swordfish.StorageService, error) {
-// 	var result []*swordfish.StorageService
-
-// 	collectionError := common.NewCollectionError()
-// 	for _, uri := range storage.storageServices {
-// 		item, err := swordfish.GetStorageService(storage.GetClient(), uri)
-// 		if err != nil {
-// 			collectionError.Failures[uri] = err
-// 		} else {
-// 			result = append(result, item)
-// 		}
-// 	}
-
-// 	if collectionError.Empty() {
-// 		return result, nil
-// 	}
-
-// 	return result, collectionError
+//  	return common.GetObjects[StorageService](storage.GetClient(), storage.storageServices)
 // }
 
 // ResetToDefaults resets the storage device to factory defaults. This can cause the loss of data.

--- a/redfish/storagecontroller.go
+++ b/redfish/storagecontroller.go
@@ -380,132 +380,36 @@ func (storagecontroller *StorageController) Ports() ([]*Port, error) {
 
 // // AttachedVolumes gets the volumes that are attached to this instance of storage controller.
 // func (storagecontroller *StorageController) AttachedVolumes() ([]*swordfish.Volume, error) {
-// 	var result []*swordfish.Volume
-
-// 	collectionError := common.NewCollectionError()
-// 	for _, uri := range storagecontroller.attachedVolumes {
-// 		endpoint, err := swordfish.GetVolume(storagecontroller.GetClient(), uri)
-// 		if err != nil {
-// 			collectionError.Failures[uri] = err
-// 		} else {
-// 			result = append(result, endpoint)
-// 		}
-// 	}
-
-// 	if collectionError.Empty() {
-// 		return result, nil
-// 	}
-
-// 	return result, collectionError
+//  	return common.GetObjects[Volume](storagecontroller.GetClient(), storagecontroller.attachedVolumes)
 // }
 
 // Batteries gets the batteries that provide power to this storage controller during a power-loss event,
 // such as with battery-backed RAID controllers. This property shall not be present if the batteries
 // power the containing chassis as a whole rather than the individual storage controller.
 func (storagecontroller *StorageController) Batteries() ([]*Battery, error) {
-	var result []*Battery
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range storagecontroller.batteries {
-		endpoint, err := GetBattery(storagecontroller.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, endpoint)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Battery](storagecontroller.GetClient(), storagecontroller.batteries)
 }
 
 // Endpoints gets the storage controller's endpoints.
 func (storagecontroller *StorageController) Endpoints() ([]*Endpoint, error) {
-	var result []*Endpoint
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range storagecontroller.endpoints {
-		endpoint, err := GetEndpoint(storagecontroller.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, endpoint)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Endpoint](storagecontroller.GetClient(), storagecontroller.endpoints)
 }
 
 // NVMeDiscoveredSubsystems gets the storage that represent the NVMe subsystems discovered by
 // this discovery controller. This property shall only be present if ControllerType in
 // NVMeControllerProperties contains 'Discovery'.
 func (storagecontroller *StorageController) NVMeDiscoveredSubsystems() ([]*Storage, error) {
-	var result []*Storage
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range storagecontroller.nvmeDiscoveredSubsystems {
-		item, err := GetStorage(storagecontroller.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Storage](storagecontroller.GetClient(), storagecontroller.nvmeDiscoveredSubsystems)
 }
 
 // NetworkDeviceFunctions the network device functions that provide connectivity to this controller.
 func (storagecontroller *StorageController) NetworkDeviceFunctions() ([]*NetworkDeviceFunction, error) {
-	var result []*NetworkDeviceFunction
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range storagecontroller.networkDeviceFunctions {
-		item, err := GetNetworkDeviceFunction(storagecontroller.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[NetworkDeviceFunction](storagecontroller.GetClient(), storagecontroller.networkDeviceFunctions)
 }
 
 // PCIeFunctions gets the the PCIe functions that the storage controller produces.
 func (storagecontroller *StorageController) PCIeFunctions() ([]*PCIeFunction, error) {
-	var result []*PCIeFunction
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range storagecontroller.pcieFunctions {
-		item, err := GetPCIeFunction(storagecontroller.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[PCIeFunction](storagecontroller.GetClient(), storagecontroller.pcieFunctions)
 }
 
 // Update commits updates to this object's properties to the running system.

--- a/redfish/switch.go
+++ b/redfish/switch.go
@@ -204,44 +204,12 @@ func (sw *Switch) Chassis() (*Chassis, error) {
 
 // Endpoints gets any endpoints associated with this fabric.
 func (sw *Switch) Endpoints() ([]*Endpoint, error) {
-	var result []*Endpoint
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range sw.endpoints {
-		cl, err := GetEndpoint(sw.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, cl)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Endpoint](sw.GetClient(), sw.endpoints)
 }
 
 // ManagedBy gets the managers of this fabric.
 func (sw *Switch) ManagedBy() ([]*Manager, error) {
-	var result []*Manager
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range sw.managedBy {
-		cl, err := GetManager(sw.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, cl)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Manager](sw.GetClient(), sw.managedBy)
 }
 
 // PCIeDevice gets the PCIe device providing this switch.

--- a/redfish/task.go
+++ b/redfish/task.go
@@ -164,23 +164,7 @@ func (task *Task) UnmarshalJSON(b []byte) error {
 // SubTasks gets the sub-tasks for this task.
 // This property shall not be present if this resource represents a sub-task for a task.
 func (task *Task) SubTasks() ([]*Task, error) {
-	var result []*Task
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range task.subTasks {
-		item, err := GetTask(task.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Task](task.GetClient(), task.subTasks)
 }
 
 // GetTask will get a Task instance from the service.

--- a/redfish/triggers.go
+++ b/redfish/triggers.go
@@ -220,26 +220,7 @@ func (triggers *Triggers) UnmarshalJSON(b []byte) error {
 // MetricReportDefinitions gets the metric report definitions that generate new metric
 // reports when a trigger condition is met and when the TriggerActions property contains 'RedfishMetricReport'.
 func (triggers *Triggers) MetricReportDefinitions() ([]*MetricReportDefinition, error) {
-	var result []*MetricReportDefinition
-	if len(triggers.metricReportDefinitions) == 0 {
-		return result, nil
-	}
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range triggers.metricReportDefinitions {
-		rb, err := GetMetricReportDefinition(triggers.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, rb)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[MetricReportDefinition](triggers.GetClient(), triggers.metricReportDefinitions)
 }
 
 // Update commits updates to this object's properties to the running system.

--- a/redfish/trustedcomponent.go
+++ b/redfish/trustedcomponent.go
@@ -178,44 +178,12 @@ func (trustedcomponent *TrustedComponent) ActiveSoftwareImage() (*SoftwareInvent
 
 // ComponentIntegrity gets the resources for which the trusted component is responsible.
 func (trustedcomponent *TrustedComponent) ComponentIntegrity() ([]*ComponentIntegrity, error) {
-	var result []*ComponentIntegrity
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range trustedcomponent.componentIntegrity {
-		cs, err := GetComponentIntegrity(trustedcomponent.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, cs)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[ComponentIntegrity](trustedcomponent.GetClient(), trustedcomponent.componentIntegrity)
 }
 
 // SoftwareImages gets the firmware images that apply to this trusted component.
 func (trustedcomponent *TrustedComponent) SoftwareImages() ([]*SoftwareInventory, error) {
-	var result []*SoftwareInventory
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range trustedcomponent.softwareImages {
-		cs, err := GetSoftwareInventory(trustedcomponent.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, cs)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[SoftwareInventory](trustedcomponent.GetClient(), trustedcomponent.softwareImages)
 }
 
 // Certificates gets the certificates associated with this trusted component.

--- a/redfish/updateservice.go
+++ b/redfish/updateservice.go
@@ -339,23 +339,7 @@ func (updateService *UpdateService) PublicIdentitySSHKey() (*Key, error) {
 // the contents of this collection, services may perform additional verification based on
 // other factors, such as the configuration of the SecurityPolicy resource.
 func (updateService *UpdateService) RemoteServerCertificates() ([]*Certificate, error) {
-	var result []*Certificate
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range updateService.remoteServerCertificates {
-		item, err := GetCertificate(updateService.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Certificate](updateService.GetClient(), updateService.remoteServerCertificates)
 }
 
 // RemoteServerSSHKeys gets the server SSH keys for the server referenced by the ImageURI
@@ -366,23 +350,7 @@ func (updateService *UpdateService) RemoteServerCertificates() ([]*Certificate, 
 // If VerifyRemoteServerSSHKey is `false`, the service shall not perform key verification
 // with keys in this collection.
 func (updateService *UpdateService) RemoteServerSSHKeys() ([]*Key, error) {
-	var result []*Key
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range updateService.remoteServerSSHKeys {
-		item, err := GetKey(updateService.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Key](updateService.GetClient(), updateService.remoteServerSSHKeys)
 }
 
 // SoftwareInventories gets the collection of software inventories of this update service

--- a/redfish/usbcontroller.go
+++ b/redfish/usbcontroller.go
@@ -87,23 +87,7 @@ func (usbcontroller *USBController) PCIeDevice() (*PCIeDevice, error) {
 
 // Processors gets the processors that can utilize this USB controller.
 func (usbcontroller *USBController) Processors() ([]*Processor, error) {
-	var result []*Processor
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range usbcontroller.processors {
-		item, err := GetProcessor(usbcontroller.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Processor](usbcontroller.GetClient(), usbcontroller.processors)
 }
 
 // Ports gets the ports of the USB controller.

--- a/redfish/virtualmedia.go
+++ b/redfish/virtualmedia.go
@@ -221,45 +221,13 @@ func (virtualmedia *VirtualMedia) UnmarshalJSON(b []byte) error {
 // services may perform additional verification based on other factors, such as the
 // configuration of the SecurityPolicy resource.
 func (virtualmedia *VirtualMedia) Certificates() ([]*Certificate, error) {
-	var result []*Certificate
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range virtualmedia.certificates {
-		item, err := GetCertificate(virtualmedia.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Certificate](virtualmedia.GetClient(), virtualmedia.certificates)
 }
 
 // ClientCertificates gets the client identity certificates that are provided to
 // the server referenced by the Image property as part of TLS handshaking.
 func (virtualmedia *VirtualMedia) ClientCertificates() ([]*Certificate, error) {
-	var result []*Certificate
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range virtualmedia.clientCertificates {
-		item, err := GetCertificate(virtualmedia.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Certificate](virtualmedia.GetClient(), virtualmedia.clientCertificates)
 }
 
 // Update commits updates to this object's properties to the running system.

--- a/redfish/volume.go
+++ b/redfish/volume.go
@@ -857,23 +857,7 @@ func (volume *Volume) SuspendReplication(targetVolumeURI string) error {
 // CacheDataVolumes gets the cache data volumes this volume serves as a cache volume. The
 // corresponding VolumeUsage property shall be set to CacheOnly when this property is used.
 func (volume *Volume) CacheDataVolumes() ([]*Volume, error) {
-	var result []*Volume
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range volume.cacheDataVolumes {
-		item, err := GetVolume(volume.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Volume](volume.GetClient(), volume.cacheDataVolumes)
 }
 
 // CacheVolumeSource gets the cache volume source for this volume. The corresponding VolumeUsage
@@ -896,88 +880,24 @@ func (volume *Volume) CacheVolumeSource() (*Volume, error) {
 
 // ClientEndpoints gets the client Endpoints this volume is associated with.
 func (volume *Volume) ClientEndpoints() ([]*Endpoint, error) {
-	var result []*Endpoint
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range volume.clientEndpoints {
-		item, err := GetEndpoint(volume.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Endpoint](volume.GetClient(), volume.clientEndpoints)
 }
 
 // Controllers gets the controllers (of type StorageController) associated with this volume.
 // When the volume is of type NVMe, these may be both the physical and logical controller
 // representations.
 func (volume *Volume) Controllers() ([]*StorageController, error) {
-	var result []*StorageController
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range volume.controllers {
-		item, err := GetStorageController(volume.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[StorageController](volume.GetClient(), volume.controllers)
 }
 
 // DedicatedSpareDrives gets the drives which are dedicated spares for this volume.
 func (volume *Volume) DedicatedSpareDrives() ([]*Drive, error) {
-	var result []*Drive
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range volume.dedicatedSpareDrives {
-		item, err := GetDrive(volume.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Drive](volume.GetClient(), volume.dedicatedSpareDrives)
 }
 
 // Drives references the Drives that this volume is associated with.
 func (volume *Volume) Drives() ([]*Drive, error) {
-	var result []*Drive
-
-	collectionError := common.NewCollectionError()
-	for _, driveLink := range volume.drives {
-		drive, err := GetDrive(volume.GetClient(), driveLink)
-		if err != nil {
-			collectionError.Failures[driveLink] = err
-		} else {
-			result = append(result, drive)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Drive](volume.GetClient(), volume.drives)
 }
 
 // OwningStorageResource gets the Storage resource that owns or contains this volume.
@@ -998,23 +918,7 @@ func (volume *Volume) OwningStorageResource() (*Storage, error) {
 
 // ServerEndpoints gets the server Endpoints this volume is associated with.
 func (volume *Volume) ServerEndpoints() ([]*Endpoint, error) {
-	var result []*Endpoint
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range volume.serverEndpoints {
-		item, err := GetEndpoint(volume.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Endpoint](volume.GetClient(), volume.serverEndpoints)
 }
 
 // Update commits updates to this object's properties to the running system.

--- a/redfish/zone.go
+++ b/redfish/zone.go
@@ -225,128 +225,32 @@ func (zone *Zone) RemoveEndpoint(endpointURI, endpointETag, zoneETag string) err
 
 // AddressPools gets the address pools associated with this zone.
 func (zone *Zone) AddressPools() ([]*AddressPool, error) {
-	var result []*AddressPool
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range zone.addressPools {
-		item, err := GetAddressPool(zone.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[AddressPool](zone.GetClient(), zone.addressPools)
 }
 
 // ContainedByZones gets the zone that contain this zone.
 func (zone *Zone) ContainedByZones() ([]*Zone, error) {
-	var result []*Zone
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range zone.containedByZones {
-		item, err := GetZone(zone.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Zone](zone.GetClient(), zone.containedByZones)
 }
 
 // ContainsZones gets the zones that are contained by this zone.
 func (zone *Zone) ContainsZones() ([]*Zone, error) {
-	var result []*Zone
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range zone.containsZones {
-		item, err := GetZone(zone.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Zone](zone.GetClient(), zone.containsZones)
 }
 
 // Endpoints gets the endpoints that this zone contains.
 func (zone *Zone) Endpoints() ([]*Endpoint, error) {
-	var result []*Endpoint
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range zone.endpoints {
-		item, err := GetEndpoint(zone.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Endpoint](zone.GetClient(), zone.endpoints)
 }
 
 // InvolvedSwitches gets the switches in this zone.
 func (zone *Zone) InvolvedSwitches() ([]*Switch, error) {
-	var result []*Switch
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range zone.involvedSwitches {
-		item, err := GetSwitch(zone.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Switch](zone.GetClient(), zone.involvedSwitches)
 }
 
 // ResourceBlocks gets the resource blocks with which this zone is associated.
 func (zone *Zone) ResourceBlocks() ([]*ResourceBlock, error) {
-	var result []*ResourceBlock
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range zone.resourceBlocks {
-		item, err := GetResourceBlock(zone.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[ResourceBlock](zone.GetClient(), zone.resourceBlocks)
 }
 
 // Update commits updates to this object's properties to the running system.

--- a/swordfish/classofservice.go
+++ b/swordfish/classofservice.go
@@ -99,109 +99,29 @@ func ListReferencedClassOfServices(c common.Client, link string) ([]*ClassOfServ
 // DataProtectionLinesOfServices gets the DataProtectionLinesOfService that are
 // part of this ClassOfService.
 func (classofservice *ClassOfService) DataProtectionLinesOfServices() ([]*DataProtectionLineOfService, error) {
-	var result []*DataProtectionLineOfService
-
-	collectionError := common.NewCollectionError()
-	for _, dpLosLink := range classofservice.dataProtectionLinesOfService {
-		dpLos, err := GetDataProtectionLineOfService(classofservice.GetClient(), dpLosLink)
-		if err != nil {
-			collectionError.Failures[dpLosLink] = err
-		} else {
-			result = append(result, dpLos)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[DataProtectionLineOfService](classofservice.GetClient(), classofservice.dataProtectionLinesOfService)
 }
 
 // DataSecurityLinesOfServices gets the DataSecurityLinesOfService that are
 // part of this ClassOfService.
 func (classofservice *ClassOfService) DataSecurityLinesOfServices() ([]*DataSecurityLineOfService, error) {
-	var result []*DataSecurityLineOfService
-
-	collectionError := common.NewCollectionError()
-	for _, dsLosLink := range classofservice.dataSecurityLinesOfService {
-		dsLos, err := GetDataSecurityLineOfService(classofservice.GetClient(), dsLosLink)
-		if err != nil {
-			collectionError.Failures[dsLosLink] = err
-		} else {
-			result = append(result, dsLos)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[DataSecurityLineOfService](classofservice.GetClient(), classofservice.dataSecurityLinesOfService)
 }
 
 // DataStorageLinesOfServices gets the DataStorageLinesOfService that are
 // part of this ClassOfService.
 func (classofservice *ClassOfService) DataStorageLinesOfServices() ([]*DataStorageLineOfService, error) {
-	var result []*DataStorageLineOfService
-
-	collectionError := common.NewCollectionError()
-	for _, dsLosLink := range classofservice.dataStorageLinesOfService {
-		dsLos, err := GetDataStorageLineOfService(classofservice.GetClient(), dsLosLink)
-		if err != nil {
-			collectionError.Failures[dsLosLink] = err
-		} else {
-			result = append(result, dsLos)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[DataStorageLineOfService](classofservice.GetClient(), classofservice.dataStorageLinesOfService)
 }
 
 // IOConnectivityLinesOfServices gets the IOConnectivityLinesOfService that are
 // part of this ClassOfService.
 func (classofservice *ClassOfService) IOConnectivityLinesOfServices() ([]*IOConnectivityLineOfService, error) {
-	var result []*IOConnectivityLineOfService
-
-	collectionError := common.NewCollectionError()
-	for _, ioLosLink := range classofservice.dataSecurityLinesOfService {
-		ioLos, err := GetIOConnectivityLineOfService(classofservice.GetClient(), ioLosLink)
-		if err != nil {
-			collectionError.Failures[ioLosLink] = err
-		} else {
-			result = append(result, ioLos)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[IOConnectivityLineOfService](classofservice.GetClient(), classofservice.ioConnectivityLinesOfService)
 }
 
 // IOPerformanceLinesOfServices gets the IOPerformanceLinesOfService that are
 // part of this ClassOfService.
 func (classofservice *ClassOfService) IOPerformanceLinesOfServices() ([]*IOPerformanceLineOfService, error) {
-	var result []*IOPerformanceLineOfService
-
-	collectionError := common.NewCollectionError()
-	for _, ioLosLink := range classofservice.dataSecurityLinesOfService {
-		ioLos, err := GetIOPerformanceLineOfService(classofservice.GetClient(), ioLosLink)
-		if err != nil {
-			collectionError.Failures[ioLosLink] = err
-		} else {
-			result = append(result, ioLos)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[IOPerformanceLineOfService](classofservice.GetClient(), classofservice.ioPerformanceLinesOfService)
 }

--- a/swordfish/consistencygroup.go
+++ b/swordfish/consistencygroup.go
@@ -264,23 +264,7 @@ func (consistencygroup *ConsistencyGroup) SuspendReplication(targetGroupURI stri
 
 // Volumes gets the volumes in this consistency group.
 func (consistencygroup *ConsistencyGroup) Volumes() ([]*Volume, error) {
-	var result []*Volume
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range consistencygroup.volumes {
-		sc, err := GetVolume(consistencygroup.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, sc)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Volume](consistencygroup.GetClient(), consistencygroup.volumes)
 }
 
 // Update commits updates to this object's properties to the running system.

--- a/swordfish/dataprotectionloscapabilities.go
+++ b/swordfish/dataprotectionloscapabilities.go
@@ -188,42 +188,14 @@ func ListReferencedDataProtectionLoSCapabilities(c common.Client, link string) (
 
 // SupportedReplicaOptions gets the support replica ClassesOfService.
 func (dataprotectionloscapabilities *DataProtectionLoSCapabilities) SupportedReplicaOptions() ([]*ClassOfService, error) {
-	var result []*ClassOfService
-
-	collectionError := common.NewCollectionError()
-	for _, link := range dataprotectionloscapabilities.supportedReplicaOptions {
-		classOfService, err := GetClassOfService(dataprotectionloscapabilities.GetClient(), link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		} else {
-			result = append(result, classOfService)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[ClassOfService](
+		dataprotectionloscapabilities.GetClient(),
+		dataprotectionloscapabilities.supportedReplicaOptions)
 }
 
 // SupportedLinesOfService gets the supported lines of service.
 func (dataprotectionloscapabilities *DataProtectionLoSCapabilities) SupportedLinesOfService() ([]*DataProtectionLineOfService, error) {
-	var result []*DataProtectionLineOfService
-
-	collectionError := common.NewCollectionError()
-	for _, link := range dataprotectionloscapabilities.supportedLinesOfService {
-		lineOfService, err := GetDataProtectionLineOfService(dataprotectionloscapabilities.GetClient(), link)
-		if err != nil {
-			collectionError.Failures[link] = err
-		} else {
-			result = append(result, lineOfService)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[DataProtectionLineOfService](
+		dataprotectionloscapabilities.GetClient(),
+		dataprotectionloscapabilities.supportedLinesOfService)
 }

--- a/swordfish/filesystem.go
+++ b/swordfish/filesystem.go
@@ -296,21 +296,5 @@ func (filesystem *FileSystem) ClassOfService() (*ClassOfService, error) {
 
 // SpareResourceSets gets the spare resource sets used for this filesystem.
 func (filesystem *FileSystem) SpareResourceSets() ([]*SpareResourceSet, error) {
-	var result []*SpareResourceSet
-
-	collectionError := common.NewCollectionError()
-	for _, rsLink := range filesystem.spareResourceSets {
-		rs, err := GetSpareResourceSet(filesystem.GetClient(), rsLink)
-		if err != nil {
-			collectionError.Failures[rsLink] = err
-		} else {
-			result = append(result, rs)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[SpareResourceSet](filesystem.GetClient(), filesystem.spareResourceSets)
 }

--- a/swordfish/nvmedomain.go
+++ b/swordfish/nvmedomain.go
@@ -131,23 +131,7 @@ func (nvmedomain *NVMeDomain) UnmarshalJSON(b []byte) error {
 
 // AssociatedDomains gets the NVMeDomains associated with this domain.
 func (nvmedomain *NVMeDomain) AssociatedDomains() ([]*NVMeDomain, error) {
-	var result []*NVMeDomain
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range nvmedomain.associatedDomains {
-		sc, err := GetNVMeDomain(nvmedomain.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, sc)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[NVMeDomain](nvmedomain.GetClient(), nvmedomain.associatedDomains)
 }
 
 // Update commits updates to this object's properties to the running system.

--- a/swordfish/storagegroup.go
+++ b/swordfish/storagegroup.go
@@ -230,44 +230,12 @@ func ListReferencedStorageGroups(c common.Client, link string) ([]*StorageGroup,
 
 // ChildStorageGroups gets child groups of this group.
 func (storagegroup *StorageGroup) ChildStorageGroups() ([]*StorageGroup, error) {
-	var result []*StorageGroup
-
-	collectionError := common.NewCollectionError()
-	for _, sgLink := range storagegroup.childStorageGroups {
-		sg, err := GetStorageGroup(storagegroup.GetClient(), sgLink)
-		if err != nil {
-			collectionError.Failures[sgLink] = err
-		} else {
-			result = append(result, sg)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[StorageGroup](storagegroup.GetClient(), storagegroup.childStorageGroups)
 }
 
 // ParentStorageGroups gets parent groups of this group.
 func (storagegroup *StorageGroup) ParentStorageGroups() ([]*StorageGroup, error) {
-	var result []*StorageGroup
-
-	collectionError := common.NewCollectionError()
-	for _, sgLink := range storagegroup.parentStorageGroups {
-		sg, err := GetStorageGroup(storagegroup.GetClient(), sgLink)
-		if err != nil {
-			collectionError.Failures[sgLink] = err
-		} else {
-			result = append(result, sg)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[StorageGroup](storagegroup.GetClient(), storagegroup.parentStorageGroups)
 }
 
 // ClassOfService gets the ClassOfService that all storage in this StorageGroup

--- a/swordfish/storagepool.go
+++ b/swordfish/storagepool.go
@@ -355,45 +355,13 @@ func ListReferencedStoragePools(c common.Client, link string) ([]*StoragePool, e
 // DedicatedSpareDrives gets the Drive entities which are currently assigned as
 // a dedicated spare and are able to support this StoragePool.
 func (storagepool *StoragePool) DedicatedSpareDrives() ([]*redfish.Drive, error) {
-	var result []*redfish.Drive
-
-	collectionError := common.NewCollectionError()
-	for _, driveLink := range storagepool.dedicatedSpareDrives {
-		drive, err := redfish.GetDrive(storagepool.GetClient(), driveLink)
-		if err != nil {
-			collectionError.Failures[driveLink] = err
-		} else {
-			result = append(result, drive)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[redfish.Drive](storagepool.GetClient(), storagepool.dedicatedSpareDrives)
 }
 
 // SpareResourceSets gets resources that may be utilized to replace the capacity
 // provided by a failed resource having a compatible type.
 func (storagepool *StoragePool) SpareResourceSets() ([]*SpareResourceSet, error) {
-	var result []*SpareResourceSet
-
-	collectionError := common.NewCollectionError()
-	for _, srsLink := range storagepool.spareResourceSets {
-		srs, err := GetSpareResourceSet(storagepool.GetClient(), srsLink)
-		if err != nil {
-			collectionError.Failures[srsLink] = err
-		} else {
-			result = append(result, srs)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[SpareResourceSet](storagepool.GetClient(), storagepool.spareResourceSets)
 }
 
 // AllocatedPools gets the storage pools allocated from this storage pool.
@@ -408,23 +376,7 @@ func (storagepool *StoragePool) AllocatedVolumes() ([]*Volume, error) {
 
 // CapacitySources gets space allocations to this pool.
 func (storagepool *StoragePool) CapacitySources() ([]*CapacitySource, error) {
-	var result []*CapacitySource
-
-	collectionError := common.NewCollectionError()
-	for _, capLink := range storagepool.capacitySources {
-		capacity, err := GetCapacitySource(storagepool.GetClient(), capLink)
-		if err != nil {
-			collectionError.Failures[capLink] = err
-		} else {
-			result = append(result, capacity)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[CapacitySource](storagepool.GetClient(), storagepool.capacitySources)
 }
 
 // ClassesOfService gets references to all classes of service supported by this

--- a/swordfish/storageservice.go
+++ b/swordfish/storageservice.go
@@ -300,87 +300,23 @@ func (storageservice *StorageService) IOPerformanceLoSCapabilities() (*IOPerform
 
 // Redundancy gets the redundancy information for the storage subsystem.
 func (storageservice *StorageService) Redundancy() ([]*redfish.Redundancy, error) {
-	var result []*redfish.Redundancy
-
-	collectionError := common.NewCollectionError()
-	for _, redundancyLink := range storageservice.redundancy {
-		redundancy, err := redfish.GetRedundancy(storageservice.GetClient(), redundancyLink)
-		if err != nil {
-			collectionError.Failures[redundancyLink] = err
-		} else {
-			result = append(result, redundancy)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[redfish.Redundancy](storageservice.GetClient(), storageservice.redundancy)
 }
 
 // LinesOfService gets lines of service for this service.
 func (storageservice *StorageService) LinesOfService() ([]*LineOfService, error) {
-	var result []*LineOfService
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range storageservice.linesOfService {
-		item, err := GetLineOfService(storageservice.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[LineOfService](storageservice.GetClient(), storageservice.linesOfService)
 }
 
 // SpareResourceSets gets resources that may be utilized to replace the capacity
 // provided by a failed resource having a compatible type.
 func (storageservice *StorageService) SpareResourceSets() ([]*SpareResourceSet, error) {
-	var result []*SpareResourceSet
-
-	collectionError := common.NewCollectionError()
-	for _, srsLink := range storageservice.spareResourceSets {
-		srs, err := GetSpareResourceSet(storageservice.GetClient(), srsLink)
-		if err != nil {
-			collectionError.Failures[srsLink] = err
-		} else {
-			result = append(result, srs)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[SpareResourceSet](storageservice.GetClient(), storageservice.spareResourceSets)
 }
 
 // StorageGroups gets the storage groups that are a part of this storage service.
 func (storageservice *StorageService) StorageGroups() ([]*StorageGroup, error) {
-	var result []*StorageGroup
-
-	collectionError := common.NewCollectionError()
-	for _, sgLink := range storageservice.spareResourceSets {
-		sg, err := GetStorageGroup(storageservice.GetClient(), sgLink)
-		if err != nil {
-			collectionError.Failures[sgLink] = err
-		} else {
-			result = append(result, sg)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetCollectionObjects[StorageGroup](storageservice.GetClient(), storageservice.storageGroups)
 }
 
 // Volumes gets the volumes that are a part of this storage service.

--- a/swordfish/volume.go
+++ b/swordfish/volume.go
@@ -805,23 +805,7 @@ func ListReferencedVolumes(c common.Client, link string) ([]*Volume, error) {
 
 // CacheDataVolumes gets the data volumes this volume serves as a cache volume.
 func (volume *Volume) CacheDataVolumes() ([]*Volume, error) {
-	var result []*Volume
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range volume.cacheDataVolumes {
-		item, err := GetVolume(volume.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[Volume](volume.GetClient(), volume.cacheDataVolumes)
 }
 
 // CacheVolumeSources gets the cache volume source for this volume.
@@ -844,88 +828,24 @@ func (volume *Volume) ClassOfService() (*ClassOfService, error) {
 
 // ClientEndpoints gets the client Endpoints associated with this volume.
 func (volume *Volume) ClientEndpoints() ([]*redfish.Endpoint, error) {
-	var result []*redfish.Endpoint
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range volume.clientEndpoints {
-		item, err := redfish.GetEndpoint(volume.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[redfish.Endpoint](volume.GetClient(), volume.clientEndpoints)
 }
 
 // ConsistencyGroups gets the ConsistencyGroups associated with this volume.
 func (volume *Volume) ConsistencyGroups() ([]*ConsistencyGroup, error) {
-	var result []*ConsistencyGroup
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range volume.consistencyGroups {
-		item, err := GetConsistencyGroup(volume.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[ConsistencyGroup](volume.GetClient(), volume.consistencyGroups)
 }
 
 // Controllers gets the controllers (of type StorageController) associated with
 // this volume. When the volume is of type NVMe, these may be both the physical
 // and logical controller representations.
 func (volume *Volume) Controllers() ([]*redfish.StorageController, error) {
-	var result []*redfish.StorageController
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range volume.controllers {
-		item, err := redfish.GetStorageController(volume.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[redfish.StorageController](volume.GetClient(), volume.controllers)
 }
 
 // getDrives gets a set of referenced drives.
 func (volume *Volume) getDrives(links []string) ([]*redfish.Drive, error) {
-	var result []*redfish.Drive
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range links {
-		drive, err := redfish.GetDrive(volume.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, drive)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[redfish.Drive](volume.GetClient(), links)
 }
 
 // DedicatedSpareDrives references the Drives that are dedicated spares for this
@@ -968,129 +888,33 @@ func (volume *Volume) ProvidingStoragePool() (*StoragePool, error) {
 
 // ServerEndpoints gets the server Endpoints associated with this volume.
 func (volume *Volume) ServerEndpoints() ([]*redfish.Endpoint, error) {
-	var result []*redfish.Endpoint
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range volume.serverEndpoints {
-		item, err := redfish.GetEndpoint(volume.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[redfish.Endpoint](volume.GetClient(), volume.serverEndpoints)
 }
 
 // SpareResourceSets gets the spare resources that can be used for this volume.
 func (volume *Volume) SpareResourceSets() ([]*SpareResourceSet, error) {
-	var result []*SpareResourceSet
-
-	collectionError := common.NewCollectionError()
-	for _, srsLink := range volume.spareResourceSets {
-		srs, err := GetSpareResourceSet(volume.GetClient(), srsLink)
-		if err != nil {
-			collectionError.Failures[srsLink] = err
-		} else {
-			result = append(result, srs)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[SpareResourceSet](volume.GetClient(), volume.spareResourceSets)
 }
 
 // StorageGroups gets the storage groups that associated with this volume.
 // This property is deprecated in favor of the Connections property.
 func (volume *Volume) StorageGroups() ([]*StorageGroup, error) {
-	var result []*StorageGroup
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range volume.storageGroups {
-		item, err := GetStorageGroup(volume.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[StorageGroup](volume.GetClient(), volume.storageGroups)
 }
 
 // AllocatedPools gets the storage pools that associated with this volume.
 func (volume *Volume) AllocatedPools() ([]*StoragePool, error) {
-	var result []*StoragePool
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range volume.allocatedPools {
-		item, err := GetStoragePool(volume.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[StoragePool](volume.GetClient(), volume.allocatedPools)
 }
 
 // CapacitySources gets the space allocations to this volume.
 func (volume *Volume) CapacitySources() ([]*CapacitySource, error) {
-	var result []*CapacitySource
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range volume.capacitySources {
-		item, err := GetCapacitySource(volume.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[CapacitySource](volume.GetClient(), volume.capacitySources)
 }
 
 // Connections gets the connections that include this volume.
 func (volume *Volume) Connections() ([]*redfish.Connection, error) {
-	var result []*redfish.Connection
-
-	collectionError := common.NewCollectionError()
-	for _, uri := range volume.connections {
-		item, err := redfish.GetConnection(volume.GetClient(), uri)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		} else {
-			result = append(result, item)
-		}
-	}
-
-	if collectionError.Empty() {
-		return result, nil
-	}
-
-	return result, collectionError
+	return common.GetObjects[redfish.Connection](volume.GetClient(), volume.connections)
 }
 
 // Metrics gets the metrics for this volume. IO metrics are reported in the IOStatistics property.


### PR DESCRIPTION
We have concurrency when getting a collection that contains a set of links to objects. But some object properties are a list themselves and not a Collection object. This adds a common function to be used for these types of properties to take advantage of the concurrent processing to fetch these objects from the system.