### PR TITLE
Add CacheMemory to Processor resource

### DIFF
--- a/redfish/processor.go
+++ b/redfish/processor.go
@@ -407,6 +407,7 @@ type Processor struct {
 	// (v1.9+) The state of the base frequency settings of
 	// the operation configuration applied to this processor.
 	BaseSpeedPriorityState BaseSpeedPriorityState
+	cacheMemory            string
 	certificates           []string
 	// Description provides a description of this resource.
 	Description string
@@ -608,6 +609,7 @@ func (processor *Processor) UnmarshalJSON(b []byte) error {
 		AppliedOperatingConfig common.Link
 		Assembly               common.Link
 		Certificates           common.LinksCollection
+		CacheMemory            common.Link
 		EnvironmentMetrics     common.Link
 		Metrics                common.Link
 		OperatingConfigs       common.LinksCollection
@@ -658,6 +660,7 @@ func (processor *Processor) UnmarshalJSON(b []byte) error {
 	processor.accelerationFunctions = t.AccelerationFunctions.ToStrings()
 	processor.appliedOperatingConfig = t.AppliedOperatingConfig.String()
 	processor.assembly = t.Assembly.String()
+	processor.cacheMemory = t.CacheMemory.String()
 	processor.certificates = t.Certificates.ToStrings()
 	processor.environmentMetrics = t.EnvironmentMetrics.String()
 	processor.metrics = t.Metrics.String()
@@ -746,6 +749,13 @@ func (processor *Processor) Assembly() (*Assembly, error) {
 		return nil, nil
 	}
 	return GetAssembly(processor.GetClient(), processor.assembly)
+}
+
+func (processor *Processor) CacheMemory() ([]*Memory, error) {
+	if processor.cacheMemory == "" {
+		return nil, nil
+	}
+	return ListReferencedMemorys(processor.GetClient(), processor.cacheMemory)
 }
 
 // Certificates gets the certificates for device identity and attestation.

--- a/redfish/processor_test.go
+++ b/redfish/processor_test.go
@@ -18,6 +18,9 @@ var processorBody = strings.NewReader(
 		"Assembly":{
 		   "@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Assembly"
 		},
+		"CacheMemory": {
+			"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.2/CacheMemory"
+		},
 		"Description":"Represents the properties of a Processor attached to this System",
 		"FPGA": {
 			"ExternalInterfaces": [{
@@ -378,6 +381,10 @@ func TestProcessor(t *testing.T) {
 
 	if result.assembly != "/redfish/v1/Chassis/System.Embedded.1/Assembly" {
 		t.Errorf("Invalid assembly link: %s", result.assembly)
+	}
+
+	if result.cacheMemory != "/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.2/CacheMemory" {
+		t.Errorf("Invalid cache memory link: %s", result.cacheMemory)
 	}
 
 	if result.FPGA.FpgaType != DiscreteFpgaType {


### PR DESCRIPTION
Adding `CacheMemory` link to Processor type. 
ref: https://www.dmtf.org/sites/default/files/standards/documents/DSP0268_2024.4.html#processor-1201

