### PR TITLE
Add PowerSuppliesUri() method

### DIFF
--- a/redfish/powersubsystem.go
+++ b/redfish/powersubsystem.go
@@ -96,6 +96,10 @@ func (powersubsystem *PowerSubsystem) PowerSupplies() ([]*PowerSupply, error) {
 	return ListReferencedPowerSupplies(powersubsystem.GetClient(), powersubsystem.powerSupplies)
 }
 
+func (powersubsystem *PowerSubsystem) PowerSuppliesURI() string {
+	return powersubsystem.powerSupplies
+}
+
 // GetPowerSubsystem will get a PowerSubsystem instance from the service.
 func GetPowerSubsystem(c common.Client, uri string) (*PowerSubsystem, error) {
 	return common.GetObject[PowerSubsystem](c, uri)


### PR DESCRIPTION
I'm adding a `PowerSuppliesUri` method because I need to access the raw link, in order to run an `expand` query on it. I'm not sure this pattern of exposing a normally private field that wraps a link with a helper method is used elsewhere in the codebase, if so, I'm happy to make any changes necessary to fit existing conventions.  