### PR TITLE
fix: retry action POST without If-Match on 412 Precondition Failed

### DIFF
--- a/schemas/task_monitor.go
+++ b/schemas/task_monitor.go
@@ -39,6 +39,20 @@ func PostWithTask(c Client, uri string, payload any, headers map[string]string, 
 	} else {
 		resp, err = c.PostWithHeaders(uri, payload, headers)
 	}
+
+	// If 412 Precondition Failed, retry without If-Match header.
+	// Some BMC implementations (e.g., Dell iDRAC10) reject If-Match
+	// on action POST endpoints.
+	if err != nil && Is412PreconditionFailed(err) {
+		DeferredCleanupHTTPResponse(resp)
+		delete(headers, "If-Match")
+		if isMMultipart {
+			resp, err = c.PostMultipartWithHeaders(uri, payload.(map[string]io.Reader), headers)
+		} else {
+			resp, err = c.PostWithHeaders(uri, payload, headers)
+		}
+	}
+
 	if err != nil {
 		defer DeferredCleanupHTTPResponse(resp)
 		return nil, nil, err

--- a/schemas/task_monitor_test.go
+++ b/schemas/task_monitor_test.go
@@ -89,6 +89,83 @@ func TestPostWithTask(t *testing.T) { //nolint: funlen
 		},
 	}
 
+	// Additional tests for 412 Precondition Failed fallback
+	t.Run("post succeeds on first try without fallback", func(t *testing.T) {
+		c := &TestClient{
+			CustomReturnForActions: map[string][]any{
+				http.MethodPost: {
+					&http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(bytes.NewBufferString("{}")),
+					},
+				},
+			},
+		}
+		res, _, err := PostWithTask(c, "/Action/test", map[string]string{}, map[string]string{"If-Match": `W/"gen-1"`}, false)
+		RequireNoError(t, err)
+		if res == nil {
+			t.Fatal("expected response, got nil")
+		}
+		calls := c.CapturedCalls()
+		if len(calls) != 1 {
+			t.Fatalf("expected 1 call (no fallback), got %d", len(calls))
+		}
+	})
+
+	t.Run("post retries without If-Match on 412", func(t *testing.T) {
+		c := &TestClient{
+			CustomReturnForActions: map[string][]any{
+				http.MethodPost: {
+					&http.Response{
+						StatusCode: http.StatusPreconditionFailed,
+						Body:       io.NopCloser(bytes.NewBufferString(`{"error":{"code":"Base.1.18.PreconditionFailed","message":"ETag mismatch"}}`)),
+					},
+					&http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(bytes.NewBufferString("{}")),
+					},
+				},
+			},
+		}
+		headers := map[string]string{"If-Match": `W/"gen-1"`}
+		res, _, err := PostWithTask(c, "/Action/test", map[string]string{}, headers, false)
+		RequireNoError(t, err)
+		if res == nil {
+			t.Fatal("expected response, got nil")
+		}
+		calls := c.CapturedCalls()
+		if len(calls) != 2 {
+			t.Fatalf("expected 2 calls (412 + retry), got %d", len(calls))
+		}
+		// Verify If-Match was removed on retry
+		if _, ok := headers["If-Match"]; ok {
+			t.Error("expected If-Match to be removed from headers after 412 fallback")
+		}
+	})
+
+	t.Run("post 412 fallback still fails with different error", func(t *testing.T) {
+		c := &TestClient{
+			CustomReturnForActions: map[string][]any{
+				http.MethodPost: {
+					&http.Response{
+						StatusCode: http.StatusPreconditionFailed,
+						Body:       io.NopCloser(bytes.NewBufferString(`{"error":{"code":"Base.1.18.PreconditionFailed","message":"ETag mismatch"}}`)),
+					},
+					&http.Response{
+						StatusCode: http.StatusBadRequest,
+						Body:       io.NopCloser(bytes.NewBufferString(`{"error":{"code":"Base.1.18.GeneralError","message":"Bad request"}}`)),
+					},
+				},
+			},
+		}
+		_, _, err := PostWithTask(c, "/Action/test", map[string]string{}, map[string]string{"If-Match": `W/"gen-1"`}, false)
+		RequireErrorContains(t, err, "400")
+		calls := c.CapturedCalls()
+		if len(calls) != 2 {
+			t.Fatalf("expected 2 calls (412 + retry), got %d", len(calls))
+		}
+	})
+
 	testURI := "/Action/test"
 	testPayload := map[string]string{}
 	var testHeaders map[string]string

--- a/schemas/types.go
+++ b/schemas/types.go
@@ -6,7 +6,9 @@ package schemas
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
 )
 
 // DefaultServiceRoot is the default path to the Redfish service endpoint.
@@ -160,6 +162,15 @@ func (e *Error) Error() string {
 		return fmt.Sprintf("%d: %s", e.HTTPReturnedStatusCode, e.rawData)
 	}
 	return string(e.rawData)
+}
+
+// Is412PreconditionFailed checks if the error is a 412 Precondition Failed response.
+func Is412PreconditionFailed(err error) bool {
+	var redfishErr *Error
+	if errors.As(err, &redfishErr) {
+		return redfishErr.HTTPReturnedStatusCode == http.StatusPreconditionFailed
+	}
+	return false
 }
 
 // ErrExtendedInfo is for redfish ExtendedInfo error response

--- a/schemas/types_test.go
+++ b/schemas/types_test.go
@@ -6,6 +6,8 @@ package schemas
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 )
@@ -42,6 +44,44 @@ func TestPartLocationString(t *testing.T) {
 
 	if *result.LocationOrdinalValue != 5 {
 		t.Errorf("Received invalid location ordinal value: %d", result.LocationOrdinalValue)
+	}
+}
+
+func TestIs412PreconditionFailed(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "412 Redfish error",
+			err:      ConstructError(http.StatusPreconditionFailed, []byte(`{"error":{"code":"Base.1.18.PreconditionFailed","message":"ETag mismatch"}}`)),
+			expected: true,
+		},
+		{
+			name:     "500 Redfish error",
+			err:      ConstructError(http.StatusInternalServerError, []byte(`{"error":{"code":"Base.1.18.GeneralError","message":"Internal error"}}`)),
+			expected: false,
+		},
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "non-Redfish error",
+			err:      fmt.Errorf("some generic error"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Is412PreconditionFailed(tt.err)
+			if result != tt.expected {
+				t.Errorf("Is412PreconditionFailed() = %v, want %v", result, tt.expected)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Some BMC implementations (e.g., Dell iDRAC10) reject If-Match headers on action POST endpoints with HTTP 412. PostWithTask now retries without If-Match on 412.

If-Match is tried first to preserve existing behavior. Only removed on 412.

Tested on Dell PowerEdge R470 (iDRAC10): Reset, InsertMedia (real ISO), and EjectMedia all pass.