### PR TITLE
Add client to the returned ManagerAccount on account creation

### DIFF
--- a/redfish/accountservice.go
+++ b/redfish/accountservice.go
@@ -518,5 +518,7 @@ func (accountservice *AccountService) CreateAccount(userName, password, roleID s
 
 	var result ManagerAccount
 	err = json.NewDecoder(resp.Body).Decode(&result)
+	result.SetClient(accountservice.GetClient())
+
 	return &result, err
 }


### PR DESCRIPTION
The returned `*ManagerAccount` when using `CreateAccount()` did not have a client set which made using `*ManagerAccount` have a nil reference when attempting to make HTTP calls afterwards.