### PR TITLE
Fix ComputerSystem.Reset() method (regression from #493)

### DIFF
--- a/schemas/computersystem.go
+++ b/schemas/computersystem.go
@@ -1221,7 +1221,7 @@ func (c *ComputerSystem) Reset(resetType ResetType) (*TaskMonitorInfo, error) {
 		ResetType ResetType
 	}{ResetType: resetType}
 	resp, taskInfo, err := PostWithTask(c.client,
-		c.removeResourceBlockTarget, t, c.Headers(), false)
+		c.resetTarget, t, c.Headers(), false)
 	defer DeferredCleanupHTTPResponse(resp)
 	return taskInfo, err
 }


### PR DESCRIPTION
### Description
This PR fixes a regression introduced in #493 that broke all reset actions (e.g., "PowerOn", "PowerOff", "PowerCycle") for `ComputerSystem`.

### The Bug
When attempting to trigger a reset action, such as calling `system.Reset(schemas.ForceOnResetType)`, the action fails and throws the following error:

> `unable to execute request, no target provided`

This occurred because the `Reset()` method in `schemas/computersystem.go` was mistakenly sending a request to  `removeResourceBlockTarget` instead of `resetTarget`. It looks like a minor copy-paste oversight from nearby code, as the call pattern is otherwise identical.

### The Fix
Updated the payload target in the `Reset()` method to correctly use `resetTarget` so the action routes properly.

### Testing
Validated against a physical **Fujitsu iRMC S6 server**. All reset actions (PowerOn, PowerOff, etc.) are successfully routing and executing again.