### PR TITLE
Patchable ServiceRoot

### DIFF
--- a/client.go
+++ b/client.go
@@ -103,8 +103,13 @@ type ClientConfig struct {
 	ReuseConnections bool
 }
 
-// setupClientWithConfig setups the client using the client config
-func setupClientWithConfig(ctx context.Context, config *ClientConfig) (c *APIClient, err error) {
+// SetupClientWithConfig setups the client using the client config. Prefer the
+// `Connect*`-family of functions to create a configured client.
+//
+// This function does not handle the authentication setup! It is meant to be
+// used in rare cases to be able to vendor patch the ServiceRoot. (E.g. to
+// workaround a broken SessionService protocol in older Huawei/XFusion BMCs).
+func SetupClientWithConfig(ctx context.Context, config *ClientConfig) (c *APIClient, err error) {
 	if !strings.HasPrefix(config.Endpoint, "http") {
 		return c, fmt.Errorf("endpoint must starts with http or https")
 	}
@@ -220,7 +225,7 @@ func Connect(config ClientConfig) (c *APIClient, err error) { //nolint:gocritic
 
 // ConnectContext is the same as Connect, but sets the ctx.
 func ConnectContext(ctx context.Context, config ClientConfig) (c *APIClient, err error) { //nolint:gocritic
-	client, err := setupClientWithConfig(ctx, &config)
+	client, err := SetupClientWithConfig(ctx, &config)
 	if err != nil {
 		return c, err
 	}

--- a/client.go
+++ b/client.go
@@ -616,3 +616,13 @@ func (c *APIClient) Logout() {
 func (c *APIClient) SetDumpWriter(writer io.Writer) {
 	c.dumpWriter = writer
 }
+
+// SetAuthToken sets the client auth token
+func (c *APIClient) SetAuthToken(token *redfish.AuthToken) {
+	c.auth = token
+}
+
+// GetAuthToken gets the client auth token
+func (c *APIClient) GetAuthToken() *redfish.AuthToken {
+	return c.auth
+}

--- a/client_test.go
+++ b/client_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/stmcginnis/gofish/common"
+	"github.com/stmcginnis/gofish/redfish"
 )
 
 const (
@@ -198,5 +199,26 @@ func TestClientRunRawRequestNoURL(t *testing.T) {
 
 	if err.Error() != "unable to execute request, no target provided" {
 		t.Errorf("Unexpected error response: %s", err.Error())
+	}
+}
+
+func TestAuthTokenAccessors(t *testing.T) {
+	c := APIClient{}
+
+	if c.GetAuthToken() != nil {
+		t.Error("Empty client should return a nil auth token")
+	}
+
+	token := &redfish.AuthToken{}
+	c.SetAuthToken(token)
+
+	if c.GetAuthToken() != token {
+		t.Error("Client should return current auth token")
+	}
+
+	c.SetAuthToken(nil)
+
+	if c.GetAuthToken() != nil {
+		t.Error("Should return nil")
 	}
 }


### PR DESCRIPTION
An first attempt at solving #425.

Made `SetupClientWithConfig()` public and added a setter for `APIClient.auth`. You can see an example usage in the added test case.

However, this is not yet finished, see my inline comment.