### PR TITLE
Update SMC OEM readwrite field values to match SMC documentation.

### DIFF
--- a/oem/smc/ikvm.go
+++ b/oem/smc/ikvm.go
@@ -54,6 +54,7 @@ func (i *IKVM) Update() error {
 
 	readWriteFields := []string{
 		"CurrentInterface",
+		"Current Interface",
 	}
 
 	originalElement := reflect.ValueOf(orig).Elem()

--- a/oem/smc/ipaccesscontrol.go
+++ b/oem/smc/ipaccesscontrol.go
@@ -71,6 +71,7 @@ func (i *IPAccessControl) Update() error {
 
 	readWriteFields := []string{
 		"Enabled",
+		"ServiceEnabled",
 	}
 
 	originalElement := reflect.ValueOf(orig).Elem()

--- a/oem/smc/lldp.go
+++ b/oem/smc/lldp.go
@@ -60,6 +60,7 @@ func (i *LLDP) Update() error {
 
 	readWriteFields := []string{
 		"Enabled",
+		"LLDPEnabled",
 	}
 
 	originalElement := reflect.ValueOf(orig).Elem()

--- a/oem/smc/memoryhealthcomp.go
+++ b/oem/smc/memoryhealthcomp.go
@@ -56,6 +56,7 @@ func (i *MemoryHealthComp) Update() error {
 
 	readWriteFields := []string{
 		"Next",
+		"MemoryHealthCompNext",
 	}
 
 	originalElement := reflect.ValueOf(orig).Elem()

--- a/oem/smc/memorypfa.go
+++ b/oem/smc/memorypfa.go
@@ -58,6 +58,7 @@ func (i *MemoryPFA) Update() error {
 
 	readWriteFields := []string{
 		"Next",
+		"MemoryPfaNext",
 		"AlertID",
 	}
 

--- a/oem/smc/ntp.go
+++ b/oem/smc/ntp.go
@@ -56,8 +56,11 @@ func (r *NTP) Update() error {
 
 	readWriteFields := []string{
 		"Enabled",
+		"NTPEnable",
 		"PrimaryServer",
+		"PrimaryNTPServer",
 		"SecondaryServer",
+		"SecondaryNTPServer",
 		"DaylightSavingTime",
 	}
 

--- a/oem/smc/radius.go
+++ b/oem/smc/radius.go
@@ -56,9 +56,13 @@ func (r *RADIUS) Update() error {
 
 	readWriteFields := []string{
 		"Enabled",
+		"RadiusEnabled",
 		"ServerIP",
+		"RadiusServerIP",
 		"PortNumber",
+		"RadiusPortNumber",
 		"Secret",
+		"RadiusSecret",
 	}
 
 	originalElement := reflect.ValueOf(rad).Elem()

--- a/oem/smc/syslockdown.go
+++ b/oem/smc/syslockdown.go
@@ -53,6 +53,7 @@ func (i *SysLockdown) Update() error {
 
 	readWriteFields := []string{
 		"Enabled",
+		"SysLockdownEnabled",
 	}
 
 	originalElement := reflect.ValueOf(orig).Elem()

--- a/oem/smc/syslog.go
+++ b/oem/smc/syslog.go
@@ -55,8 +55,11 @@ func (i *Syslog) Update() error {
 
 	readWriteFields := []string{
 		"Enabled",
+		"EnableSyslog",
 		"Port",
+		"SyslogPortNumber",
 		"Server",
+		"SyslogServer",
 	}
 
 	originalElement := reflect.ValueOf(orig).Elem()


### PR DESCRIPTION
This PR *adds* more SMC entity field names that should be allowed for read/write. This started as matching the field names provided in https://www.supermicro.com/manuals/other/redfish-ref-guide-html/Content/general-content/bmc-configuration-examples.htm but then continued to follow the JSON field names that were found higher in each file as that matched what a new SMC chassis expected.

The previous field names were left as read/write field names in case some of the older chassis BMCs expect those names.

The NTP and Syslog file changes have been confirmed to fix bugs that we've seen on our end. All of the changes are additions rather than updates/renames, so this should break nothing.