### PR TITLE
Update PartLocation to handle string int.

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -383,6 +383,8 @@ func (p *PartLocation) UnmarshalJSON(b []byte) error {
 			return fmt.Errorf("invalid string for LocationOrdinalValue: %v", err)
 		}
 		p.LocationOrdinalValue = i
+	case nil:
+		p.LocationOrdinalValue = 0
 	default:
 		return fmt.Errorf("unsupported type for LocationOrdinalValue: %T", v)
 	}

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -1,0 +1,67 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package common
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+var partLocationBodyString = strings.NewReader(`
+	{
+		"ServiceLabel": "Battery 1",
+		"LocationType": "Bay",
+		"LocationOrdinalValue": "5"
+	}`)
+
+var partLocationBodyInt = strings.NewReader(`
+	{
+		"ServiceLabel": "Battery 1",
+		"LocationType": "Bay",
+		"LocationOrdinalValue": 5
+	}`)
+
+func TestPartLocationString(t *testing.T) {
+	var result PartLocation
+	err := json.NewDecoder(partLocationBodyString).Decode(&result)
+
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+
+	if result.ServiceLabel != "Battery 1" {
+		t.Errorf("Received invalid service label: %s", result.ServiceLabel)
+	}
+
+	if result.LocationType != "Bay" {
+		t.Errorf("Received invalid location type: %s", result.LocationType)
+	}
+
+	if result.LocationOrdinalValue != 5 {
+		t.Errorf("Received invalid location ordinal value: %d", result.LocationOrdinalValue)
+	}
+}
+
+func TestPartLocationInt(t *testing.T) {
+	var result PartLocation
+	err := json.NewDecoder(partLocationBodyInt).Decode(&result)
+
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+
+	if result.ServiceLabel != "Battery 1" {
+		t.Errorf("Received invalid service label: %s", result.ServiceLabel)
+	}
+
+	if result.LocationType != "Bay" {
+		t.Errorf("Received invalid location type: %s", result.LocationType)
+	}
+
+	if result.LocationOrdinalValue != 5 {
+		t.Errorf("Received invalid location ordinal value: %d", result.LocationOrdinalValue)
+	}
+}

--- a/redfish/resource.go
+++ b/redfish/resource.go
@@ -209,7 +209,7 @@ type ResourceLocation struct {
 	OEM json.RawMessage `json:"Oem"`
 	// PartLocation shall contain the part location for a resource within an enclosure. This representation shall
 	// indicate the location of a part within a location specified by the Placement property.
-	PartLocation PartLocation
+	PartLocation common.PartLocation
 	// PartLocationContext shall contain a human-readable string to enable differentiation between PartLocation values
 	// for parts in the same enclosure, which may include hierarchical information of containing PartLocation values
 	// for the part. The value of this property shall not include values of the PartLocation properties for the part
@@ -225,21 +225,6 @@ type ResourceLocation struct {
 	Placement Placement
 	// PostalAddress shall contain a postal address of the resource.
 	PostalAddress PostalAddress
-}
-
-// PartLocation shall describe a location for a resource within an enclosure.
-type PartLocation struct {
-	// LocationOrdinalValue shall contain the number that represents the location of the part based on the
-	// LocationType. LocationOrdinalValue shall be measured based on the Orientation value starting with '0'.
-	LocationOrdinalValue int
-	// LocationType shall contain the type of location of the part.
-	LocationType LocationType
-	// Orientation shall contain the orientation for the ordering used by the LocationOrdinalValue property.
-	Orientation Orientation
-	// Reference shall contain the general location within the unit of the part.
-	Reference Reference
-	// ServiceLabel shall contain the label assigned for service at the part location.
-	ServiceLabel string
 }
 
 // PhysicalAddress shall contain a physical address for a resource.


### PR DESCRIPTION
Gb200's have LocationOrdinalValue as "3"
This creates a custom unmarshal to handle it.

A request looks something like this, adding a custom unmarshaller to handle converting the string to int.
```
        "PartLocation": {
          "LocationOrdinalValue": "4",
          "LocationType": "Slot",
          "ServiceLabel": "PSU 4"
        }
```