### PR TITLE
Handle empty arrays for PCIeInterfaces.

### DIFF
--- a/redfish/pciedevice.go
+++ b/redfish/pciedevice.go
@@ -379,6 +379,26 @@ type PCIeInterface struct {
 	PCIeType PCIeTypes
 }
 
+func (p *PCIeInterface) UnmarshalJSON(b []byte) error {
+	// If it's an empty array, ignore zero value.
+	if string(b) == "[]" {
+		return nil
+	}
+
+	type temp PCIeInterface
+	var t struct {
+		temp
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	*p = PCIeInterface(t.temp)
+	return nil
+}
+
 // Assembly gets the assembly for this device.
 func (pciedevice *PCIeDevice) Assembly() (*Assembly, error) {
 	if pciedevice.assembly == "" {


### PR DESCRIPTION
Handles #442. I know this is a vendor issue, but I feel we should be liberal in handling this data. Are you worried that fixing it in one place means we have to handle incorrect specs everywhere?