### PR TITLE
Fix: handle missing NetworkAdapters link in Chassis resources

### DIFF
--- a/redfish/chassis.go
+++ b/redfish/chassis.go
@@ -816,6 +816,9 @@ func (chassis *Chassis) Switches() ([]*Switch, error) {
 
 // NetworkAdapters gets the collection of network adapters of this chassis
 func (chassis *Chassis) NetworkAdapters() ([]*NetworkAdapter, error) {
+	if chassis.networkAdapters == "" {
+		return nil, nil
+	}
 	return ListReferencedNetworkAdapter(chassis.GetClient(), chassis.networkAdapters)
 }
 


### PR DESCRIPTION
### Context

According to the Redfish schema [Chassis.v1_27_0](https://redfish.dmtf.org/schemas/v1/Chassis.v1_27_0.json), the `NetworkAdapters` property is optional. It may be absent when no adapters are present in the chassis, which is a valid and expected situation.

However, the current implementation of `(*Chassis).NetworkAdapters()` does not account for this and attempts to fetch the collection even when the link is undefined. This can result in unnecessary HTTP requests or 404 errors.

This occurs in particular with hardware elements like **backplanes** or modular storage components, which are exposed as `Chassis` (with types like `"Component"` or `"Module"`) but do not contain any network adapters.

---

### Change

This patch adds a guard clause to check if the `networkAdapters` link is empty before attempting to retrieve it. If it is not defined, the method simply returns `nil` without error.

---

### Impact

- Prevents misleading errors when no `NetworkAdapters` are exposed.
- Ensures consistent behavior with other optional links such as `Power()`, `Thermal()`, and `PCIeSlots()`.
- Improves compatibility with real-world Redfish implementations.
- No breaking changes introduced.