### PR TITLE
improved transport config and context improvement

### DIFF
--- a/client.go
+++ b/client.go
@@ -276,6 +276,16 @@ func (c *APIClient) GetService() *Service {
 func (c *APIClient) WithContext(ctx context.Context) *APIClient {
 	newClient := *c
 	newClient.ctx = ctx
+
+	// clone the service onto the new client so that any requests against it use the proper client
+	newService := Service{}
+	if newClient.Service != nil {
+		newService = *newClient.Service
+	}
+
+	newClient.Service = &newService
+	newClient.Service.SetClient(&newClient)
+
 	return &newClient
 }
 


### PR DESCRIPTION
@stmcginnis - adding a couple of small changes here:
- when cloning the client `WithContext` - set the new client onto a copied `Service` so that any new requests automatically use the new client
- add an option to prevent gofish from touching the transport so the caller can be fully responsible for the transport