### PR TITLE
expose componentintegrity ComponentsProtected

### DIFF
--- a/redfish/componentintegrity.go
+++ b/redfish/componentintegrity.go
@@ -182,7 +182,8 @@ type ComponentIntegrity struct {
 	rawData                         []byte
 	SPDMGetSignedMeasurementsTarget string
 	TPMGetSignedMeasurementsTarget  string
-	componentsProtected             []string
+	// An array of links to resources that the target component (TargetComponentURI) protects, excluding TargetComponentURI itself.
+	ComponentsProtected []string
 	// ComponentsProtectedCount is the number of resources protected by the component identified by TargetComponentURI.
 	ComponentsProtectedCount int
 }
@@ -218,7 +219,7 @@ func (componentintegrity *ComponentIntegrity) UnmarshalJSON(b []byte) error {
 	// Extract the links to other entities for later
 	componentintegrity.SPDMGetSignedMeasurementsTarget = t.Actions.SPDMGetSignedMeasurements.Target
 	componentintegrity.TPMGetSignedMeasurementsTarget = t.Actions.TPMGetSignedMeasurements.Target
-	componentintegrity.componentsProtected = t.Links.ComponentsProtected.ToStrings()
+	componentintegrity.ComponentsProtected = t.Links.ComponentsProtected.ToStrings()
 	componentintegrity.ComponentsProtectedCount = t.Links.ComponentsProtectedCount
 
 	// This is a read/write object, so we need to save the raw object data for later


### PR DESCRIPTION
changes `ComponentsProtected` to be public

this field contains a list of links to arbitrary components, so I'm not sure if gofish can provide a generic function for this beyond just collecting everything as `common.Entity` which is of limited use.

maybe an entity with `Raw` such that the user can type switch + decode into more specific structs as needed?
```go
type EntityWithRaw struct {
  Entity
  RawData []byte
}
```

thoughts?