### PR TITLE
Add new FullPowerCycle ResetType

### DIFF
--- a/redfish/computersystem.go
+++ b/redfish/computersystem.go
@@ -622,6 +622,8 @@ const (
 	ForceOffResetType ResetType = "ForceOff"
 	// ForceRestartResetType shall be used to restart the machine without wait the OS to shutdown
 	ForceRestartResetType ResetType = "ForceRestart"
+	// FullPowerCycleResetType shall be used to perform an AC power cycle
+	FullPowerCycleResetType
 	// GracefulRestartResetType shall be used to restart the machine waiting the OS shutdown gracefully
 	GracefulRestartResetType ResetType = "GracefulRestart"
 	// GracefulShutdownResetType shall be used to restart the machine waiting the OS shutdown gracefully


### PR DESCRIPTION
With the new DMTF Redfish release 2024.4 there is a new [ResetType](https://www.dmtf.org/sites/default/files/standards/documents/DSP2046_2024.4.html#resettype) `FullPowerCycle`.