### PR TITLE
Update golangci-lint to 1.59.1

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -44,4 +44,4 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.57
+        version: v1.59.1

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 PKGS := $(shell go list ./... | grep -v example | grep -v tools)
 ROOT_DIR := $(shell git rev-parse --show-toplevel)
-GOLANGCI_VERSION := "v1.57"
+GOLANGCI_VERSION := "v1.59.1"
 
 all: lint build test
 


### PR DESCRIPTION
This updates the version of golangci-lint used in linting to the current latest release of 1.59.1.