### PR TITLE
Add initial support for  in system.Memory()

### DIFF
--- a/common/odata.go
+++ b/common/odata.go
@@ -1,0 +1,51 @@
+package common
+
+import "fmt"
+
+type Query struct {
+	expand      ExpandOption
+	expandLevel int
+}
+
+type QueryOption func(*Query)
+
+type ExpandOption string
+
+const (
+	ExpandOptionAsterisk ExpandOption = "*"
+	ExpandOptionTilde    ExpandOption = "~"
+	ExpandOptionPeriod   ExpandOption = "."
+)
+
+func WithExpand(expandValue ExpandOption) func(*Query) {
+	return func(q *Query) {
+		q.expand = expandValue
+	}
+}
+
+func WithExpandLevel(expandLevel int) func(*Query) {
+	return func(q *Query) {
+		q.expandLevel = expandLevel
+	}
+}
+
+func BuildQuery(url string, opts ...QueryOption) string {
+	if len(opts) == 0 {
+		return url
+	}
+
+	q := &Query{}
+	for _, opt := range opts {
+		opt(q)
+	}
+
+	url += "?"
+	if q.expand != "" {
+		url += fmt.Sprintf("$expand=%s", string(q.expand))
+		if q.expandLevel > 0 {
+			url += fmt.Sprintf("($levels=%d)", q.expandLevel)
+		}
+	}
+
+	return url
+}

--- a/redfish/computersystem.go
+++ b/redfish/computersystem.go
@@ -1104,8 +1104,8 @@ func (computersystem *ComputerSystem) ManagedBy() ([]*Manager, error) {
 }
 
 // Memory gets this system's memory.
-func (computersystem *ComputerSystem) Memory() ([]*Memory, error) {
-	return ListReferencedMemorys(computersystem.GetClient(), computersystem.memory)
+func (computersystem *ComputerSystem) Memory(queryOpts ...common.QueryOption) ([]*Memory, error) {
+	return ListReferencedMemorys(computersystem.GetClient(), computersystem.memory, queryOpts...)
 }
 
 // MemoryDomains gets this system's memory domains.

--- a/redfish/memory.go
+++ b/redfish/memory.go
@@ -323,7 +323,7 @@ type Memory struct {
 	// represented by this resource.
 	MemoryType MemoryType
 	// Metrics is a reference to the Metrics associated with this Memory.
-	metrics string
+	metrics *MemoryMetrics
 	// Model shall indicate the model information as provided by the manufacturer of this memory.
 	Model string
 	// ModuleManufacturerID shall be the two byte manufacturer ID of this memory
@@ -513,7 +513,7 @@ func (memory *Memory) UnmarshalJSON(b []byte) error {
 		Certificates       common.LinksCollection
 		EnvironmentMetrics common.Link
 		Log                common.Link
-		Metrics            common.Link
+		Metrics            *MemoryMetrics
 	}
 
 	err := json.Unmarshal(b, &t)
@@ -528,7 +528,7 @@ func (memory *Memory) UnmarshalJSON(b []byte) error {
 	memory.certificates = t.Certificates.ToStrings()
 	memory.environmentMetrics = t.EnvironmentMetrics.String()
 	memory.log = t.Log.String()
-	memory.metrics = t.Metrics.String()
+	memory.metrics = t.Metrics
 
 	memory.batteries = t.Links.Batteries.ToStrings()
 	memory.BatteriesCount = t.Links.BatteriesCount
@@ -594,8 +594,8 @@ func GetMemory(c common.Client, uri string) (*Memory, error) {
 
 // ListReferencedMemorys gets the collection of Memory from
 // a provided reference.
-func ListReferencedMemorys(c common.Client, link string) ([]*Memory, error) {
-	return common.GetCollectionObjects[Memory](c, link)
+func ListReferencedMemorys(c common.Client, link string, queryOpts ...common.QueryOption) ([]*Memory, error) {
+	return common.GetCollectionObjects[Memory](c, link, queryOpts...)
 }
 
 // Assembly gets this memory's assembly.
@@ -629,10 +629,13 @@ func (memory *Memory) Log() (*LogService, error) {
 
 // Metrics gets the memory metrics.
 func (memory *Memory) Metrics() (*MemoryMetrics, error) {
-	if memory.metrics == "" {
+	if memory.metrics == nil {
 		return nil, nil
 	}
-	return GetMemoryMetrics(memory.GetClient(), memory.metrics)
+	if memory.metrics.ID != "" {
+		return memory.metrics, nil
+	}
+	return GetMemoryMetrics(memory.GetClient(), memory.metrics.ODataID)
 }
 
 // Batteries gets the batteries that provide power to this memory device during


### PR DESCRIPTION
This is a proposal of how to handle '$expand' redfish odata queries. Related issue: #340

Note: creating PR to get early feedback if general approach is valid, things to be added to this PR:

- [ ] add tests for queries with expand option
- [ ] godoc comments
- [ ] handle all Memory 'subresources', not only `Metrics`

Assumptions, I've made:
- I don't want to break existing clients of the pkg
- I don't want to change default behavior (in case someone update the pkg)

Because of above, I'd like to introduce the 'expand feature' with 'functional options' approach.
There's a new `common/odata.go` file with 2 'options' functions responsible for controlling the expand value and level (ref: [redfish spec](https://www.dmtf.org/sites/default/files/standards/documents/DSP0266_1.21.1.html#the-expand-query-parameter)).

Draft of this PR supports 'expand' only for `system.Memory()` and 'expands' only `Metrics`. It's possible to us it as it was (`system.Memory()`) or with expand option (`system.Memory(common.WithExpand(common.ExpandOptionPeriod))`). By default, no 'expand' is used, so we won't change the default behavior.
`Memory` struct was changed, and `metrics` var type is changed from `common.Link` to `MemoryMetrics`. In case the expand is not used for `system.Memory()`, `memory.Metrics()` call will make a call to redfish API.

Tested with Redfish mockup server and real device.

Please let me know if above approach is ok or if you have any suggestions how to do it differently.

---

Something I'm not sure how to tackle right now...
Following my use case (get system's memory and it's metrics):

```
system
  -> memory collection
    -> memory item
      -> metrics
```

`system.Memory()` encapsulate '2 levels' above: it send request to API to get 'memory collection' and then 'memory item'
Both of the requests can handle expand parameter. Let's assume Redfish API supports only 1 level for expand.
If we do `system.Memory(common.WithExpand(common.ExpandOptionPeriod))`, should gofish pass $expand param:
- only to 'memory collection'
- only to 'memory item'
- both?
Or should it be possible to decide when invoking `system.Memory()`

I assumed, when we use `system.Memory()` and get in response `[]Memory` we're interested in `Memory` resource and that's what expanded in this 'draft' PR. (tbh: that's what I'm interested in my use case - getting metrics for all 'memory items')
With this approach we don't change anything in `GetCollectionObjects` (except 'optional' list of `QueryOption` in the definition)

If we'd like to support that at 'memory collection' request, it will get more dificult and complex and would need more changes to those 'generic' functions (GetCollectionObjects -> CollectList -> GetCollection etc).

Let me know what you think and how you suggest to approach that.