### PR TITLE
Strip omitempty when formulating object update

### DIFF
--- a/common/entity.go
+++ b/common/entity.go
@@ -194,6 +194,8 @@ func getPatchPayloadFromUpdate(originalEntity, updatedEntity reflect.Value) (pay
 		}
 		fieldName := field.Name
 		jsonName := field.Tag.Get("json")
+		// Strip out marshaling directives
+		jsonName = strings.ReplaceAll(jsonName, ",omitempty", "")
 		if jsonName == "-" {
 			continue
 		}

--- a/common/entity_test.go
+++ b/common/entity_test.go
@@ -13,8 +13,9 @@ type nestedStruct struct {
 	X bool `json:"x"`
 	Y []string
 }
+
 type F struct {
-	Field string
+	Field string `json:",omitempty"`
 }
 
 type testStruct struct {


### PR DESCRIPTION
Update payload logic was not aware of things like ",omitempty". This would cause an invalid field name in the PATCH payload to update objects with optional fields. This updates the handling to strip out this string from the JSON property name.

Closes: #431