### PR TITLE
redfish/drive: expose oem data and actions

### DIFF
--- a/oem/smc/drive.go
+++ b/oem/smc/drive.go
@@ -1,0 +1,62 @@
+package smc
+
+import (
+	"encoding/json"
+
+	"github.com/stmcginnis/gofish/redfish"
+)
+
+type Drive struct {
+	redfish.Drive
+	Oem DriveOem `json:"Oem"`
+}
+
+type DriveOem struct {
+	Supermicro struct {
+		Temperature             int
+		PercentageDriveLifeUsed int
+		DriveFunctional         bool
+	} `json:"Supermicro"`
+}
+
+type DriveTarget struct {
+	Target     string `json:"target"`
+	ActionInfo string `json:"@Redfish.ActionInfo"`
+}
+
+type DriveActions struct {
+	redfish.DriveActions
+	Oem struct {
+		DriveIndicate    DriveTarget `json:"#Drive.Indicate"`
+		SmcDriveIndicate DriveTarget `json:"#SmcDrive.Indicate"`
+	} `json:"Oem"`
+}
+
+func FromDrive(drive *redfish.Drive) (Drive, error) {
+	var oem DriveOem
+	err := json.Unmarshal(drive.Oem, &oem)
+
+	return Drive{
+		Drive: *drive,
+		Oem:   oem,
+	}, err
+}
+
+func FromDriveActions(da *redfish.DriveActions) (DriveActions, error) {
+	oemActions := DriveActions{
+		DriveActions: *da,
+	}
+
+	err := json.Unmarshal(da.Oem, &oemActions.Oem)
+	return oemActions, err
+}
+
+// DriveIndicateTarget checks both the SmcDriveIndicate and DriveIndicateTarget
+// Oem entries and returns the first populated target, due to key inconsistencies
+func (da DriveActions) DriveIndicateTarget() string {
+	if len(da.Oem.SmcDriveIndicate.Target) > 0 {
+		return da.Oem.SmcDriveIndicate.Target
+	}
+
+	return da.Oem.DriveIndicate.Target
+}

--- a/oem/smc/drive.go
+++ b/oem/smc/drive.go
@@ -18,9 +18,9 @@ type Drive struct {
 	redfish.Drive
 
 	// Fields from the SMC OEM section
-	temperature             int
-	percentageDriveLifeUsed int
-	driveFunctional         bool
+	Temperature             int
+	PercentageDriveLifeUsed int
+	DriveFunctional         bool
 
 	// indicateTarget is the uri to hit to change the light state
 	indicateTarget string
@@ -53,9 +53,9 @@ func FromDrive(drive *redfish.Drive) (Drive, error) {
 		return smcDrive, err
 	}
 
-	smcDrive.temperature = t.Oem.Supermicro.Temperature
-	smcDrive.percentageDriveLifeUsed = t.Oem.Supermicro.PercentageDriveLifeUsed
-	smcDrive.driveFunctional = t.Oem.Supermicro.DriveFunctional
+	smcDrive.Temperature = t.Oem.Supermicro.Temperature
+	smcDrive.PercentageDriveLifeUsed = t.Oem.Supermicro.PercentageDriveLifeUsed
+	smcDrive.DriveFunctional = t.Oem.Supermicro.DriveFunctional
 
 	// We check both the SmcDriveIndicate and the DriveIndicate targets
 	// in the Oem sections - certain models and bmc firmwares will mix
@@ -66,21 +66,6 @@ func FromDrive(drive *redfish.Drive) (Drive, error) {
 	}
 
 	return smcDrive, nil
-}
-
-// Temperature returns the OEM provided temperature for the drive
-func (d Drive) Temperature() int {
-	return d.temperature
-}
-
-// PercentageDriveLifeUsed returns the OEM provided drive life estimate as a percentage used
-func (d Drive) PercentageDriveLifeUsed() int {
-	return d.percentageDriveLifeUsed
-}
-
-// Functional returns the OEM provided flag that suggests whether a drive is functional or not
-func (d Drive) Functional() bool {
-	return d.driveFunctional
 }
 
 // Indicate will set the indicator light activity, true for on, false for off

