### PR TITLE
Expose ManagersProvidingService link from service root

### DIFF
--- a/serviceroot.go
+++ b/serviceroot.go
@@ -192,9 +192,9 @@ type Service struct {
 
 	// Sessions shall contain the link to a collection of Sessions.
 	sessions string
-	// ManagerProvidingService shall contain a link to a resource of type Manager that represents the manager providing
+	// ManagerProvidingServiceLink shall contain a link to a resource of type Manager that represents the manager providing
 	// this Redfish service.
-	managerProvidingService string
+	ManagerProvidingServiceLink string
 }
 
 // UnmarshalJSON unmarshals a Service object from the raw JSON.
@@ -277,7 +277,7 @@ func (serviceroot *Service) UnmarshalJSON(b []byte) error {
 	serviceroot.updateService = t.UpdateService.String()
 
 	serviceroot.sessions = t.Links.Sessions.String()
-	serviceroot.managerProvidingService = t.Links.ManagerProvidingService.String()
+	serviceroot.ManagerProvidingServiceLink = t.Links.ManagerProvidingService.String()
 
 	return nil
 }
@@ -474,10 +474,10 @@ func (serviceroot *Service) CreateSession(username, password string) (*redfish.A
 
 // ManagerProvidingService gets the manager for this Redfish service.
 func (serviceroot *Service) ManagerProvidingService() (*redfish.Manager, error) {
-	if serviceroot.managerProvidingService == "" {
+	if serviceroot.ManagerProvidingServiceLink == "" {
 		return nil, nil
 	}
-	return redfish.GetManager(serviceroot.GetClient(), serviceroot.managerProvidingService)
+	return redfish.GetManager(serviceroot.GetClient(), serviceroot.ManagerProvidingServiceLink)
 }
 
 // PowerEquipment gets the powerEquipment instances of this service.

--- a/serviceroot_test.go
+++ b/serviceroot_test.go
@@ -46,6 +46,9 @@ var serviceRootBody = strings.NewReader(
 			"@odata.id": "/redfish/v1/JsonSchemas"
 		},
 		"Links": {
+			"ManagerProvidingService": {
+				"@odata.id": "/redfish/v1/Managers/1"
+			},
 			"Sessions": {
 				"@odata.id": "/redfish/v1/Sessions"
 			}
@@ -194,6 +197,10 @@ func TestServiceRoot(t *testing.T) {
 
 	if result.updateService != "/redfish/v1/UpdateService" {
 		t.Errorf("Invalid UpdateService link: %s", result.updateService)
+	}
+
+	if result.ManagerProvidingServiceLink != "/redfish/v1/Managers/1" {
+		t.Errorf("Invalid ManagerProvidingService link: %s", result.ManagerProvidingServiceLink)
 	}
 }
 


### PR DESCRIPTION
I'd like to be able to just see the uri of the managers link from service root without calling the url.