### PR TITLE
Add Oem property to EnvironmentMetrics

### DIFF
--- a/redfish/environmentmetrics.go
+++ b/redfish/environmentmetrics.go
@@ -50,6 +50,9 @@ type EnvironmentMetrics struct {
 	// property, if present, shall reference a resource of type Sensor with the ReadingType property containing the
 	// value 'Humidity'.
 	HumidityPercent SensorExcerpt
+	// Oem shall contain the OEM extensions. All values for properties that this object contains shall conform to the
+	// Redfish Specification-described requirements.
+	OEM json.RawMessage `json:"Oem"`
 	// PowerLimitWatts shall contain the power limit control, in watt units, for this resource. The value of the
 	// DataSourceUri property, if present, shall reference a resource of type Control with the ControlType property
 	// containing the value of 'Power'.


### PR DESCRIPTION
This PR adds `Oem` property for `EnvironmentMetrics` resource, similarly like in `ProcessorMetrics`