### PR TITLE
Add support for idref EventDestination.OriginResources

### DIFF
--- a/redfish/eventdestination.go
+++ b/redfish/eventdestination.go
@@ -352,7 +352,24 @@ func (eventdestination *EventDestination) UnmarshalJSON(b []byte) error {
 
 	err := json.Unmarshal(b, &t)
 	if err != nil {
-		return err
+		// Workaround for the OriginResources actually being an idref
+		var x struct {
+			temp
+			OriginResources    common.Links
+			Certificates       common.Link
+			ClientCertificates common.Link
+		}
+
+		err2 := json.Unmarshal(b, &x)
+		if err2 != nil {
+			// That didn't work either, just return the original error
+			return err
+		}
+
+		t.temp = x.temp
+		t.Certificates = x.Certificates
+		t.ClientCertificates = x.ClientCertificates
+		t.OriginResources = x.OriginResources.ToStrings()
 	}
 
 	// Extract the links to other entities for later

--- a/redfish/eventdestination_test.go
+++ b/redfish/eventdestination_test.go
@@ -31,6 +31,11 @@ var eventDestinationBody = `{
 		],
 		"HttpHeaders": [],
 		"MessageIds": ["One", "Two"],
+		"OriginResources": [
+			{
+				"@odata.id": "/redfish/v1/Chassis/1/Power#/PowerSupplies/0"
+			}
+		],
 		"Protocol": "Redfish",
 		"RegistryPrefixes": ["ONE_", "TWO_"],
 		"ResourceTypes": ["one", "two"],
@@ -90,6 +95,14 @@ func TestEventDestination(t *testing.T) {
 		if !et.IsValidEventType() {
 			t.Errorf("invalid event type: %s", et)
 		}
+	}
+
+	if len(result.OriginResources) != 1 {
+		t.Error("Expected 1 OriginDestinations")
+	}
+
+	if result.OriginResources[0] != "/redfish/v1/Chassis/1/Power#/PowerSupplies/0" {
+		t.Errorf("Expected OriginResources '/redfish/v1/Chassis/1/Power#/PowerSupplies/0', got %q", result.OriginResources[0])
 	}
 }
 


### PR DESCRIPTION
Handles idrefs rather than an array of strings.

Closes: #479