### PR TITLE
Change Memory Struct (NonVolatileSizeLimitMiB)

### DIFF
--- a/redfish/memory.go
+++ b/redfish/memory.go
@@ -333,7 +333,7 @@ type Memory struct {
 	// product ID of this memory module as defined by the manufacturer.
 	ModuleProductID string
 	// NonVolatileSizeLimitMiB shall contain the total non-volatile memory capacity in mebibytes (MiB).
-	NonVolatileSizeLimitMiB string
+	NonVolatileSizeLimitMiB int
 	// NonVolatileSizeMiB shall contain the total size of the non-volatile portion memory in MiB.
 	NonVolatileSizeMiB int
 	// OperatingMemoryModes shall be the memory


### PR DESCRIPTION
Since Redfish DMTF Data Spec 2022.2 the Memory field `NonVolatileSizeLimitMiB` is supposed to be type `integer` but Gofish has it as `string` resulting in unmarshalling errors.

This fixes that.

(Had a problem locally, wanted to help upstream in case someone runs into the same issue eventually)