### PR TITLE
Refactor Update method to reduce boilerplate

### DIFF
--- a/redfish/accountservice.go
+++ b/redfish/accountservice.go
@@ -7,7 +7,6 @@ package redfish
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -448,14 +447,6 @@ func (accountservice *AccountService) PrivilegeMap() (*PrivilegeRegistry, error)
 
 // Update commits updates to this object's properties to the running system.
 func (accountservice *AccountService) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(AccountService)
-	err := original.UnmarshalJSON(accountservice.RawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"AccountLockoutCounterResetAfter",
 		"AccountLockoutCounterResetEnabled",
@@ -468,10 +459,7 @@ func (accountservice *AccountService) Update() error {
 		"ServiceEnabled",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(accountservice).Elem()
-
-	return accountservice.Entity.Update(originalElement, currentElement, readWriteFields)
+	return accountservice.UpdateFromRawData(accountservice, accountservice.RawData, readWriteFields)
 }
 
 // GetAccountService will get the AccountService instance from the Redfish

--- a/redfish/aggregationservice.go
+++ b/redfish/aggregationservice.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -127,19 +126,11 @@ func (aggregationservice *AggregationService) ConnectionMethods() ([]*Connection
 
 // Update commits updates to this object's properties to the running system.
 func (aggregationservice *AggregationService) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(AggregationService)
-	original.UnmarshalJSON(aggregationservice.rawData)
-
 	readWriteFields := []string{
 		"ServiceEnabled",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(aggregationservice).Elem()
-
-	return aggregationservice.Entity.Update(originalElement, currentElement, readWriteFields)
+	return aggregationservice.UpdateFromRawData(aggregationservice, aggregationservice.rawData, readWriteFields)
 }
 
 // GetAggregationService will get a AggregationService instance from the service.

--- a/redfish/aggregationsource.go
+++ b/redfish/aggregationsource.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -170,11 +169,6 @@ func (aggregationsource *AggregationSource) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (aggregationsource *AggregationSource) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(AggregationSource)
-	original.UnmarshalJSON(aggregationsource.rawData)
-
 	readWriteFields := []string{
 		"AggregationType",
 		"HostName",
@@ -182,10 +176,7 @@ func (aggregationsource *AggregationSource) Update() error {
 		"UserName",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(aggregationsource).Elem()
-
-	return aggregationsource.Entity.Update(originalElement, currentElement, readWriteFields)
+	return aggregationsource.UpdateFromRawData(aggregationsource, aggregationsource.rawData, readWriteFields)
 }
 
 // GetAggregationSource will get a AggregationSource instance from the service.

--- a/redfish/allowdeny.go
+++ b/redfish/allowdeny.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -100,11 +99,6 @@ func (allowdeny *AllowDeny) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (allowdeny *AllowDeny) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(AllowDeny)
-	_ = original.UnmarshalJSON(allowdeny.rawData)
-
 	readWriteFields := []string{
 		"AllowType",
 		"DestinationPortLower",
@@ -119,10 +113,7 @@ func (allowdeny *AllowDeny) Update() error {
 		"StatefulSession",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(allowdeny).Elem()
-
-	return allowdeny.Entity.Update(originalElement, currentElement, readWriteFields)
+	return allowdeny.UpdateFromRawData(allowdeny, allowdeny.rawData, readWriteFields)
 }
 
 // GetAllowDeny will get a AllowDeny instance from the service.

--- a/redfish/assembly.go
+++ b/redfish/assembly.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -53,22 +52,11 @@ func (assembly *Assembly) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (assembly *Assembly) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Assembly)
-	err := original.UnmarshalJSON(assembly.rawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"Assemblies",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(assembly).Elem()
-
-	return assembly.Entity.Update(originalElement, currentElement, readWriteFields)
+	return assembly.UpdateFromRawData(assembly, assembly.rawData, readWriteFields)
 }
 
 // GetAssembly will get a Assembly instance from the service.

--- a/redfish/battery.go
+++ b/redfish/battery.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -171,19 +170,11 @@ func (battery *Battery) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (battery *Battery) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Battery)
-	_ = original.UnmarshalJSON(battery.rawData)
-
 	readWriteFields := []string{
 		"LocationIndicatorActive",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(battery).Elem()
-
-	return battery.Entity.Update(originalElement, currentElement, readWriteFields)
+	return battery.UpdateFromRawData(battery, battery.rawData, readWriteFields)
 }
 
 // GetBattery will get a Battery instance from the service.

--- a/redfish/cable.go
+++ b/redfish/cable.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -250,11 +249,6 @@ func (cable *Cable) UptreamPorts() ([]*Port, error) {
 
 // Update commits updates to this object's properties to the running system.
 func (cable *Cable) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Cable)
-	original.UnmarshalJSON(cable.rawData)
-
 	readWriteFields := []string{
 		"AssetTag",
 		"CableClass",
@@ -275,10 +269,7 @@ func (cable *Cable) Update() error {
 		"Vendor",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(cable).Elem()
-
-	return cable.Entity.Update(originalElement, currentElement, readWriteFields)
+	return cable.UpdateFromRawData(cable, cable.rawData, readWriteFields)
 }
 
 // GetCable will get a Cable instance from the service.

--- a/redfish/chassis.go
+++ b/redfish/chassis.go
@@ -7,7 +7,6 @@ package redfish
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -572,14 +571,6 @@ func (chassis *Chassis) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (chassis *Chassis) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Chassis)
-	err := original.UnmarshalJSON(chassis.RawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"AssetTag",
 		"IndicatorLED",
@@ -591,10 +582,7 @@ func (chassis *Chassis) Update() error {
 		"LocationIndicatorActive",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(chassis).Elem()
-
-	return chassis.Entity.Update(originalElement, currentElement, readWriteFields)
+	return chassis.UpdateFromRawData(chassis, chassis.RawData, readWriteFields)
 }
 
 // GetChassis will get a Chassis instance from the Redfish service.

--- a/redfish/circuit.go
+++ b/redfish/circuit.go
@@ -7,7 +7,6 @@ package redfish
 import (
 	"encoding/json"
 	"errors"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -446,14 +445,6 @@ func GetCircuit(c common.Client, uri string) (*Circuit, error) {
 
 // Update commits updates to this object's properties to the running system.
 func (circuit *Circuit) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	ct := new(Circuit)
-	err := ct.UnmarshalJSON(circuit.rawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"ConfigurationLocked",
 		"CriticalCircuit",
@@ -471,10 +462,7 @@ func (circuit *Circuit) Update() error {
 		"UserLabel",
 	}
 
-	originalElement := reflect.ValueOf(ct).Elem()
-	currentElement := reflect.ValueOf(circuit).Elem()
-
-	return circuit.Entity.Update(originalElement, currentElement, readWriteFields)
+	return circuit.UpdateFromRawData(circuit, circuit.rawData, readWriteFields)
 }
 
 // This action shall control the state of the circuit breaker or over-current protection device.

--- a/redfish/componentintegrity.go
+++ b/redfish/componentintegrity.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -229,19 +228,11 @@ func (componentintegrity *ComponentIntegrity) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (componentintegrity *ComponentIntegrity) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(ComponentIntegrity)
-	original.UnmarshalJSON(componentintegrity.rawData)
-
 	readWriteFields := []string{
 		"ComponentIntegrityEnabled",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(componentintegrity).Elem()
-
-	return componentintegrity.Entity.Update(originalElement, currentElement, readWriteFields)
+	return componentintegrity.UpdateFromRawData(componentintegrity, componentintegrity.rawData, readWriteFields)
 }
 
 // GetComponentIntegrity will get a ComponentIntegrity instance from the service.

--- a/redfish/compositionservice.go
+++ b/redfish/compositionservice.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -150,23 +149,12 @@ func (compositionservice *CompositionService) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (compositionservice *CompositionService) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(CompositionService)
-	err := original.UnmarshalJSON(compositionservice.rawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"AllowOverprovisioning",
 		"ServiceEnabled",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(compositionservice).Elem()
-
-	return compositionservice.Entity.Update(originalElement, currentElement, readWriteFields)
+	return compositionservice.UpdateFromRawData(compositionservice, compositionservice.rawData, readWriteFields)
 }
 
 // GetCompositionService will get a CompositionService instance from the service.

--- a/redfish/computersystem.go
+++ b/redfish/computersystem.go
@@ -7,7 +7,6 @@ package redfish
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/stmcginnis/gofish/common"
@@ -1031,14 +1030,6 @@ func (computersystem *ComputerSystem) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (computersystem *ComputerSystem) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	cs := new(ComputerSystem)
-	err := cs.UnmarshalJSON(computersystem.RawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"AssetTag",
 		"HostName",
@@ -1051,10 +1042,7 @@ func (computersystem *ComputerSystem) Update() error {
 		"IndicatorLED",
 	}
 
-	originalElement := reflect.ValueOf(cs).Elem()
-	currentElement := reflect.ValueOf(computersystem).Elem()
-
-	return computersystem.Entity.Update(originalElement, currentElement, readWriteFields)
+	return computersystem.UpdateFromRawData(computersystem, computersystem.RawData, readWriteFields)
 }
 
 // GetComputerSystem will get a ComputerSystem instance from the service.

--- a/redfish/control.go
+++ b/redfish/control.go
@@ -7,7 +7,6 @@ package redfish
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -207,11 +206,6 @@ func (control *Control) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (control *Control) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Control)
-	original.UnmarshalJSON(control.rawData)
-
 	readWriteFields := []string{
 		"ControlDelaySeconds",
 		"ControlMode",
@@ -221,10 +215,7 @@ func (control *Control) Update() error {
 		"SettingMin",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(control).Elem()
-
-	return control.Entity.Update(originalElement, currentElement, readWriteFields)
+	return control.UpdateFromRawData(control, control.rawData, readWriteFields)
 }
 
 // GetControl will get a Control instance from the service.

--- a/redfish/coolantconnector.go
+++ b/redfish/coolantconnector.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -161,11 +160,6 @@ func (coolantconnector *CoolantConnector) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (coolantconnector *CoolantConnector) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(CoolantConnector)
-	original.UnmarshalJSON(coolantconnector.rawData)
-
 	readWriteFields := []string{
 		"CoolingLoopName",
 		"CoolingManagerURI",
@@ -177,10 +171,7 @@ func (coolantconnector *CoolantConnector) Update() error {
 		"SupplyTemperatureControlCelsius",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(coolantconnector).Elem()
-
-	return coolantconnector.Entity.Update(originalElement, currentElement, readWriteFields)
+	return coolantconnector.UpdateFromRawData(coolantconnector, coolantconnector.rawData, readWriteFields)
 }
 
 // GetCoolantConnector will get a CoolantConnector instance from the service.

--- a/redfish/coolingloop.go
+++ b/redfish/coolingloop.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -150,11 +149,6 @@ func (coolingloop *CoolingLoop) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (coolingloop *CoolingLoop) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(CoolingLoop)
-	original.UnmarshalJSON(coolingloop.rawData)
-
 	readWriteFields := []string{
 		"ConsumingEquipmentNames",
 		"CoolingManagerURI",
@@ -163,10 +157,7 @@ func (coolingloop *CoolingLoop) Update() error {
 		"UserLabel",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(coolingloop).Elem()
-
-	return coolingloop.Entity.Update(originalElement, currentElement, readWriteFields)
+	return coolingloop.UpdateFromRawData(coolingloop, coolingloop.rawData, readWriteFields)
 }
 
 // GetCoolingLoop will get a CoolingLoop instance from the service.

--- a/redfish/coolingunit.go
+++ b/redfish/coolingunit.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -199,20 +198,12 @@ func (coolingunit *CoolingUnit) SetMode(mode CoolingUnitMode) error {
 
 // Update commits updates to this object's properties to the running system.
 func (coolingunit *CoolingUnit) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(CoolingUnit)
-	original.UnmarshalJSON(coolingunit.rawData)
-
 	readWriteFields := []string{
 		"AssetTag",
 		"UserLabel",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(coolingunit).Elem()
-
-	return coolingunit.Entity.Update(originalElement, currentElement, readWriteFields)
+	return coolingunit.UpdateFromRawData(coolingunit, coolingunit.rawData, readWriteFields)
 }
 
 // GetCoolingUnit will get a CoolingUnit instance from the service.

--- a/redfish/drive.go
+++ b/redfish/drive.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -415,14 +414,6 @@ func (drive *Drive) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (drive *Drive) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Drive)
-	err := original.UnmarshalJSON(drive.RawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"AssetTag",
 		"HotspareReplacementMode",
@@ -434,10 +425,7 @@ func (drive *Drive) Update() error {
 		"IndicatorLED",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(drive).Elem()
-
-	return drive.Entity.Update(originalElement, currentElement, readWriteFields)
+	return drive.UpdateFromRawData(drive, drive.RawData, readWriteFields)
 }
 
 // GetDrive will get a Drive instance from the service.

--- a/redfish/endpointgroup.go
+++ b/redfish/endpointgroup.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -106,20 +105,12 @@ func (endpointgroup *EndpointGroup) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (endpointgroup *EndpointGroup) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(EndpointGroup)
-	original.UnmarshalJSON(endpointgroup.rawData)
-
 	readWriteFields := []string{
 		"GroupType",
 		"TargetEndpointGroupIdentifier",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(endpointgroup).Elem()
-
-	return endpointgroup.Entity.Update(originalElement, currentElement, readWriteFields)
+	return endpointgroup.UpdateFromRawData(endpointgroup, endpointgroup.rawData, readWriteFields)
 }
 
 // GetEndpointGroup will get a EndpointGroup instance from the service.

--- a/redfish/environmentmetrics.go
+++ b/redfish/environmentmetrics.go
@@ -7,7 +7,6 @@ package redfish
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -125,19 +124,11 @@ func (environmentmetrics *EnvironmentMetrics) ResetToDefaults() error {
 
 // Update commits updates to this object's properties to the running system.
 func (environmentmetrics *EnvironmentMetrics) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(EnvironmentMetrics)
-	original.UnmarshalJSON(environmentmetrics.rawData)
-
 	readWriteFields := []string{
 		"PowerLimitWatts",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(environmentmetrics).Elem()
-
-	return environmentmetrics.Entity.Update(originalElement, currentElement, readWriteFields)
+	return environmentmetrics.UpdateFromRawData(environmentmetrics, environmentmetrics.rawData, readWriteFields)
 }
 
 // GetEnvironmentMetrics will get a EnvironmentMetrics instance from the service.

--- a/redfish/ethernetinterface.go
+++ b/redfish/ethernetinterface.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -362,14 +361,6 @@ func (ethernetinterface *EthernetInterface) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (ethernetinterface *EthernetInterface) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(EthernetInterface)
-	err := original.UnmarshalJSON(ethernetinterface.rawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"AutoNeg",
 		"DHCPv4",
@@ -392,10 +383,7 @@ func (ethernetinterface *EthernetInterface) Update() error {
 		"VLAN",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(ethernetinterface).Elem()
-
-	return ethernetinterface.Entity.Update(originalElement, currentElement, readWriteFields)
+	return ethernetinterface.UpdateFromRawData(ethernetinterface, ethernetinterface.rawData, readWriteFields)
 }
 
 // GetEthernetInterface will get a EthernetInterface instance from the service.

--- a/redfish/eventdestination.go
+++ b/redfish/eventdestination.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"reflect"
 	"strings"
 
 	"github.com/stmcginnis/gofish/common"
@@ -369,24 +368,13 @@ func (eventdestination *EventDestination) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (eventdestination *EventDestination) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(EventDestination)
-	err := original.UnmarshalJSON(eventdestination.rawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"Context",
 		"DeliveryRetryPolicy",
 		"VerifyCertificate",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(eventdestination).Elem()
-
-	return eventdestination.Entity.Update(originalElement, currentElement, readWriteFields)
+	return eventdestination.UpdateFromRawData(eventdestination, eventdestination.rawData, readWriteFields)
 }
 
 // GetEventDestination will get a EventDestination instance from the service.

--- a/redfish/eventservice.go
+++ b/redfish/eventservice.go
@@ -7,7 +7,6 @@ package redfish
 import (
 	"encoding/json"
 	"errors"
-	"reflect"
 	"strings"
 	"time"
 
@@ -228,24 +227,13 @@ func (eventservice *EventService) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (eventservice *EventService) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(EventService)
-	err := original.UnmarshalJSON(eventservice.RawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"DeliveryRetryAttempts",
 		"DeliveryRetryIntervalSeconds",
 		"ServiceEnabled",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(eventservice).Elem()
-
-	return eventservice.Entity.Update(originalElement, currentElement, readWriteFields)
+	return eventservice.UpdateFromRawData(eventservice, eventservice.RawData, readWriteFields)
 }
 
 // GetEventService will get a EventService instance from the service.

--- a/redfish/externalaccountprovider.go
+++ b/redfish/externalaccountprovider.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -134,11 +133,6 @@ func (externalaccountprovider *ExternalAccountProvider) Certificates() ([]*Certi
 
 // Update commits updates to this object's properties to the running system.
 func (externalaccountprovider *ExternalAccountProvider) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(ExternalAccountProvider)
-	original.UnmarshalJSON(externalaccountprovider.rawData)
-
 	readWriteFields := []string{
 		"Priority",
 		"Retries",
@@ -147,10 +141,7 @@ func (externalaccountprovider *ExternalAccountProvider) Update() error {
 		"TimeoutSeconds",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(externalaccountprovider).Elem()
-
-	return externalaccountprovider.Entity.Update(originalElement, currentElement, readWriteFields)
+	return externalaccountprovider.UpdateFromRawData(externalaccountprovider, externalaccountprovider.rawData, readWriteFields)
 }
 
 // GetExternalAccountProvider will get a ExternalAccountProvider instance from the service.

--- a/redfish/fabric.go
+++ b/redfish/fabric.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -111,19 +110,11 @@ func (fabric *Fabric) Switches() ([]*Switch, error) {
 
 // Update commits updates to this object's properties to the running system.
 func (fabric *Fabric) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Fabric)
-	original.UnmarshalJSON(fabric.rawData)
-
 	readWriteFields := []string{
 		"UUID",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(fabric).Elem()
-
-	return fabric.Entity.Update(originalElement, currentElement, readWriteFields)
+	return fabric.UpdateFromRawData(fabric, fabric.rawData, readWriteFields)
 }
 
 // GetFabric will get a Fabric instance from the service.

--- a/redfish/fabricadapter.go
+++ b/redfish/fabricadapter.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -169,20 +168,12 @@ func (fabricadapter *FabricAdapter) Processors() ([]*Processor, error) {
 
 // Update commits updates to this object's properties to the running system.
 func (fabricadapter *FabricAdapter) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(FabricAdapter)
-	original.UnmarshalJSON(fabricadapter.rawData)
-
 	readWriteFields := []string{
 		"FabricType",
 		"LocationIndicatorActive",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(fabricadapter).Elem()
-
-	return fabricadapter.Entity.Update(originalElement, currentElement, readWriteFields)
+	return fabricadapter.UpdateFromRawData(fabricadapter, fabricadapter.rawData, readWriteFields)
 }
 
 // GetFabricAdapter will get a FabricAdapter instance from the service.

--- a/redfish/fan.go
+++ b/redfish/fan.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -137,19 +136,11 @@ func (fan *Fan) CoolingChassis() ([]*Chassis, error) {
 
 // Update commits updates to this object's properties to the running system.
 func (fan *Fan) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Fan)
-	original.UnmarshalJSON(fan.rawData)
-
 	readWriteFields := []string{
 		"LocationIndicatorActive",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(fan).Elem()
-
-	return fan.Entity.Update(originalElement, currentElement, readWriteFields)
+	return fan.UpdateFromRawData(fan, fan.rawData, readWriteFields)
 }
 
 // GetFan will get a Fan instance from the service.

--- a/redfish/filter.go
+++ b/redfish/filter.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -109,11 +108,6 @@ func (filter *Filter) Assembly() (*Assembly, error) {
 
 // Update commits updates to this object's properties to the running system.
 func (filter *Filter) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Filter)
-	original.UnmarshalJSON(filter.rawData)
-
 	readWriteFields := []string{
 		"LocationIndicatorActive",
 		"ServiceHours",
@@ -121,10 +115,7 @@ func (filter *Filter) Update() error {
 		"UserLabel",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(filter).Elem()
-
-	return filter.Entity.Update(originalElement, currentElement, readWriteFields)
+	return filter.UpdateFromRawData(filter, filter.rawData, readWriteFields)
 }
 
 // GetFilter will get a Filter instance from the service.

--- a/redfish/graphicscontroller.go
+++ b/redfish/graphicscontroller.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -118,19 +117,11 @@ func (graphicscontroller *GraphicsController) Processors() ([]*Processor, error)
 
 // Update commits updates to this object's properties to the running system.
 func (graphicscontroller *GraphicsController) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(GraphicsController)
-	original.UnmarshalJSON(graphicscontroller.rawData)
-
 	readWriteFields := []string{
 		"AssetTag",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(graphicscontroller).Elem()
-
-	return graphicscontroller.Entity.Update(originalElement, currentElement, readWriteFields)
+	return graphicscontroller.UpdateFromRawData(graphicscontroller, graphicscontroller.rawData, readWriteFields)
 }
 
 // GetGraphicsController will get a GraphicsController instance from the service.

--- a/redfish/heater.go
+++ b/redfish/heater.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -176,19 +175,11 @@ func (heater *Heater) Metrics() (*HeaterMetrics, error) {
 
 // Update commits updates to this object's properties to the running system.
 func (heater *Heater) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Heater)
-	original.UnmarshalJSON(heater.rawData)
-
 	readWriteFields := []string{
 		"LocationIndicatorActive",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(heater).Elem()
-
-	return heater.Entity.Update(originalElement, currentElement, readWriteFields)
+	return heater.UpdateFromRawData(heater, heater.rawData, readWriteFields)
 }
 
 // GetHeater will get a Heater instance from the service.

--- a/redfish/hostinterface.go
+++ b/redfish/hostinterface.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -187,24 +186,13 @@ func (hostinterface *HostInterface) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (hostinterface *HostInterface) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(HostInterface)
-	err := original.UnmarshalJSON(hostinterface.rawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"AuthNoneRoleId",
 		"AuthenticationModes",
 		"InterfaceEnabled",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(hostinterface).Elem()
-
-	return hostinterface.Entity.Update(originalElement, currentElement, readWriteFields)
+	return hostinterface.UpdateFromRawData(hostinterface, hostinterface.rawData, readWriteFields)
 }
 
 // GetHostInterface will get a HostInterface instance from the service.

--- a/redfish/key.go
+++ b/redfish/key.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -118,19 +117,11 @@ func (key *Key) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (key *Key) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Key)
-	original.UnmarshalJSON(key.rawData)
-
 	readWriteFields := []string{
 		"UserDescription",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(key).Elem()
-
-	return key.Entity.Update(originalElement, currentElement, readWriteFields)
+	return key.UpdateFromRawData(key, key.rawData, readWriteFields)
 }
 
 // GetKey will get a Key instance from the service.

--- a/redfish/keypolicy.go
+++ b/redfish/keypolicy.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -145,19 +144,11 @@ func (keypolicy *KeyPolicy) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (keypolicy *KeyPolicy) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(KeyPolicy)
-	original.UnmarshalJSON(keypolicy.rawData)
-
 	readWriteFields := []string{
 		"IsDefault",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(keypolicy).Elem()
-
-	return keypolicy.Entity.Update(originalElement, currentElement, readWriteFields)
+	return keypolicy.UpdateFromRawData(keypolicy, keypolicy.rawData, readWriteFields)
 }
 
 // GetKeyPolicy will get a KeyPolicy instance from the service.

--- a/redfish/leakdetector.go
+++ b/redfish/leakdetector.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -109,17 +108,9 @@ type LeakDetectorExcerpt struct {
 }
 
 func (leakdetector *LeakDetector) Update() error {
-	ld := new(LeakDetector)
-	err := ld.OEM.UnmarshalJSON(leakdetector.RawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"Enabled",
 	}
 
-	originalElement := reflect.ValueOf(ld).Elem()
-	currentElement := reflect.ValueOf(leakdetector).Elem()
-	return leakdetector.Entity.Update(originalElement, currentElement, readWriteFields)
+	return leakdetector.UpdateFromRawData(leakdetector, leakdetector.RawData, readWriteFields)
 }

--- a/redfish/licenseservice.go
+++ b/redfish/licenseservice.go
@@ -7,7 +7,6 @@ package redfish
 import (
 	"encoding/json"
 	"errors"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -115,20 +114,12 @@ func (licenseservice *LicenseService) Licenses() ([]*License, error) {
 
 // Update commits updates to this object's properties to the running system.
 func (licenseservice *LicenseService) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(LicenseService)
-	original.UnmarshalJSON(licenseservice.rawData)
-
 	readWriteFields := []string{
 		"LicenseExpirationWarningDays",
 		"ServiceEnabled",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(licenseservice).Elem()
-
-	return licenseservice.Entity.Update(originalElement, currentElement, readWriteFields)
+	return licenseservice.UpdateFromRawData(licenseservice, licenseservice.rawData, readWriteFields)
 }
 
 // GetLicenseService will get a LicenseService instance from the service.

--- a/redfish/logentry.go
+++ b/redfish/logentry.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -570,19 +569,11 @@ func (logentry *LogEntry) RelatedLogEntries() ([]*LogEntry, error) {
 
 // Update commits updates to this object's properties to the running system.
 func (logentry *LogEntry) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(LogEntry)
-	original.UnmarshalJSON(logentry.rawData)
-
 	readWriteFields := []string{
 		"Resolved",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(logentry).Elem()
-
-	return logentry.Entity.Update(originalElement, currentElement, readWriteFields)
+	return logentry.UpdateFromRawData(logentry, logentry.rawData, readWriteFields)
 }
 
 // GetLogEntry will get a LogEntry instance from the service.

--- a/redfish/logservice.go
+++ b/redfish/logservice.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/stmcginnis/gofish/common"
@@ -180,14 +179,6 @@ func (logservice *LogService) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (logservice *LogService) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(LogService)
-	err := original.UnmarshalJSON(logservice.rawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"AutoDSTEnabled",
 		"DateTime",
@@ -195,10 +186,7 @@ func (logservice *LogService) Update() error {
 		"ServiceEnabled",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(logservice).Elem()
-
-	return logservice.Entity.Update(originalElement, currentElement, readWriteFields)
+	return logservice.UpdateFromRawData(logservice, logservice.rawData, readWriteFields)
 }
 
 // GetLogService will get a LogService instance from the service.

--- a/redfish/manager.go
+++ b/redfish/manager.go
@@ -7,7 +7,6 @@ package redfish
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -492,14 +491,6 @@ func (manager *Manager) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (manager *Manager) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Manager)
-	err := original.UnmarshalJSON(manager.RawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"AutoDSTEnabled",
 		"DateTime",
@@ -509,10 +500,7 @@ func (manager *Manager) Update() error {
 		"TimeZoneName",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(manager).Elem()
-
-	return manager.Entity.Update(originalElement, currentElement, readWriteFields)
+	return manager.UpdateFromRawData(manager, manager.RawData, readWriteFields)
 }
 
 // GetManager will get a Manager instance from the Swordfish service.

--- a/redfish/manageraccount.go
+++ b/redfish/manageraccount.go
@@ -7,7 +7,6 @@ package redfish
 import (
 	"encoding/json"
 	"errors"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -204,14 +203,6 @@ func (manageraccount *ManagerAccount) ChangePassword(newPassword, sessionAccount
 
 // Update commits updates to this object's properties to the running system.
 func (manageraccount *ManagerAccount) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(ManagerAccount)
-	err := original.UnmarshalJSON(manageraccount.rawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"AccountExpiration",
 		"AccountTypes",
@@ -229,10 +220,7 @@ func (manageraccount *ManagerAccount) Update() error {
 		"UserName",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(manageraccount).Elem()
-
-	return manageraccount.Entity.Update(originalElement, currentElement, readWriteFields)
+	return manageraccount.UpdateFromRawData(manageraccount, manageraccount.rawData, readWriteFields)
 }
 
 // GetManagerAccount will get a ManagerAccount instance from the service.

--- a/redfish/memory.go
+++ b/redfish/memory.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -563,14 +562,6 @@ func (memory *Memory) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (memory *Memory) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Memory)
-	err := original.UnmarshalJSON(memory.rawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"Enabled",
 		"LocationIndicatorActive",
@@ -581,10 +572,7 @@ func (memory *Memory) Update() error {
 		"VolatileSizeLimitMiB",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(memory).Elem()
-
-	return memory.Entity.Update(originalElement, currentElement, readWriteFields)
+	return memory.UpdateFromRawData(memory, memory.rawData, readWriteFields)
 }
 
 // GetMemory will get a Memory instance from the service.

--- a/redfish/memorychunks.go
+++ b/redfish/memorychunks.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -178,21 +177,13 @@ func (memorychunks *MemoryChunks) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (memorychunks *MemoryChunks) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(MemoryChunks)
-	original.UnmarshalJSON(memorychunks.rawData)
-
 	readWriteFields := []string{
 		"DisplayName",
 		"MediaLocation",
 		"RequestedOperationalState",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(memorychunks).Elem()
-
-	return memorychunks.Entity.Update(originalElement, currentElement, readWriteFields)
+	return memorychunks.UpdateFromRawData(memorychunks, memorychunks.rawData, readWriteFields)
 }
 
 // GetMemoryChunks will get a MemoryChunks instance from the service.

--- a/redfish/memoryregion.go
+++ b/redfish/memoryregion.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -149,20 +148,12 @@ func (memoryregion *MemoryRegion) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (memoryregion *MemoryRegion) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(MemoryRegion)
-	original.UnmarshalJSON(memoryregion.rawData)
-
 	readWriteFields := []string{
 		"BlockSizeMiB",
 		"SanitizeOnRelease",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(memoryregion).Elem()
-
-	return memoryregion.Entity.Update(originalElement, currentElement, readWriteFields)
+	return memoryregion.UpdateFromRawData(memoryregion, memoryregion.rawData, readWriteFields)
 }
 
 // GetMemoryRegion will get a MemoryRegion instance from the service.

--- a/redfish/metricdefinition.go
+++ b/redfish/metricdefinition.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -188,11 +187,6 @@ func (metricdefinition *MetricDefinition) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (metricdefinition *MetricDefinition) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(MetricDefinition)
-	original.UnmarshalJSON(metricdefinition.rawData)
-
 	readWriteFields := []string{
 		"Calculable",
 		"CalculationTimeInterval",
@@ -205,10 +199,7 @@ func (metricdefinition *MetricDefinition) Update() error {
 		"Units",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(metricdefinition).Elem()
-
-	return metricdefinition.Entity.Update(originalElement, currentElement, readWriteFields)
+	return metricdefinition.UpdateFromRawData(metricdefinition, metricdefinition.rawData, readWriteFields)
 }
 
 // GetMetricDefinition will get a MetricDefinition instance from the service.

--- a/redfish/metricreportdefinition.go
+++ b/redfish/metricreportdefinition.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -244,11 +243,6 @@ func (metricreportdefinition *MetricReportDefinition) Triggers() ([]*Triggers, e
 
 // Update commits updates to this object's properties to the running system.
 func (metricreportdefinition *MetricReportDefinition) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(MetricReportDefinition)
-	original.UnmarshalJSON(metricreportdefinition.rawData)
-
 	readWriteFields := []string{
 		"MetricProperties",
 		"MetricReportDefinitionEnabled",
@@ -260,10 +254,7 @@ func (metricreportdefinition *MetricReportDefinition) Update() error {
 		"SuppressRepeatedMetricValue",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(metricreportdefinition).Elem()
-
-	return metricreportdefinition.Entity.Update(originalElement, currentElement, readWriteFields)
+	return metricreportdefinition.UpdateFromRawData(metricreportdefinition, metricreportdefinition.rawData, readWriteFields)
 }
 
 // GetMetricReportDefinition will get a MetricReportDefinition instance from the service.

--- a/redfish/networkadapter.go
+++ b/redfish/networkadapter.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -331,19 +330,11 @@ func (networkadapter *NetworkAdapter) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (networkadapter *NetworkAdapter) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(NetworkAdapter)
-	original.UnmarshalJSON(networkadapter.rawData)
-
 	readWriteFields := []string{
 		"LLDPEnabled",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(networkadapter).Elem()
-
-	return networkadapter.Entity.Update(originalElement, currentElement, readWriteFields)
+	return networkadapter.UpdateFromRawData(networkadapter, networkadapter.rawData, readWriteFields)
 }
 
 // GetNetworkAdapter will get a NetworkAdapter instance from the Redfish service.

--- a/redfish/networkdevicefunction.go
+++ b/redfish/networkdevicefunction.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -488,14 +487,6 @@ func (networkdevicefunction *NetworkDeviceFunction) PhysicalPortAssignment() (*N
 
 // Update commits updates to this object's properties to the running system.
 func (networkdevicefunction *NetworkDeviceFunction) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(NetworkDeviceFunction)
-	err := original.UnmarshalJSON(networkdevicefunction.rawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"BootMode",
 		"DeviceEnabled",
@@ -503,10 +494,7 @@ func (networkdevicefunction *NetworkDeviceFunction) Update() error {
 		"SAVIEnabled",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(networkdevicefunction).Elem()
-
-	return networkdevicefunction.Entity.Update(originalElement, currentElement, readWriteFields)
+	return networkdevicefunction.UpdateFromRawData(networkdevicefunction, networkdevicefunction.rawData, readWriteFields)
 }
 
 // GetNetworkDeviceFunction will get a NetworkDeviceFunction instance from the service.

--- a/redfish/networkport.go
+++ b/redfish/networkport.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -250,14 +249,6 @@ func (networkport *NetworkPort) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (networkport *NetworkPort) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(NetworkPort)
-	err := original.UnmarshalJSON(networkport.rawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"ActiveLinkTechnology",
 		"CurrentLinkSpeedMbps",
@@ -266,10 +257,7 @@ func (networkport *NetworkPort) Update() error {
 		"WakeOnLANEnabled",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(networkport).Elem()
-
-	return networkport.Entity.Update(originalElement, currentElement, readWriteFields)
+	return networkport.UpdateFromRawData(networkport, networkport.rawData, readWriteFields)
 }
 
 // GetNetworkPort will get a NetworkPort instance from the service.

--- a/redfish/networkprotocol.go
+++ b/redfish/networkprotocol.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -258,14 +257,6 @@ func (networkProtocol *NetworkProtocolSettings) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (networkProtocol *NetworkProtocolSettings) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(NetworkProtocolSettings)
-	err := original.UnmarshalJSON(networkProtocol.rawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"DHCP",
 		"DHCPv6",
@@ -284,10 +275,7 @@ func (networkProtocol *NetworkProtocolSettings) Update() error {
 		"VirtualMedia",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(networkProtocol).Elem()
-
-	return networkProtocol.Entity.Update(originalElement, currentElement, readWriteFields)
+	return networkProtocol.UpdateFromRawData(networkProtocol, networkProtocol.rawData, readWriteFields)
 }
 
 func GetNetworkProtocol(c common.Client, uri string) (*NetworkProtocolSettings, error) {

--- a/redfish/outboundconnection.go
+++ b/redfish/outboundconnection.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -163,20 +162,12 @@ func (outboundconnection *OutboundConnection) ClientCertificates() ([]*Certifica
 
 // Update commits updates to this object's properties to the running system.
 func (outboundconnection *OutboundConnection) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(OutboundConnection)
-	original.UnmarshalJSON(outboundconnection.rawData)
-
 	readWriteFields := []string{
 		"ConnectionEnabled",
 		"WebSocketPingIntervalMinutes",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(outboundconnection).Elem()
-
-	return outboundconnection.Entity.Update(originalElement, currentElement, readWriteFields)
+	return outboundconnection.UpdateFromRawData(outboundconnection, outboundconnection.rawData, readWriteFields)
 }
 
 // GetOutboundConnection will get a OutboundConnection instance from the service.

--- a/redfish/outlet.go
+++ b/redfish/outlet.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -287,11 +286,6 @@ func (outlet *Outlet) PowerSupplies() ([]*PowerSupply, error) {
 
 // Update commits updates to this object's properties to the running system.
 func (outlet *Outlet) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Outlet)
-	original.UnmarshalJSON(outlet.rawData)
-
 	readWriteFields := []string{
 		"ConfigurationLocked",
 		"ElectricalConsumerNames",
@@ -305,10 +299,7 @@ func (outlet *Outlet) Update() error {
 		"UserLabel",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(outlet).Elem()
-
-	return outlet.Entity.Update(originalElement, currentElement, readWriteFields)
+	return outlet.UpdateFromRawData(outlet, outlet.rawData, readWriteFields)
 }
 
 // GetOutlet will get a Outlet instance from the service.

--- a/redfish/outletgroup.go
+++ b/redfish/outletgroup.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -140,11 +139,6 @@ func (outletgroup *OutletGroup) Outlets() ([]*Outlet, error) {
 
 // Update commits updates to this object's properties to the running system.
 func (outletgroup *OutletGroup) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(OutletGroup)
-	original.UnmarshalJSON(outletgroup.rawData)
-
 	readWriteFields := []string{
 		"ConfigurationLocked",
 		"CreatedBy",
@@ -156,10 +150,7 @@ func (outletgroup *OutletGroup) Update() error {
 		"PowerRestorePolicy",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(outletgroup).Elem()
-
-	return outletgroup.Entity.Update(originalElement, currentElement, readWriteFields)
+	return outletgroup.UpdateFromRawData(outletgroup, outletgroup.rawData, readWriteFields)
 }
 
 // GetOutletGroup will get a OutletGroup instance from the service.

--- a/redfish/pciedevice.go
+++ b/redfish/pciedevice.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -334,24 +333,13 @@ func (pciedevice *PCIeDevice) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (pciedevice *PCIeDevice) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(PCIeDevice)
-	err := original.UnmarshalJSON(pciedevice.rawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"AssetTag",
 		"LocationIndicatorActive",
 		"ReadyToRemove",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(pciedevice).Elem()
-
-	return pciedevice.Entity.Update(originalElement, currentElement, readWriteFields)
+	return pciedevice.UpdateFromRawData(pciedevice, pciedevice.rawData, readWriteFields)
 }
 
 // GetPCIeDevice will get a PCIeDevice instance from the service.

--- a/redfish/port.go
+++ b/redfish/port.go
@@ -7,7 +7,6 @@ package redfish
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -937,14 +936,6 @@ func (port *Port) GenZVCAT() ([]*VCATEntry, error) {
 
 // Update commits updates to this object's properties to the running system.
 func (port *Port) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Port)
-	err := original.UnmarshalJSON(port.rawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"BackpressureSampleInterval",
 		"CompletionCollectionInterval",
@@ -979,10 +970,7 @@ func (port *Port) Update() error {
 		"LocationIndicatorActive",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(port).Elem()
-
-	return port.Entity.Update(originalElement, currentElement, readWriteFields)
+	return port.UpdateFromRawData(port, port.rawData, readWriteFields)
 }
 
 // GetPort will get a Port instance from the service.

--- a/redfish/power.go
+++ b/redfish/power.go
@@ -7,7 +7,6 @@ package redfish
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"strconv"
 
 	"github.com/stmcginnis/gofish/common"
@@ -425,17 +424,9 @@ func ListReferencedPowerSupplies(c common.Client, link string) ([]*PowerSupply, 
 
 // Update commits updates to this object's properties to the running system.
 func (powersupply *PowerSupply) Update() error {
-	original := new(PowerSupply)
-	err := original.UnmarshalJSON(powersupply.rawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{"IndicatorLED"}
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(powersupply).Elem()
 
-	return powersupply.Entity.Update(originalElement, currentElement, readWriteFields)
+	return powersupply.UpdateFromRawData(powersupply, powersupply.rawData, readWriteFields)
 }
 
 // GetAssembly retrieves the containing Assembly.

--- a/redfish/powerdistribution.go
+++ b/redfish/powerdistribution.go
@@ -7,7 +7,6 @@ package redfish
 import (
 	"encoding/json"
 	"errors"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -256,14 +255,6 @@ func GetPowerDistribution(c common.Client, uri string) (*PowerDistribution, erro
 
 // Update commits updates to this object's properties to the running system.
 func (powerDistribution *PowerDistribution) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	pd := new(PowerDistribution)
-	err := pd.UnmarshalJSON(powerDistribution.rawData)
-	if err != nil {
-		return err
-	}
-
 	// Note: current definition (2023.3) only includes AssetTag and UserLabel.
 	// May have errors trying to set other values, but keeping in here for backwards
 	// compatibility.
@@ -286,10 +277,7 @@ func (powerDistribution *PowerDistribution) Update() error {
 		"UnderVoltageRMSPercentage",
 	}
 
-	originalElement := reflect.ValueOf(pd).Elem()
-	currentElement := reflect.ValueOf(powerDistribution).Elem()
-
-	return powerDistribution.Entity.Update(originalElement, currentElement, readWriteFields)
+	return powerDistribution.UpdateFromRawData(powerDistribution, powerDistribution.rawData, readWriteFields)
 }
 
 // This action shall transfer power input from the existing mains circuit to the alternative mains circuit.

--- a/redfish/powersupplyunit.go
+++ b/redfish/powersupplyunit.go
@@ -7,7 +7,6 @@ package redfish
 import (
 	"encoding/json"
 	"errors"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -209,24 +208,13 @@ func (powerSupplyUnit *PowerSupplyUnit) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (powerSupplyUnit *PowerSupplyUnit) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	psu := new(PowerSupplyUnit)
-	err := psu.UnmarshalJSON(powerSupplyUnit.rawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"ElectricalSourceManagerURIs",
 		"ElectricalSourceNames",
 		"LocationIndicatorActive",
 	}
 
-	originalElement := reflect.ValueOf(psu).Elem()
-	currentElement := reflect.ValueOf(powerSupplyUnit).Elem()
-
-	return powerSupplyUnit.Entity.Update(originalElement, currentElement, readWriteFields)
+	return powerSupplyUnit.UpdateFromRawData(powerSupplyUnit, powerSupplyUnit.rawData, readWriteFields)
 }
 
 // GetPowerSupplyUnit will get a PowerSupplyUnit instance from the Redfish service.

--- a/redfish/processor.go
+++ b/redfish/processor.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 	"strconv"
 
 	"github.com/stmcginnis/gofish/common"
@@ -698,24 +697,14 @@ func (processor *Processor) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (processor *Processor) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Processor)
-	original.UnmarshalJSON(processor.rawData)
-
-	readWriteFields := []string{
-		"AppliedOperatingConfig",
+	readWriteFields := []string{"AppliedOperatingConfig",
 		"Enabled",
 		"LocationIndicatorActive",
 		"OperatingSpeedRangeMHz",
 		"SpeedLimitMHz",
-		"SpeedLocked",
-	}
+		"SpeedLocked"}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(processor).Elem()
-
-	return processor.Entity.Update(originalElement, currentElement, readWriteFields)
+	return processor.UpdateFromRawData(processor, processor.rawData, readWriteFields)
 }
 
 // Reset resets the processor.

--- a/redfish/pump.go
+++ b/redfish/pump.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -156,23 +155,13 @@ func (pump *Pump) Filters() ([]*Filter, error) {
 
 // Update commits updates to this object's properties to the running system.
 func (pump *Pump) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Pump)
-	original.UnmarshalJSON(pump.rawData)
-
-	readWriteFields := []string{
-		"AssetTag",
+	readWriteFields := []string{"AssetTag",
 		"LocationIndicatorActive",
 		"ServiceHours",
 		"SpeedControlPercent",
-		"UserLabel",
-	}
+		"UserLabel"}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(pump).Elem()
-
-	return pump.Entity.Update(originalElement, currentElement, readWriteFields)
+	return pump.UpdateFromRawData(pump, pump.rawData, readWriteFields)
 }
 
 // GetPump will get a Pump instance from the service.

--- a/redfish/redundancy.go
+++ b/redfish/redundancy.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -94,23 +93,12 @@ func (redundancy *Redundancy) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (redundancy *Redundancy) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Redundancy)
-	err := original.UnmarshalJSON(redundancy.rawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"Mode",
 		"RedundancyEnabled",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(redundancy).Elem()
-
-	return redundancy.Entity.Update(originalElement, currentElement, readWriteFields)
+	return redundancy.UpdateFromRawData(redundancy, redundancy.rawData, readWriteFields)
 }
 
 // GetRedundancy will get a Redundancy instance from the service.

--- a/redfish/registeredclient.go
+++ b/redfish/registeredclient.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -106,23 +105,13 @@ func (registeredclient *RegisteredClient) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (registeredclient *RegisteredClient) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(RegisteredClient)
-	original.UnmarshalJSON(registeredclient.rawData)
-
-	readWriteFields := []string{
-		"ClientType",
+	readWriteFields := []string{"ClientType",
 		"ClientURI",
 		"Context",
 		"ExpirationDate",
-		"SubContext",
-	}
+		"SubContext"}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(registeredclient).Elem()
-
-	return registeredclient.Entity.Update(originalElement, currentElement, readWriteFields)
+	return registeredclient.UpdateFromRawData(registeredclient, registeredclient.rawData, readWriteFields)
 }
 
 // GetRegisteredClient will get a RegisteredClient instance from the service.

--- a/redfish/reservoir.go
+++ b/redfish/reservoir.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -130,20 +129,10 @@ func (reservoir *Reservoir) Filters() ([]*Filter, error) {
 
 // Update commits updates to this object's properties to the running system.
 func (reservoir *Reservoir) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Reservoir)
-	original.UnmarshalJSON(reservoir.rawData)
+	readWriteFields := []string{"LocationIndicatorActive",
+		"UserLabel"}
 
-	readWriteFields := []string{
-		"LocationIndicatorActive",
-		"UserLabel",
-	}
-
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(reservoir).Elem()
-
-	return reservoir.Entity.Update(originalElement, currentElement, readWriteFields)
+	return reservoir.UpdateFromRawData(reservoir, reservoir.rawData, readWriteFields)
 }
 
 // GetReservoir will get a Reservoir instance from the service.

--- a/redfish/resource.go
+++ b/redfish/resource.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -385,13 +384,7 @@ func (postaladdress *PostalAddress) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (postaladdress *PostalAddress) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(PostalAddress)
-	original.UnmarshalJSON(postaladdress.rawData)
-
-	readWriteFields := []string{
-		"AdditionalCode",
+	readWriteFields := []string{"AdditionalCode",
 		"AdditionalInfo",
 		"Building",
 		"City",
@@ -420,13 +413,9 @@ func (postaladdress *PostalAddress) Update() error {
 		"StreetSuffix",
 		"Territory",
 		"TrailingStreetSuffix",
-		"Unit",
-	}
+		"Unit"}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(postaladdress).Elem()
-
-	return postaladdress.Entity.Update(originalElement, currentElement, readWriteFields)
+	return postaladdress.UpdateFromRawData(postaladdress, postaladdress.rawData, readWriteFields)
 }
 
 // ReferenceableMember shall contain the location of this element within an item.

--- a/redfish/resourceblock.go
+++ b/redfish/resourceblock.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -267,20 +266,10 @@ func (resourceblock *ResourceBlock) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (resourceblock *ResourceBlock) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(ResourceBlock)
-	original.UnmarshalJSON(resourceblock.rawData)
+	readWriteFields := []string{"Client",
+		"Pool"}
 
-	readWriteFields := []string{
-		"Client",
-		"Pool",
-	}
-
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(resourceblock).Elem()
-
-	return resourceblock.Entity.Update(originalElement, currentElement, readWriteFields)
+	return resourceblock.UpdateFromRawData(resourceblock, resourceblock.rawData, readWriteFields)
 }
 
 // GetResourceBlock will get a ResourceBlock instance from the service.

--- a/redfish/role.go
+++ b/redfish/role.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -104,23 +103,12 @@ func (role *Role) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (role *Role) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Role)
-	err := original.UnmarshalJSON(role.rawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"AssignedPrivileges",
 		"OemPrivileges",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(role).Elem()
-
-	return role.Entity.Update(originalElement, currentElement, readWriteFields)
+	return role.UpdateFromRawData(role, role.rawData, readWriteFields)
 }
 
 // GetRole will get a Role instance from the service.

--- a/redfish/routeentry.go
+++ b/redfish/routeentry.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -66,20 +65,10 @@ func (routeentry *RouteEntry) RouteSet() ([]*RouteSetEntry, error) {
 
 // Update commits updates to this object's properties to the running system.
 func (routeentry *RouteEntry) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(RouteEntry)
-	original.UnmarshalJSON(routeentry.rawData)
+	readWriteFields := []string{"MinimumHopCount",
+		"RawEntryHex"}
 
-	readWriteFields := []string{
-		"MinimumHopCount",
-		"RawEntryHex",
-	}
-
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(routeentry).Elem()
-
-	return routeentry.Entity.Update(originalElement, currentElement, readWriteFields)
+	return routeentry.UpdateFromRawData(routeentry, routeentry.rawData, readWriteFields)
 }
 
 // GetRouteEntry will get a RouteEntry instance from the service.

--- a/redfish/routesetentry.go
+++ b/redfish/routesetentry.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -61,22 +60,12 @@ func (routesetentry *RouteSetEntry) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (routesetentry *RouteSetEntry) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(RouteSetEntry)
-	original.UnmarshalJSON(routesetentry.rawData)
-
-	readWriteFields := []string{
-		"EgressIdentifier",
+	readWriteFields := []string{"EgressIdentifier",
 		"HopCount",
 		"VCAction",
-		"Valid",
-	}
+		"Valid"}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(routesetentry).Elem()
-
-	return routesetentry.Entity.Update(originalElement, currentElement, readWriteFields)
+	return routesetentry.UpdateFromRawData(routesetentry, routesetentry.rawData, readWriteFields)
 }
 
 // GetRouteSetEntry will get a RouteSetEntry instance from the service.

--- a/redfish/schedule.go
+++ b/redfish/schedule.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -115,26 +114,16 @@ func (schedule *Schedule) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (schedule *Schedule) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Schedule)
-	original.UnmarshalJSON(schedule.rawData)
-
-	readWriteFields := []string{
-		"EnabledDaysOfMonth",
+	readWriteFields := []string{"EnabledDaysOfMonth",
 		"EnabledDaysOfWeek",
 		"EnabledIntervals",
 		"EnabledMonthsOfYear",
 		"InitialStartTime",
 		"Lifetime",
 		"MaxOccurrences",
-		"RecurrenceInterval",
-	}
+		"RecurrenceInterval"}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(schedule).Elem()
-
-	return schedule.Entity.Update(originalElement, currentElement, readWriteFields)
+	return schedule.UpdateFromRawData(schedule, schedule.rawData, readWriteFields)
 }
 
 // GetSchedule will get a Schedule instance from the service.

--- a/redfish/secureboot.go
+++ b/redfish/secureboot.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -107,22 +106,11 @@ func (secureboot *SecureBoot) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (secureboot *SecureBoot) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(SecureBoot)
-	err := original.UnmarshalJSON(secureboot.rawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"SecureBootEnable",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(secureboot).Elem()
-
-	return secureboot.Entity.Update(originalElement, currentElement, readWriteFields)
+	return secureboot.UpdateFromRawData(secureboot, secureboot.rawData, readWriteFields)
 }
 
 // GetSecureBoot will get a SecureBoot instance from the service.

--- a/redfish/securitypolicy.go
+++ b/redfish/securitypolicy.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -164,19 +163,9 @@ func (securitypolicy *SecurityPolicy) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (securitypolicy *SecurityPolicy) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(SecurityPolicy)
-	original.UnmarshalJSON(securitypolicy.rawData)
+	readWriteFields := []string{"OverrideParentManager"}
 
-	readWriteFields := []string{
-		"OverrideParentManager",
-	}
-
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(securitypolicy).Elem()
-
-	return securitypolicy.Entity.Update(originalElement, currentElement, readWriteFields)
+	return securitypolicy.UpdateFromRawData(securitypolicy, securitypolicy.rawData, readWriteFields)
 }
 
 // GetSecurityPolicy will get a SecurityPolicy instance from the service.

--- a/redfish/serialinterface.go
+++ b/redfish/serialinterface.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -191,13 +190,6 @@ func (serialInterface *SerialInterface) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (serialInterface *SerialInterface) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(SerialInterface)
-	if err := original.UnmarshalJSON(serialInterface.rawData); err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"BitRate",
 		"DataBits",
@@ -207,10 +199,7 @@ func (serialInterface *SerialInterface) Update() error {
 		"StopBits",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(serialInterface).Elem()
-
-	return serialInterface.Entity.Update(originalElement, currentElement, readWriteFields)
+	return serialInterface.UpdateFromRawData(serialInterface, serialInterface.rawData, readWriteFields)
 }
 
 // GetSerialInterface will get a SerialInterface instance from the service.

--- a/redfish/sessionservice.go
+++ b/redfish/sessionservice.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -72,20 +71,10 @@ func (sessionservice *SessionService) Sessions() ([]*Session, error) {
 
 // Update commits updates to this object's properties to the running system.
 func (sessionservice *SessionService) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(SessionService)
-	original.UnmarshalJSON(sessionservice.rawData)
+	readWriteFields := []string{"ServiceEnabled",
+		"SessionTimeout"}
 
-	readWriteFields := []string{
-		"ServiceEnabled",
-		"SessionTimeout",
-	}
-
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(sessionservice).Elem()
-
-	return sessionservice.Entity.Update(originalElement, currentElement, readWriteFields)
+	return sessionservice.UpdateFromRawData(sessionservice, sessionservice.rawData, readWriteFields)
 }
 
 // GetSessionService will get a SessionService instance from the service.

--- a/redfish/softwareinventory.go
+++ b/redfish/softwareinventory.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -154,19 +153,9 @@ func (softwareinventory *SoftwareInventory) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (softwareinventory *SoftwareInventory) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(SoftwareInventory)
-	original.UnmarshalJSON(softwareinventory.rawData)
+	readWriteFields := []string{"WriteProtected"}
 
-	readWriteFields := []string{
-		"WriteProtected",
-	}
-
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(softwareinventory).Elem()
-
-	return softwareinventory.Entity.Update(originalElement, currentElement, readWriteFields)
+	return softwareinventory.UpdateFromRawData(softwareinventory, softwareinventory.rawData, readWriteFields)
 }
 
 // GetSoftwareInventory will get a SoftwareInventory instance from the service.

--- a/redfish/storage.go
+++ b/redfish/storage.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -352,21 +351,11 @@ func (storage *Storage) SetEncryptionKey(key, currentEncryptionKey, encryptionKe
 
 // Update commits updates to this object's properties to the running system.
 func (storage *Storage) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Storage)
-	original.UnmarshalJSON(storage.rawData)
-
-	readWriteFields := []string{
-		"AutoVolumeCreate",
+	readWriteFields := []string{"AutoVolumeCreate",
 		"EncryptionMode",
-		"HotspareActivationPolicy",
-	}
+		"HotspareActivationPolicy"}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(storage).Elem()
-
-	return storage.Entity.Update(originalElement, currentElement, readWriteFields)
+	return storage.UpdateFromRawData(storage, storage.rawData, readWriteFields)
 }
 
 // GetStorage will get a Storage instance from the service.

--- a/redfish/storagecontroller.go
+++ b/redfish/storagecontroller.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -414,22 +413,11 @@ func (storagecontroller *StorageController) PCIeFunctions() ([]*PCIeFunction, er
 
 // Update commits updates to this object's properties to the running system.
 func (storagecontroller *StorageController) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(StorageController)
-	err := original.UnmarshalJSON(storagecontroller.rawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"AssetTag",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(storagecontroller).Elem()
-
-	return storagecontroller.Entity.Update(originalElement, currentElement, readWriteFields)
+	return storagecontroller.UpdateFromRawData(storagecontroller, storagecontroller.rawData, readWriteFields)
 }
 
 // GetStorageController will get a Storage controller instance from the service.

--- a/redfish/switch.go
+++ b/redfish/switch.go
@@ -7,7 +7,6 @@ package redfish
 import (
 	"encoding/json"
 	"errors"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -233,22 +232,12 @@ func (sw *Switch) Reset(resetType ResetType) error {
 
 // Update commits updates to this object's properties to the running system.
 func (sw *Switch) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Switch)
-	original.UnmarshalJSON(sw.rawData)
-
-	readWriteFields := []string{
-		"AssetTag",
+	readWriteFields := []string{"AssetTag",
 		"Enabled",
 		"IsManaged",
-		"LocationIndicatorActive",
-	}
+		"LocationIndicatorActive"}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(sw).Elem()
-
-	return sw.Entity.Update(originalElement, currentElement, readWriteFields)
+	return sw.UpdateFromRawData(sw, sw.rawData, readWriteFields)
 }
 
 // GetSwitch will get a Switch instance from the service.

--- a/redfish/taskervice.go
+++ b/redfish/taskervice.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 	"time"
 
 	"github.com/stmcginnis/gofish/common"
@@ -83,20 +82,10 @@ func (taskService *TaskService) Tasks() ([]*Task, error) {
 
 // Update commits updates to this object's properties to the running system.
 func (taskService *TaskService) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(TaskService)
-	original.UnmarshalJSON(taskService.rawData)
+	readWriteFields := []string{"ServiceEnabled",
+		"TaskAutoDeleteTimeoutMinutes"}
 
-	readWriteFields := []string{
-		"ServiceEnabled",
-		"TaskAutoDeleteTimeoutMinutes",
-	}
-
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(taskService).Elem()
-
-	return taskService.Entity.Update(originalElement, currentElement, readWriteFields)
+	return taskService.UpdateFromRawData(taskService, taskService.rawData, readWriteFields)
 }
 
 // GetTaskService will get a TaskService instance from the service.

--- a/redfish/telemetryservice.go
+++ b/redfish/telemetryservice.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -196,19 +195,9 @@ func (telemetryservice *TelemetryService) SubmitTestMetricReport(reportValues []
 
 // Update commits updates to this object's properties to the running system.
 func (telemetryservice *TelemetryService) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(TelemetryService)
-	original.UnmarshalJSON(telemetryservice.rawData)
+	readWriteFields := []string{"ServiceEnabled"}
 
-	readWriteFields := []string{
-		"ServiceEnabled",
-	}
-
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(telemetryservice).Elem()
-
-	return telemetryservice.Entity.Update(originalElement, currentElement, readWriteFields)
+	return telemetryservice.UpdateFromRawData(telemetryservice, telemetryservice.rawData, readWriteFields)
 }
 
 // GetTelemetryService will get a TelemetryService instance from the service.

--- a/redfish/thermal.go
+++ b/redfish/thermal.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -117,18 +116,9 @@ func (fan *ThermalFan) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (fan *ThermalFan) Update() error {
-	// Get a representation of the object's original state so we can find what to update.
-	original := new(ThermalFan)
-	original.UnmarshalJSON(fan.rawData)
+	readWriteFields := []string{"IndicatorLED"}
 
-	readWriteFields := []string{
-		"IndicatorLED",
-	}
-
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(fan).Elem()
-
-	return fan.Entity.Update(originalElement, currentElement, readWriteFields)
+	return fan.UpdateFromRawData(fan, fan.rawData, readWriteFields)
 }
 
 // Temperature represents a temperature sensor in a Redfish system.
@@ -217,19 +207,10 @@ func (temperature *Temperature) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (temperature *Temperature) Update() error {
-	// Get a representation of the object's original state so we can find what to update.
-	original := new(Temperature)
-	original.UnmarshalJSON(temperature.rawData)
+	readWriteFields := []string{"LowerThresholdUser",
+		"UpperThresholdUser"}
 
-	readWriteFields := []string{
-		"LowerThresholdUser",
-		"UpperThresholdUser",
-	}
-
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(temperature).Elem()
-
-	return temperature.Entity.Update(originalElement, currentElement, readWriteFields)
+	return temperature.UpdateFromRawData(temperature, temperature.rawData, readWriteFields)
 }
 
 // Thermal represents thermal management data in a Redfish system.
@@ -284,19 +265,10 @@ func (thermal *Thermal) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (thermal *Thermal) Update() error {
-	// Get a representation of the object's original state so we can find what to update.
-	original := new(Thermal)
-	original.UnmarshalJSON(thermal.rawData)
+	readWriteFields := []string{"Fans",
+		"Temperatures"}
 
-	readWriteFields := []string{
-		"Fans",
-		"Temperatures",
-	}
-
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(thermal).Elem()
-
-	return thermal.Entity.Update(originalElement, currentElement, readWriteFields)
+	return thermal.UpdateFromRawData(thermal, thermal.rawData, readWriteFields)
 }
 
 // GetThermal will get a Thermal instance from the service.

--- a/redfish/triggers.go
+++ b/redfish/triggers.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -100,21 +99,11 @@ func (discretetrigger *DiscreteTrigger) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (discretetrigger *DiscreteTrigger) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(DiscreteTrigger)
-	original.UnmarshalJSON(discretetrigger.rawData)
-
-	readWriteFields := []string{
-		"DwellTime",
+	readWriteFields := []string{"DwellTime",
 		"Severity",
-		"Value",
-	}
+		"Value"}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(discretetrigger).Elem()
-
-	return discretetrigger.Entity.Update(originalElement, currentElement, readWriteFields)
+	return discretetrigger.UpdateFromRawData(discretetrigger, discretetrigger.rawData, readWriteFields)
 }
 
 // Triggers shall contain a trigger that applies to metrics.
@@ -225,23 +214,13 @@ func (triggers *Triggers) MetricReportDefinitions() ([]*MetricReportDefinition, 
 
 // Update commits updates to this object's properties to the running system.
 func (triggers *Triggers) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Triggers)
-	original.UnmarshalJSON(triggers.rawData)
-
-	readWriteFields := []string{
-		"EventTriggers",
+	readWriteFields := []string{"EventTriggers",
 		"HysteresisDuration",
 		"HysteresisReading",
 		"MetricIds",
-		"MetricProperties",
-	}
+		"MetricProperties"}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(triggers).Elem()
-
-	return triggers.Entity.Update(originalElement, currentElement, readWriteFields)
+	return triggers.UpdateFromRawData(triggers, triggers.rawData, readWriteFields)
 }
 
 // GetTriggers will get a Triggers instance from the service.

--- a/redfish/vcatentry.go
+++ b/redfish/vcatentry.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -59,19 +58,9 @@ func (vcatentry *VCATEntry) UnmarshalJSON(b []byte) error {
 
 // Update commits updates to this object's properties to the running system.
 func (vcatentry *VCATEntry) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(VCATEntry)
-	original.UnmarshalJSON(vcatentry.rawData)
+	readWriteFields := []string{"RawEntryHex"}
 
-	readWriteFields := []string{
-		"RawEntryHex",
-	}
-
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(vcatentry).Elem()
-
-	return vcatentry.Entity.Update(originalElement, currentElement, readWriteFields)
+	return vcatentry.UpdateFromRawData(vcatentry, vcatentry.rawData, readWriteFields)
 }
 
 // GetVCATEntry will get a VCATEntry instance from the service.

--- a/redfish/virtualmedia.go
+++ b/redfish/virtualmedia.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -233,14 +232,6 @@ func (virtualmedia *VirtualMedia) ClientCertificates() ([]*Certificate, error) {
 
 // Update commits updates to this object's properties to the running system.
 func (virtualmedia *VirtualMedia) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(VirtualMedia)
-	err := original.UnmarshalJSON(virtualmedia.rawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"EjectPolicy",
 		"EjectTimeout",
@@ -254,10 +245,7 @@ func (virtualmedia *VirtualMedia) Update() error {
 		"WriteProtected",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(virtualmedia).Elem()
-
-	return virtualmedia.Entity.Update(originalElement, currentElement, readWriteFields)
+	return virtualmedia.UpdateFromRawData(virtualmedia, virtualmedia.rawData, readWriteFields)
 }
 
 // EjectMedia sends a request to eject the media.

--- a/redfish/vlannetworkinterface.go
+++ b/redfish/vlannetworkinterface.go
@@ -6,7 +6,6 @@ package redfish
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -67,24 +66,13 @@ func (vlannetworkinterface *VLanNetworkInterface) UnmarshalJSON(b []byte) error 
 
 // Update commits updates to this object's properties to the running system.
 func (vlannetworkinterface *VLanNetworkInterface) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(VLanNetworkInterface)
-	err := original.UnmarshalJSON(vlannetworkinterface.rawData)
-	if err != nil {
-		return err
-	}
-
 	readWriteFields := []string{
 		"VLANEnable",
 		"VLANId",
 		"VLANPriority",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(vlannetworkinterface).Elem()
-
-	return vlannetworkinterface.Entity.Update(originalElement, currentElement, readWriteFields)
+	return vlannetworkinterface.UpdateFromRawData(vlannetworkinterface, vlannetworkinterface.rawData, readWriteFields)
 }
 
 // GetVLanNetworkInterface will get a VLanNetworkInterface instance from the service.

--- a/redfish/volume.go
+++ b/redfish/volume.go
@@ -7,7 +7,6 @@ package redfish
 import (
 	"encoding/json"
 	"errors"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -923,13 +922,7 @@ func (volume *Volume) ServerEndpoints() ([]*Endpoint, error) {
 
 // Update commits updates to this object's properties to the running system.
 func (volume *Volume) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Volume)
-	original.UnmarshalJSON(volume.rawData)
-
-	readWriteFields := []string{
-		"AccessCapabilities",
+	readWriteFields := []string{"AccessCapabilities",
 		"CapacityBytes",
 		"CapacitySources",
 		"Compressed",
@@ -946,13 +939,9 @@ func (volume *Volume) Update() error {
 		"ReplicationEnabled",
 		"StripSizeBytes",
 		"WriteCachePolicy",
-		"WriteHoleProtectionPolicy",
-	}
+		"WriteHoleProtectionPolicy"}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(volume).Elem()
-
-	return volume.Entity.Update(originalElement, currentElement, readWriteFields)
+	return volume.UpdateFromRawData(volume, volume.rawData, readWriteFields)
 }
 
 // GetVolume will get a Volume instance from the service.

--- a/redfish/zone.go
+++ b/redfish/zone.go
@@ -7,7 +7,6 @@ package redfish
 import (
 	"encoding/json"
 	"errors"
-	"reflect"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -255,21 +254,12 @@ func (zone *Zone) ResourceBlocks() ([]*ResourceBlock, error) {
 
 // Update commits updates to this object's properties to the running system.
 func (zone *Zone) Update() error {
-	// Get a representation of the object's original state so we can find what
-	// to update.
-	original := new(Zone)
-	original.UnmarshalJSON(zone.rawData)
-
-	readWriteFields := []string{
-		"DefaultRoutingEnabled",
+	readWriteFields := []string{"DefaultRoutingEnabled",
 		"ExternalAccessibility",
 		"ZoneType",
 	}
 
-	originalElement := reflect.ValueOf(original).Elem()
-	currentElement := reflect.ValueOf(zone).Elem()
-
-	return zone.Entity.Update(originalElement, currentElement, readWriteFields)
+	return zone.UpdateFromRawData(zone, zone.rawData, readWriteFields)
 }
 
 // GetZone will get a Zone instance from the service.


### PR DESCRIPTION
There is a lot of duplication in the Update calls that doesn't need to be there. This refactors the update logic to centralize more of the code and reduce the code duplication.