### PR TITLE
Fix panic when the dumper cannot read nil payload

### DIFF
--- a/client.go
+++ b/client.go
@@ -532,11 +532,13 @@ func (c *APIClient) runRawRequestWithHeaders(method, url string, payloadBuffer i
 
 	endpoint := fmt.Sprintf("%s%s", c.endpoint, url)
 
-	body := io.Reader(payloadBuffer)
-	if body == nil {
-		body = http.NoBody
+	var req *http.Request
+	var err error
+	if payloadBuffer == nil {
+		req, err = http.NewRequestWithContext(c.ctx, method, endpoint, http.NoBody)
+	} else {
+		req, err = http.NewRequestWithContext(c.ctx, method, endpoint, payloadBuffer)
 	}
-	req, err := http.NewRequestWithContext(c.ctx, method, endpoint, body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
It happens when we create a dumper and send a get request


`panic: runtime error: invalid memory address or nil pointer dereference [signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x9d3768] goroutine 35615013 [running]: github.com/stmcginnis/gofish.(*APIClient).dumpRequest(0xc00a1ea4e0, 0xc00c9d3080?) /.cache/go-mod/github.com/stmcginnis/gofish@v0.20.0/client.go:568 +0x88 github.com/stmcginnis/gofish.(*APIClient).runRawRequestWithHeaders(0xc00a1ea4e0, \{0xe4121d, 0x3}, \{0xc00f88d3c0, 0x1f}, \{0x0, 0x0}, \{0xe4d35a, 0x10}, 0x0) /.cache/go-mod/github.com/stmcginnis/gofish@v0.20.0/client.go:526 +0xbd9`