--- a/oem/smc/drive.go
+++ b/oem/smc/drive.go
@@ -1,3 +1,7 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
 package smc
 
 import (
@@ -61,7 +65,7 @@ func FromDrive(drive *redfish.Drive) (Drive, error) {
 	// in the Oem sections - certain models and bmc firmwares will mix
 	// these up, so we check both
 	smcDrive.indicateTarget = t.Actions.Oem.DriveIndicate.Target
-	if len(t.Actions.Oem.SmcDriveIndicate.Target) > 0 {
+	if t.Actions.Oem.SmcDriveIndicate.Target != "" {
 		smcDrive.indicateTarget = t.Actions.Oem.SmcDriveIndicate.Target
 	}
 
@@ -69,7 +73,7 @@ func FromDrive(drive *redfish.Drive) (Drive, error) {
 }
 
 // Indicate will set the indicator light activity, true for on, false for off
-func (d Drive) Indicate(active bool) error {
+func (d *Drive) Indicate(active bool) error {
 	// Return a common error to let the user try falling back on the normal gofish path
 	if d.indicateTarget == "" {
 		return ErrActionNotSupported

--- a/oem/smc/drive_test.go
+++ b/oem/smc/drive_test.go
@@ -61,7 +61,7 @@ func TestSmcDriveOem(t *testing.T) {
 		t.Errorf("unexpected oem drive temerature: %d", smcDrive.Temperature())
 	}
 
-	if smcDrive.indicateTarget() != "/redfish/v1/Chassis/NVMeSSD.0.Group.0.StorageBackplane/Drives/Disk.Bay.22/Actions/Oem/Drive.Indicate" {
-		t.Errorf("unexpected oem drive indicator target: %s", smcDrive.indicateTarget())
+	if smcDrive.indicateTarget != "/redfish/v1/Chassis/NVMeSSD.0.Group.0.StorageBackplane/Drives/Disk.Bay.22/Actions/Oem/Drive.Indicate" {
+		t.Errorf("unexpected oem drive indicator target: %s", smcDrive.indicateTarget)
 	}
 }

--- a/oem/smc/drive_test.go
+++ b/oem/smc/drive_test.go
@@ -1,3 +1,7 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
 package smc
 
 import (
@@ -58,7 +62,7 @@ func TestSmcDriveOem(t *testing.T) {
 	}
 
 	if smcDrive.Temperature != 33 {
-		t.Errorf("unexpected oem drive temerature: %d", smcDrive.Temperature)
+		t.Errorf("unexpected oem drive temperature: %d", smcDrive.Temperature)
 	}
 
 	if smcDrive.indicateTarget != "/redfish/v1/Chassis/NVMeSSD.0.Group.0.StorageBackplane/Drives/Disk.Bay.22/Actions/Oem/Drive.Indicate" {

--- a/oem/smc/drive_test.go
+++ b/oem/smc/drive_test.go
@@ -57,24 +57,11 @@ func TestSmcDriveOem(t *testing.T) {
 		t.Fatalf("error getting oem info from drive: %v", err)
 	}
 
-	if smcDrive.Oem.Supermicro.Temperature != 33 {
-		t.Errorf("unexpected oem drive temerature: %d", smcDrive.Oem.Supermicro.Temperature)
-	}
-}
-
-// TestSmcDriveActionOem tests the parsing of the Drive Actions field
-func TestSmcDriveActionOem(t *testing.T) {
-	drive := &redfish.Drive{}
-	if err := json.Unmarshal([]byte(smcDriveBody), drive); err != nil {
-		t.Fatalf("error decoding json: %v", err)
+	if smcDrive.Temperature() != 33 {
+		t.Errorf("unexpected oem drive temerature: %d", smcDrive.Temperature())
 	}
 
-	smcDriveActions, err := FromDriveActions(&drive.Actions)
-	if err != nil {
-		t.Fatalf("error getting oem info from drive: %v", err)
-	}
-
-	if smcDriveActions.DriveIndicateTarget() != "/redfish/v1/Chassis/NVMeSSD.0.Group.0.StorageBackplane/Drives/Disk.Bay.22/Actions/Oem/Drive.Indicate" {
-		t.Errorf("unexpected oem drive indicator target: %s", smcDriveActions.DriveIndicateTarget())
+	if smcDrive.indicateTarget() != "/redfish/v1/Chassis/NVMeSSD.0.Group.0.StorageBackplane/Drives/Disk.Bay.22/Actions/Oem/Drive.Indicate" {
+		t.Errorf("unexpected oem drive indicator target: %s", smcDrive.indicateTarget())
 	}
 }

--- a/oem/smc/drive_test.go
+++ b/oem/smc/drive_test.go
@@ -1,0 +1,80 @@
+package smc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stmcginnis/gofish/redfish"
+)
+
+var smcDriveBody = `{
+    "@odata.type": "#Drive.v1_6_2.Drive",
+    "@odata.id": "/redfish/v1/Chassis/NVMeSSD.0.Group.0.StorageBackplane/Drives/Disk.Bay.22",
+    "Name": "Disk.Bay.22",
+    "Id": "22",
+    "Manufacturer": "INTEL",
+    "SerialNumber": "PHLWOOFMEOWIAMCATDOG",
+    "Model": "INTEL SSDPE2KX080T8O",
+    "StatusIndicator": "OK",
+    "FailurePredicted": false,
+    "CapacityBytes": 8001563222016,
+    "CapableSpeedGbs": 31.5,
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcDriveExtensions.v1_0_0.Drive",
+            "Temperature": 33,
+            "PercentageDriveLifeUsed": 3,
+            "DriveFunctional": true
+        }
+    },
+    "IndicatorLED": "Off",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Links": {
+        "Volumes": []
+    },
+    "Actions": {
+        "Oem": {
+            "#Drive.Indicate": {
+                "target": "/redfish/v1/Chassis/NVMeSSD.0.Group.0.StorageBackplane/Drives/Disk.Bay.22/Actions/Oem/Drive.Indicate",
+                "@Redfish.ActionInfo": "/redfish/v1/Chassis/NVMeSSD.0.Group.0.StorageBackplane/Drives/Disk.Bay.22/IndicateActionInfo"
+            }
+        }
+    }
+}`
+
+// TestSmcDriveOem tests the parsing of the Drive oem field
+func TestSmcDriveOem(t *testing.T) {
+	drive := &redfish.Drive{}
+	if err := json.Unmarshal([]byte(smcDriveBody), drive); err != nil {
+		t.Fatalf("error decoding json: %v", err)
+	}
+
+	smcDrive, err := FromDrive(drive)
+	if err != nil {
+		t.Fatalf("error getting oem info from drive: %v", err)
+	}
+
+	if smcDrive.Oem.Supermicro.Temperature != 33 {
+		t.Errorf("unexpected oem drive temerature: %d", smcDrive.Oem.Supermicro.Temperature)
+	}
+}
+
+// TestSmcDriveActionOem tests the parsing of the Drive Actions field
+func TestSmcDriveActionOem(t *testing.T) {
+	drive := &redfish.Drive{}
+	if err := json.Unmarshal([]byte(smcDriveBody), drive); err != nil {
+		t.Fatalf("error decoding json: %v", err)
+	}
+
+	smcDriveActions, err := FromDriveActions(&drive.Actions)
+	if err != nil {
+		t.Fatalf("error getting oem info from drive: %v", err)
+	}
+
+	if smcDriveActions.DriveIndicateTarget() != "/redfish/v1/Chassis/NVMeSSD.0.Group.0.StorageBackplane/Drives/Disk.Bay.22/Actions/Oem/Drive.Indicate" {
+		t.Errorf("unexpected oem drive indicator target: %s", smcDriveActions.DriveIndicateTarget())
+	}
+}

--- a/oem/smc/drive_test.go
+++ b/oem/smc/drive_test.go
@@ -57,8 +57,8 @@ func TestSmcDriveOem(t *testing.T) {
 		t.Fatalf("error getting oem info from drive: %v", err)
 	}
 
-	if smcDrive.Temperature() != 33 {
-		t.Errorf("unexpected oem drive temerature: %d", smcDrive.Temperature())
+	if smcDrive.Temperature != 33 {
+		t.Errorf("unexpected oem drive temerature: %d", smcDrive.Temperature)
 	}
 
 	if smcDrive.indicateTarget != "/redfish/v1/Chassis/NVMeSSD.0.Group.0.StorageBackplane/Drives/Disk.Bay.22/Actions/Oem/Drive.Indicate" {

--- a/redfish/drive_test.go
+++ b/redfish/drive_test.go
@@ -138,8 +138,8 @@ func TestDrive(t *testing.T) {
 		t.Errorf("Invalid chassis link: %s", result.chassis)
 	}
 
-	if result.Actions.SecureErase.Target != "/redfish/v1/Chassis/NVMeChassis/Disk.Bay.0/Actions/Drive.SecureErase" {
-		t.Errorf("Invalid SecureErase target: %s", result.Actions.SecureErase.Target)
+	if result.secureEraseTarget != "/redfish/v1/Chassis/NVMeChassis/Disk.Bay.0/Actions/Drive.SecureErase" {
+		t.Errorf("Invalid SecureErase target: %s", result.secureEraseTarget)
 	}
 }
 

--- a/redfish/drive_test.go
+++ b/redfish/drive_test.go
@@ -138,8 +138,8 @@ func TestDrive(t *testing.T) {
 		t.Errorf("Invalid chassis link: %s", result.chassis)
 	}
 
-	if result.secureEraseTarget != "/redfish/v1/Chassis/NVMeChassis/Disk.Bay.0/Actions/Drive.SecureErase" {
-		t.Errorf("Invalid SecureErase target: %s", result.secureEraseTarget)
+	if result.Actions.SecureErase.Target != "/redfish/v1/Chassis/NVMeChassis/Disk.Bay.0/Actions/Drive.SecureErase" {
+		t.Errorf("Invalid SecureErase target: %s", result.Actions.SecureErase.Target)
 	}
 }
 


### PR DESCRIPTION
We have some nodes that don't follow the typical indicator light flow that `Update()` would handle. Instead, we have to hit a linked reference (with a variable key, sigh..) from the OEM section.

I'm hoping to expose the `Oem` field in both the `Drive` and the `Drive.Actions` (while also exposing the `Actions`) so that the user can follow that chain when necessary. This allows us to get the right link to where we need to send the `POST` or `PATCH` (also variable, heh) to enable lights for our datacenter folks.

Tests updated to not lose secure erase functionality.