### PR TITLE
Set client.keepAlive flag also for passed HTTPClient

### DIFF
--- a/client.go
+++ b/client.go
@@ -147,6 +147,9 @@ func setupClientWithConfig(ctx context.Context, config *ClientConfig) (c *APICli
 
 		client.HTTPClient = &http.Client{Transport: transport}
 	} else {
+		if config.ReuseConnections {
+			client.keepAlive = true
+		}
 		client.HTTPClient = config.HTTPClient
 	}
 


### PR DESCRIPTION
When `ClientConfig.HTTPClient` is passed, the `Client.keepAlive` field is not set even if we set `ClientConfig.ReuseConnection`.

With this PR, the `keepAlive` field will be properly set (based on `ClientConfig.ReuseConnection` value) in both cases.