### PR TITLE
fix: In computersystem Boot struct, omitempty everything

### DIFF
--- a/schemas/computersystem.go
+++ b/schemas/computersystem.go
@@ -1644,7 +1644,7 @@ type Boot struct {
 	// UefiTargetBootSourceOverride shall contain the UEFI device path of the
 	// override boot target. Changes to this property do not alter the BIOS
 	// persistent boot order configuration.
-	UefiTargetBootSourceOverride                string `json:",omitempty"`
+	UefiTargetBootSourceOverride                string   `json:",omitempty"`
 	AllowableUefiTargetBootSourceOverrideValues []string `json:"UefiTargetBootSourceOverride@Redfish.AllowableValues,omitempty"`
 }
 


### PR DESCRIPTION
Chassis from multiple manufacturers have rejected this struct recently, citing unexpected properties. Omiting these properties when unset resolves the issues.