### PR TITLE
feat: add WithContext function to client

### DIFF
--- a/client.go
+++ b/client.go
@@ -268,6 +268,13 @@ func (c *APIClient) GetService() *Service {
 	return c.Service
 }
 
+// WithContext returns a copy of the client using the provided context
+func (c *APIClient) WithContext(ctx context.Context) *APIClient {
+	newClient := *c
+	newClient.ctx = ctx
+	return &newClient
+}
+
 // CloneWithSession will create a new Client with a session instead of basic auth.
 func (c *APIClient) CloneWithSession() (*APIClient, error) {
 	if c.auth.Session != "" {


### PR DESCRIPTION
right now, the context setup is a bit clunky. I think the ideal situation would be providing a context argument on every function call to allow for different context for different requests.

I understand that it's not really feasible given that it would be essentially be a full rewrite. Instead I propose adding `WithContext` to the `APIClient` to allow for creating a copied client, using the same auth and everything, just with a different context.