### PR TITLE
Fix Drive.Location regression: restore array type per DMTF spec

### DIFF
--- a/schemas/drive.go
+++ b/schemas/drive.go
@@ -279,7 +279,7 @@ type Drive struct {
 	// Deprecated: v1.4.0
 	// This property has been deprecated in favor of the singular
 	// 'PhysicalLocation' property.
-	Location Location
+	Location []Location
 	// LocationIndicatorActive shall contain the state of the indicator used to
 	// physically identify or locate this resource. A write to this property shall
 	// update the value of 'IndicatorLED' in this resource, if supported, to


### PR DESCRIPTION
## Fix Drive.Location Regression

Fixes #505 (reference the issue number)

### Changes
- Restore `Drive.Location` to array type (`[]Location`) to match DMTF Redfish specification
- This was inadvertently changed to a struct during the v0.21.0 refactoring

### Testing
Tested against real BMC implementations:
- Dell PowerEdge R660 (returns empty array: `[]`)
- HPE ProLiant DL380 Gen11 (returns array with items)

### Backward Compatibility
This is a breaking change from v0.21.x but restores v0.20.0 behavior and DMTF spec compliance.