### PR TITLE
Add back VirtualMedia MediaType handling

### DIFF
--- a/schemas/virtualmedia.go
+++ b/schemas/virtualmedia.go
@@ -143,6 +143,8 @@ type VirtualMedia struct {
 	// MediaTypes shall contain an array of the supported media types for this
 	// connection.
 	MediaTypes []VirtualMediaType
+	// MediaType indicates which MediaTypes is used (non-standard)
+	MediaType VirtualMediaType
 	// ODataContext is the odata context.
 	ODataContext string `json:"@odata.context"`
 	// ODataType is the odata type.
@@ -324,6 +326,8 @@ type VirtualMediaInsertMediaParameters struct {
 	// write-protected. If the client does not provide this parameter, the service
 	// shall default this value to 'true'.
 	WriteProtected *bool `json:"WriteProtected,omitempty"`
+	// MediaType is not part of the current schema, but some vendors require it.
+	MediaType VirtualMediaType `json:",omitempty"`
 }
 
 // InsertMediaActionInfo provides the ActionInfo, if supported, for an InsertMedia Action

--- a/schemas/virtualmedia_test.go
+++ b/schemas/virtualmedia_test.go
@@ -212,6 +212,7 @@ func TestVirtualMediaInsertConfig(t *testing.T) {
 	virtualMediaConfig := VirtualMediaInsertMediaParameters{
 		Image:          "https://example.com/image",
 		Inserted:       toRef(true),
+		MediaType:      CDVirtualMediaType,
 		Password:       toRef("test1234"),
 		UserName:       toRef("root"),
 		WriteProtected: toRef(true),
@@ -228,6 +229,9 @@ func TestVirtualMediaInsertConfig(t *testing.T) {
 		t.Errorf("Unexpected InsertMedia Image payload: %s", calls[0].Payload)
 	}
 	if !strings.Contains(calls[0].Payload, "Inserted:true") {
+		t.Errorf("Unexpected InsertMedia Inserted payload: %s", calls[0].Payload)
+	}
+	if !strings.Contains(calls[0].Payload, "MediaType:CD") {
 		t.Errorf("Unexpected InsertMedia Inserted payload: %s", calls[0].Payload)
 	}
 	if !strings.Contains(calls[0].Payload, "Password:test1234") {


### PR DESCRIPTION
This is not in the schema, but some vendors require it. It had been added before but dropped in the last refactoring. Best to just carry it as a customization and hope it gets added to the official schema.