### PR TITLE
fix: TrustedComponent TPM is a json object

### DIFF
--- a/redfish/trustedcomponent.go
+++ b/redfish/trustedcomponent.go
@@ -106,7 +106,7 @@ type TrustedComponent struct {
 	Status common.Status
 	// TPM shall contain TPM-specific information for this trusted component. This property shall only be present for
 	// TCG-defined TPM trusted components.
-	TPM json.RawMessage `json:"TPM,omitempty"`
+	TPM TPM
 	// TrustedComponentType shall contain the type of trusted component.
 	TrustedComponentType TrustedComponentType
 	// UUID shall contain a universally unique identifier number for the trusted component.

--- a/redfish/trustedcomponent.go
+++ b/redfish/trustedcomponent.go
@@ -106,7 +106,7 @@ type TrustedComponent struct {
 	Status common.Status
 	// TPM shall contain TPM-specific information for this trusted component. This property shall only be present for
 	// TCG-defined TPM trusted components.
-	TPM string
+	TPM json.RawMessage `json:"TPM,omitempty"`
 	// TrustedComponentType shall contain the type of trusted component.
 	TrustedComponentType TrustedComponentType
 	// UUID shall contain a universally unique identifier number for the trusted component.


### PR DESCRIPTION
Redfish TrustedComponents can have a `TPM` object that looks like this:


```json
  "TPM": {
    "CapabilitiesVendorID": "IFX",
    "HardwareInterfaceVendorID": "0x15D1"
  },
```

Currently, the gofish TrustedComponent type has a `string` struct field for TPMs, and when using the gofish `ListReferencedTrustedComponents`, the Unmarshal fails.

There is a custom TPM struct that we should use as the type instead

```go
// TPM shall contain TPM-specific information for a trusted component.
type TPM struct {
	// CapabilitiesVendorID shall contain an ASCII string of the 4-byte TCG-defined 'TPM Capabilities Vendor ID' for
	// this trusted component.
	CapabilitiesVendorID string
	// HardwareInterfaceVendorID shall contain the TCG-defined 'TPM Hardware Interface Vendor ID' for this trusted
	// component with the most significant byte shown first.
	HardwareInterfaceVendorID string
}

```