### PR TITLE
feat: add support for reset action info

### DIFF
--- a/redfish/actioninfo.go
+++ b/redfish/actioninfo.go
@@ -65,7 +65,8 @@ func GetActionInfo(c common.Client, uri string) (*ActionInfo, error) {
 }
 
 func (actionInfo *ActionInfo) GetParamValues(name string, dataType ActionInfoDataTypes) ([]string, error) {
-	for _, param := range actionInfo.Parameters {
+	for idx := range actionInfo.Parameters {
+		param := &actionInfo.Parameters[idx]
 		if param.Name != name || (param.DataType != "" && param.DataType != dataType) {
 			continue
 		}

--- a/redfish/actioninfo.go
+++ b/redfish/actioninfo.go
@@ -4,7 +4,11 @@
 
 package redfish
 
-import "github.com/stmcginnis/gofish/common"
+import (
+	"fmt"
+
+	"github.com/stmcginnis/gofish/common"
+)
 
 // ActionInfoDataTypes is the datatype for an ActionInfo value.
 type ActionInfoDataTypes string
@@ -58,4 +62,15 @@ type ActionInfoParameter struct {
 
 func GetActionInfo(c common.Client, uri string) (*ActionInfo, error) {
 	return common.GetObject[ActionInfo](c, uri)
+}
+
+func (actionInfo *ActionInfo) GetParamValues(name string, dataType ActionInfoDataTypes) ([]string, error) {
+	for _, param := range actionInfo.Parameters {
+		if param.Name != name || (param.DataType != "" && param.DataType != dataType) {
+			continue
+		}
+
+		return param.AllowableValues, nil
+	}
+	return nil, fmt.Errorf("failed to find supported values of type %s", name)
 }

--- a/redfish/chassis.go
+++ b/redfish/chassis.go
@@ -6,6 +6,7 @@ package redfish
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/stmcginnis/gofish/common"
@@ -372,6 +373,8 @@ type Chassis struct {
 
 	// resetTarget is the internal URL to send reset actions to.
 	resetTarget string
+	// resetActionInfoTarget is the URL to check what values are supported
+	resetActionInfoTarget string
 	// SupportedResetTypes, if provided, is the reset types this chassis supports.
 	SupportedResetTypes []ResetType
 
@@ -459,8 +462,8 @@ type chassisLinks struct {
 
 type chassisActions struct {
 	ChassisReset struct {
+		common.ActionTarget
 		AllowedResetTypes []ResetType `json:"ResetType@Redfish.AllowableValues"`
-		Target            string
 	} `json:"#Chassis.Reset"`
 }
 
@@ -525,6 +528,7 @@ func (chassis *Chassis) UnmarshalJSON(b []byte) error {
 	chassis.trustedComponents = t.TrustedComponents.String()
 
 	chassis.resetTarget = t.Actions.ChassisReset.Target
+	chassis.resetActionInfoTarget = t.Actions.ChassisReset.ActionInfoTarget
 	chassis.SupportedResetTypes = t.Actions.ChassisReset.AllowedResetTypes
 
 	chassis.cables = t.Links.Cables.ToStrings()
@@ -820,6 +824,42 @@ func (chassis *Chassis) LogServices() ([]*LogService, error) {
 // It also provides access to the original data for the assembly.
 func (chassis *Chassis) Assembly() (*Assembly, error) {
 	return GetAssembly(chassis.GetClient(), chassis.assembly)
+}
+
+// GetSupportedResetTypes returns any reset types that the Chassis declares as supported
+// via either ActionInfo or AllowableValues.
+func (chassis *Chassis) GetSupportedResetTypes() ([]ResetType, error) {
+	if len(chassis.SupportedResetTypes) > 0 {
+		return chassis.SupportedResetTypes, nil
+	}
+
+	// if we don't have ResetTypes, try to get from ActionInfo
+	if len(chassis.resetActionInfoTarget) > 0 {
+		resetActionInfo, err := chassis.ResetActionInfo()
+		if err != nil {
+			return nil, err
+		}
+
+		vals, err := resetActionInfo.GetParamValues("ResetType", StringActionInfoDataTypes)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, val := range vals {
+			chassis.SupportedResetTypes = append(chassis.SupportedResetTypes, ResetType(val))
+		}
+	}
+
+	return chassis.SupportedResetTypes, nil
+}
+
+// ResetActionInfo returns the ActionInfo for the Chassis reset action if supported
+func (chassis *Chassis) ResetActionInfo() (*ActionInfo, error) {
+	if chassis.resetActionInfoTarget == "" {
+		return nil, errors.New("Chassis Reset resetActionInfoTarget not supported")
+	}
+
+	return common.GetObject[ActionInfo](chassis.GetClient(), chassis.resetActionInfoTarget)
 }
 
 // Reset shall reset the chassis. This action shall not reset Systems or other

--- a/redfish/chassis.go
+++ b/redfish/chassis.go
@@ -834,7 +834,7 @@ func (chassis *Chassis) GetSupportedResetTypes() ([]ResetType, error) {
 	}
 
 	// if we don't have ResetTypes, try to get from ActionInfo
-	if len(chassis.resetActionInfoTarget) > 0 {
+	if chassis.resetActionInfoTarget != "" {
 		resetActionInfo, err := chassis.ResetActionInfo()
 		if err != nil {
 			return nil, err

--- a/redfish/computersystem.go
+++ b/redfish/computersystem.go
@@ -6,6 +6,7 @@ package redfish
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -931,6 +932,8 @@ type ComputerSystem struct {
 	removeResourceBlockTarget string
 	// resetTarget is the internal URL to send reset targets to.
 	resetTarget string
+	// resetActionInfoTarget is the URL to check what values are supported
+	resetActionInfoTarget string
 	// setDefaultBootOrderTarget is the URL to send SetDefaultBootOrder actions to.
 	setDefaultBootOrderTarget string
 	settingsTarget            string
@@ -945,8 +948,8 @@ func (computersystem *ComputerSystem) UnmarshalJSON(b []byte) error {
 		Decommission        common.ActionTarget `json:"#ComputerSystem.Decommission"`
 		RemoveResourceBlock common.ActionTarget `json:"#ComputerSystem.RemoveResourceBlock"`
 		Reset               struct {
+			common.ActionTarget
 			AllowedResetTypes []ResetType `json:"ResetType@Redfish.AllowableValues"`
-			Target            string
 		} `json:"#ComputerSystem.Reset"`
 		SetDefaultBootOrder common.ActionTarget `json:"#ComputerSystem.SetDefaultBootOrder"`
 	}
@@ -1010,6 +1013,7 @@ func (computersystem *ComputerSystem) UnmarshalJSON(b []byte) error {
 	computersystem.decommissionTarget = t.Actions.Decommission.Target
 	computersystem.removeResourceBlockTarget = t.Actions.RemoveResourceBlock.Target
 	computersystem.resetTarget = t.Actions.Reset.Target
+	computersystem.resetActionInfoTarget = t.Actions.Reset.ActionInfoTarget
 	computersystem.SupportedResetTypes = t.Actions.Reset.AllowedResetTypes
 	computersystem.setDefaultBootOrderTarget = t.Actions.SetDefaultBootOrder.Target
 
@@ -1176,6 +1180,42 @@ func (computersystem *ComputerSystem) Reset(resetType ResetType) error {
 	}{ResetType: resetType}
 
 	return computersystem.Post(computersystem.resetTarget, t)
+}
+
+// GetSupportedResetTypes returns any reset types that the ComputerSystem declares as supported
+// via either ActionInfo or AllowableValues.
+func (computersystem *ComputerSystem) GetSupportedResetTypes() ([]ResetType, error) {
+	if len(computersystem.SupportedResetTypes) > 0 {
+		return computersystem.SupportedResetTypes, nil
+	}
+
+	// if we don't have ResetTypes, try to get from ActionInfo
+	if len(computersystem.resetActionInfoTarget) > 0 {
+		resetActionInfo, err := computersystem.ResetActionInfo()
+		if err != nil {
+			return nil, err
+		}
+
+		vals, err := resetActionInfo.GetParamValues("ResetType", StringActionInfoDataTypes)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, val := range vals {
+			computersystem.SupportedResetTypes = append(computersystem.SupportedResetTypes, ResetType(val))
+		}
+	}
+
+	return computersystem.SupportedResetTypes, nil
+}
+
+// ResetActionInfo returns the ActionInfo for the ComputerSystem reset action if supported
+func (computersystem *ComputerSystem) ResetActionInfo() (*ActionInfo, error) {
+	if computersystem.resetActionInfoTarget == "" {
+		return nil, errors.New("ComputerSystem Reset ActionInfo not supported")
+	}
+
+	return common.GetObject[ActionInfo](computersystem.GetClient(), computersystem.resetActionInfoTarget)
 }
 
 // UpdateBootAttributesApplyAt is used to update attribute values and set apply time together

--- a/redfish/computersystem.go
+++ b/redfish/computersystem.go
@@ -1190,7 +1190,7 @@ func (computersystem *ComputerSystem) GetSupportedResetTypes() ([]ResetType, err
 	}
 
 	// if we don't have ResetTypes, try to get from ActionInfo
-	if len(computersystem.resetActionInfoTarget) > 0 {
+	if computersystem.resetActionInfoTarget != "" {
 		resetActionInfo, err := computersystem.ResetActionInfo()
 		if err != nil {
 			return nil, err

--- a/redfish/manager.go
+++ b/redfish/manager.go
@@ -549,7 +549,7 @@ func (manager *Manager) GetSupportedResetTypes() ([]ResetType, error) {
 	}
 
 	// if we don't have ResetTypes, try to get from ActionInfo
-	if len(manager.actionInfo) > 0 {
+	if manager.actionInfo != "" {
 		resetActionInfo, err := manager.ResetActionInfo()
 		if err != nil {
 			return nil, err
@@ -619,7 +619,7 @@ func (manager *Manager) GetSupportedResetToDefaultsTypes() ([]ResetToDefaultsTyp
 	}
 
 	// if we don't have ResetTypes, try to get from ActionInfo
-	if len(manager.resetToDefaultsActionInfoTarget) > 0 {
+	if manager.resetToDefaultsActionInfoTarget != "" {
 		resetActionInfo, err := manager.ResetToDefaultsActionInfo()
 		if err != nil {
 			return nil, err

--- a/redfish/manager.go
+++ b/redfish/manager.go
@@ -6,6 +6,7 @@ package redfish
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/stmcginnis/gofish/common"
@@ -381,8 +382,10 @@ type Manager struct {
 	// resetInfo contains URI for an ActionInfo Resource that describes this action.
 	actionInfo string
 	// SupportedResetTypes, if provided, is the reset types this system supports.
-	SupportedResetTypes   []ResetType
-	resetToDefaultsTarget string
+	SupportedResetTypes             []ResetType
+	resetToDefaultsTarget           string
+	resetToDefaultsActionInfoTarget string
+	SupportedResetToDefaultsTypes   []ResetToDefaultsType
 	// RawData holds the original serialized JSON so we can compare updates.
 	RawData []byte
 }
@@ -394,11 +397,13 @@ func (manager *Manager) UnmarshalJSON(b []byte) error {
 		ForceFailover       common.ActionTarget `json:"#Manager.ForceFailover"`
 		ModifyRedundancySet common.ActionTarget `json:"#Manager.ModifyRedundancySet"`
 		Reset               struct {
-			ActionInfo        string      `json:"@Redfish.ActionInfo"`
+			common.ActionTarget
 			AllowedResetTypes []ResetType `json:"ResetType@Redfish.AllowableValues"`
-			Target            string
 		} `json:"#Manager.Reset"`
-		ResetToDefaults common.ActionTarget `json:"#Manager.ResetToDefaults"`
+		ResetToDefaults struct {
+			common.ActionTarget
+			AllowedResetTypes []ResetToDefaultsType `json:"ResetType@Redfish.AllowableValues"`
+		} `json:"#Manager.ResetToDefaults"`
 
 		Oem json.RawMessage
 	}
@@ -480,8 +485,10 @@ func (manager *Manager) UnmarshalJSON(b []byte) error {
 	manager.modifyRedundancySetTarget = t.Actions.ModifyRedundancySet.Target
 	manager.SupportedResetTypes = t.Actions.Reset.AllowedResetTypes
 	manager.resetTarget = t.Actions.Reset.Target
+	manager.SupportedResetToDefaultsTypes = t.Actions.ResetToDefaults.AllowedResetTypes
 	manager.resetToDefaultsTarget = t.Actions.ResetToDefaults.Target
-	manager.actionInfo = t.Actions.Reset.ActionInfo
+	manager.resetToDefaultsActionInfoTarget = t.Actions.ResetToDefaults.ActionInfoTarget
+	manager.actionInfo = t.Actions.Reset.ActionInfoTarget
 
 	// This is a read/write object, so we need to save the raw object data for later
 	manager.RawData = b
@@ -534,6 +541,42 @@ func (manager *Manager) ModifyRedundancySet(addManagers, removeManagers []*Manag
 	return manager.Post(manager.modifyRedundancySetTarget, parameters)
 }
 
+// GetSupportedResetTypes returns any reset types that the Manager declares as supported
+// via either ActionInfo or AllowableValues.
+func (manager *Manager) GetSupportedResetTypes() ([]ResetType, error) {
+	if len(manager.SupportedResetTypes) > 0 {
+		return manager.SupportedResetTypes, nil
+	}
+
+	// if we don't have ResetTypes, try to get from ActionInfo
+	if len(manager.actionInfo) > 0 {
+		resetActionInfo, err := manager.ResetActionInfo()
+		if err != nil {
+			return nil, err
+		}
+
+		vals, err := resetActionInfo.GetParamValues("ResetType", StringActionInfoDataTypes)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, val := range vals {
+			manager.SupportedResetTypes = append(manager.SupportedResetTypes, ResetType(val))
+		}
+	}
+
+	return manager.SupportedResetTypes, nil
+}
+
+// ResetActionInfo returns the ActionInfo for the Manager reset action if supported
+func (manager *Manager) ResetActionInfo() (*ActionInfo, error) {
+	if manager.actionInfo == "" {
+		return nil, errors.New("Manager Reset ActionInfo not supported")
+	}
+
+	return common.GetObject[ActionInfo](manager.GetClient(), manager.actionInfo)
+}
+
 // Reset shall perform a reset of the manager.
 func (manager *Manager) Reset(resetType ResetType) error {
 	if len(manager.SupportedResetTypes) == 0 {
@@ -566,6 +609,42 @@ func (manager *Manager) Reset(resetType ResetType) error {
 		ResetType ResetType
 	}{ResetType: resetType}
 	return manager.Post(manager.resetTarget, t)
+}
+
+// GetSupportedResetToDefaultsTypes returns any reset to defaults
+// types that the Manager declares as supported via either ActionInfo or AllowableValues.
+func (manager *Manager) GetSupportedResetToDefaultsTypes() ([]ResetToDefaultsType, error) {
+	if len(manager.SupportedResetToDefaultsTypes) > 0 {
+		return manager.SupportedResetToDefaultsTypes, nil
+	}
+
+	// if we don't have ResetTypes, try to get from ActionInfo
+	if len(manager.resetToDefaultsActionInfoTarget) > 0 {
+		resetActionInfo, err := manager.ResetToDefaultsActionInfo()
+		if err != nil {
+			return nil, err
+		}
+
+		vals, err := resetActionInfo.GetParamValues("ResetType", StringActionInfoDataTypes)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, val := range vals {
+			manager.SupportedResetToDefaultsTypes = append(manager.SupportedResetToDefaultsTypes, ResetToDefaultsType(val))
+		}
+	}
+
+	return manager.SupportedResetToDefaultsTypes, nil
+}
+
+// ResetToDefaultsActionInfo returns the ActionInfo for the Manager ResetToDefaults action if supported
+func (manager *Manager) ResetToDefaultsActionInfo() (*ActionInfo, error) {
+	if manager.resetToDefaultsActionInfoTarget == "" {
+		return nil, errors.New("Manager ResetToDefaults ActionInfo not supported")
+	}
+
+	return common.GetObject[ActionInfo](manager.GetClient(), manager.resetToDefaultsActionInfoTarget)
 }
 
 // ResetToDefaults resets the manager settings to factory defaults. This can cause the manager to reset.


### PR DESCRIPTION
this change adds support for describing the supported Reset and ResetToDefaults types via ActionInfo in addition to the existing inline AllowableValues

This is implemented here for chassis, manager and computer system

It's implemented as a function called by the user as it issues an additional request, so if the user doesn't care about supported actions, they can choose not to call it. In addition, if AllowableValues are provided, they are always preferred to ActionInfo