### PR TITLE
Handle etag properly on CreateAccount call

### DIFF
--- a/common/entity.go
+++ b/common/entity.go
@@ -63,6 +63,11 @@ func (e *Entity) DisableEtagMatch(b bool) {
 	e.disableEtagMatch = b
 }
 
+// IsEtagMatchDisabled indicates if etag matching is enabled on this entity
+func (e *Entity) IsEtagMatchDisabled() bool {
+	return e.disableEtagMatch
+}
+
 // Update commits changes to an entity.
 func (e *Entity) Update(originalEntity, updatedEntity reflect.Value, allowedUpdates []string) error {
 	payload := getPatchPayloadFromUpdate(originalEntity, updatedEntity)


### PR DESCRIPTION
I discovered that BMCs send a different ETag on the `/AccountService/Accounts` endpoint, which is used to both list accounts and create a new account. On some BMCs, the ETag is the same for both `/AccountService` and `/AccountService/Accounts`

As a result, `CreateAccount` fails if ETag is properly validated on a BMC. This change adjusts the request to retrieve the proper ETag before creating an account if ETag is enabled