### PR TITLE
Update pciedevice.go

### DIFF
--- a/schemas/pciedevice.go
+++ b/schemas/pciedevice.go
@@ -601,6 +601,26 @@ type PCIeInterface struct {
 	PCIeType PCIeTypes
 }
 
+func (p *PCIeInterface) UnmarshalJSON(b []byte) error {
+	// If it's an empty array, ignore zero value.
+	if string(b) == "[]" {
+		return nil
+	}
+
+	type temp PCIeInterface
+	var t struct {
+		temp
+	}
+
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+
+	*p = PCIeInterface(t.temp)
+	return nil
+}
+
 // PCIeMetrics shall contain properties that describe the PCIe metrics
 // associated with this device.
 type PCIeMetrics struct {


### PR DESCRIPTION
My previous fix https://github.com/stmcginnis/gofish/pull/443 got removed. Adding back. Nvidia HGX for whatever reason is incorrectly using [] instead of null. This handles the vendor one-off.