### PR TITLE
Use float64 for Sensor.ReadingRangeMin

### DIFF
--- a/redfish/sensor.go
+++ b/redfish/sensor.go
@@ -398,7 +398,7 @@ type Sensor struct {
 	// The maximum possible value for this sensor.
 	ReadingRangeMax float64
 	// The minimum possible value for this sensor.
-	ReadingRangeMin float32
+	ReadingRangeMin float64
 	// The date and time that the reading was acquired from the sensor.
 	ReadingTime string
 	// The type of sensor.

--- a/redfish/sensor_test.go
+++ b/redfish/sensor_test.go
@@ -24,7 +24,7 @@ var sensorBody = strings.NewReader(
 		},
 		"Reading": 31.6,
 		"ReadingUnits": "C",
-		"ReadingRangeMin": 0,
+		"ReadingRangeMin": -1.7976931348623157e+308,
 		"ReadingRangeMax": 1.7976931348623157e+308,
 		"Accuracy": 0.25,
 		"Precision": 1,


### PR DESCRIPTION
Similar to #362 but for `ReadingRangeMin`.

For some BMCs I was also getting errors like `cannot unmarshal number -1.7976931348623157e+308 into Go struct field .temp.ReadingRangeMin of type float32`