### PR TITLE
Raise minimum Go version to 1.21

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22.0'
+        go-version: '1.21'
 
     # Build the code
     - name: Run build
@@ -39,7 +39,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22.0'
+        go-version: '1.21'
 
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v6

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/stmcginnis/gofish
 
-go 1.18
+go 1.21


### PR DESCRIPTION
There have apparently been some bug fixes related to generics in recent releases. This causes problems when using Gofish with older Go releases where it does not like the contraints defined on some of the recent updates using generics. This raises our minimum to 1.21 as this is a version known to work.

While I would have liked to keep the minimum version older to give more flexibility to library consumers, there are multiple good reasons to update to the newer release. I do feel bad about the very short notice though.