### PR TITLE
Allow logout even when APIClient ctx is canceled

### DIFF
--- a/client.go
+++ b/client.go
@@ -593,6 +593,12 @@ func (c *APIClient) dumpResponse(resp *http.Response) error {
 // a new connection.
 func (c *APIClient) Logout() {
 	if c != nil && c.Service != nil && c.auth != nil {
+		// if APIClient is created with ConnectContext (f.e. with http request ctx)
+		// and passed context is cancelled (f.e. downstream request is aborted),
+		// we need to create a new context to clean up Redfish API session
+		if c.ctx.Err() != nil {
+			c.ctx = context.Background()
+		}
 		if err := c.Service.DeleteSession(c.auth.Session); err == nil {
 			// Clean up invalid session token and ID upon successful Logout
 			c.auth.Session = ""


### PR DESCRIPTION
I use gofish in a custom redfish prometheus exporter. `APIClient` is created for each scrape http request with `ConnectContext` where I pass http request ctx.

If the scrape request is aborted (f.e. when scrape timeout is reached), I discovered the redfish session is not deleted. In some cases it can block access to bmc (when the limit of existing sessions is reached).

When I looked into the code, I see the `APIclient.Logout()` eventually invoke `APIClient.runRawRequestWithHeaders()` where the `APIclient.ctx` is used in `http.NewRequestWithContext` ([link](https://github.com/stmcginnis/gofish/blob/b73be00f1f7cd5a2a9e46e4fc69bae1bf0bf4b25/client.go#L474)) - and this fails with "context canceled" error.

I'd like to be able to clean up the redfish session even when the downstream request is canceled (at the same time I still want to propagate http scrape request's ctx to cancel any pending redfish API requests)

In this PR I propose to create a new ctx, just for 'Logout' call, and only if the existing `APIClient.ctx` is canceled. 