### PR TITLE
Initialize TLSClientConfig when using default transport

### DIFF
--- a/client.go
+++ b/client.go
@@ -7,6 +7,7 @@ package gofish
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -141,6 +142,13 @@ func setupClientWithConfig(ctx context.Context, config *ClientConfig) (c *APICli
 	// amend its configuration to match what was provided to us
 	if transport, ok := client.HTTPClient.Transport.(*http.Transport); ok {
 		if config.Insecure {
+			// If we're using the default transport, need to make sure there
+			// is a TLSClientConfig set in order to set the SkipVerify flag.
+			if transport.TLSClientConfig == nil {
+				transport.TLSClientConfig = &tls.Config{
+					MinVersion: tls.VersionTLS12,
+				}
+			}
 			transport.TLSClientConfig.InsecureSkipVerify = config.Insecure
 		}
 


### PR DESCRIPTION
To allow insecure (unverified TLS) connections, we need to set a flag allowing it. When using the default http client, or if a supplied client has not been fully configured, the struct containing this flag is not initialized and set to nil in the http client transport.

This makes sure the config property is initialized if we are configured to set the flag to avoid nil pointer errors.

Closes: #436 