### PR TITLE
SMC: Add UsbCd boot source target

### DIFF
--- a/oem/smc/computersystem.go
+++ b/oem/smc/computersystem.go
@@ -11,6 +11,10 @@ import (
 	"github.com/stmcginnis/gofish/redfish"
 )
 
+// USBCDBootSourceOverrideTarget is a Supermicro-specific boot target that is not
+// part of the Redfish specification.
+const USBCDBootSourceOverrideTarget redfish.BootSourceOverrideTarget = "UsbCd"
+
 // ComputerSystem is a Supermicro OEM instance of a ComputerSystem.
 type ComputerSystem struct {
 	redfish.ComputerSystem


### PR DESCRIPTION
This is not part of the spec, but is common enough that it makes sense to add to the OEM implementation for SMC.