### PR TITLE
Increase Sensor.ReadingRangeMax to float64

### DIFF
--- a/redfish/sensor.go
+++ b/redfish/sensor.go
@@ -396,7 +396,7 @@ type Sensor struct {
 	// The basis for the reading of this sensor.
 	ReadingBasis ReadingBasisType
 	// The maximum possible value for this sensor.
-	ReadingRangeMax float32
+	ReadingRangeMax float64
 	// The minimum possible value for this sensor.
 	ReadingRangeMin float32
 	// The date and time that the reading was acquired from the sensor.

--- a/redfish/sensor_test.go
+++ b/redfish/sensor_test.go
@@ -25,7 +25,7 @@ var sensorBody = strings.NewReader(
 		"Reading": 31.6,
 		"ReadingUnits": "C",
 		"ReadingRangeMin": 0,
-		"ReadingRangeMax": 70,
+		"ReadingRangeMax": 1.7976931348623157e+308,
 		"Accuracy": 0.25,
 		"Precision": 1,
 		"SensingInterval": "PT3S",


### PR DESCRIPTION
This property has been found to require the larger type with some implementations. This may require some consumers to update their expected return type, but prevents an JSON unmarshalling error when reading the values from the system.

Closes: #361