### PR TITLE
Fix golangci config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -19,7 +19,7 @@ linters-settings:
   goheader:
     values:
       const:
-        - LICENSE: BSD-3-Clause
+        LICENSE: BSD-3-Clause
     template: |-
       SPDX-License-Identifier: {{ LICENSE }}
   goconst:
@@ -50,7 +50,6 @@ linters-settings:
   misspell:
     locale: US
   nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
     allow-unused: false # report any unused nolint directives
     require-explanation: false # don't require an explanation for nolint directives
     require-specific: false # don't require nolint directives to be specific about which linter is being skipped


### PR DESCRIPTION
Lint job started to fail complaining about jsonschema of config (f.e. one of my previous [PRs is ok](https://github.com/stmcginnis/gofish/actions/runs/13303597831/job/37149525323?pr=404#step:1:38), [the other fails](https://github.com/stmcginnis/gofish/actions/runs/13518590958/job/37772547791?pr=406#step:1:38))

Lint job uses v6 version of action and it was updated recently with this PR: https://github.com/golangci/golangci-lint-action/pull/1171 - so the job started to verify the config's schema.

This PR fixes the config:
- removes unsupported property for `nolintlint` - https://golangci-lint.run/usage/linters/#nolintlint
- changes from array to object in `goheader` - https://golangci-lint.run/usage/linters/#goheader
