### PR TITLE
fix(computersystem): use settingsTarget in SetBoot and sanitize gzip ETags

### DIFF
--- a/schemas/computersystem.go
+++ b/schemas/computersystem.go
@@ -1061,12 +1061,37 @@ func ListReferencedComputerSystems(c Client, link string) ([]*ComputerSystem, er
 	return GetCollectionObjects[ComputerSystem](c, link)
 }
 
-// SetBoot sets a boot object based on a payload request
+// If @Redfish.Settings is present, PATCH goes to the Settings URI with ETag
+// concurrency control. Falls back to ODataID when absent.
 func (c *ComputerSystem) SetBoot(b *Boot) error {
 	t := struct {
 		Boot *Boot
 	}{Boot: b}
-	return c.Patch(c.ODataID, t)
+
+	// If settingsTarget differs from ODataID, we are targeting a Settings resource
+	// which may require an ETag for concurrency control (e.g., Dell iDRAC10).
+	if c.settingsTarget != c.ODataID {
+		resp, err := c.GetClient().Get(c.settingsTarget)
+		defer DeferredCleanupHTTPResponse(resp)
+		if err != nil {
+			return err
+		}
+
+		var header = make(map[string]string)
+		if resp.Header["Etag"] != nil {
+			header["If-Match"] = sanitizeETag(resp.Header["Etag"][0])
+		}
+
+		resp, err = c.GetClient().PatchWithHeaders(c.settingsTarget, t, header)
+		defer DeferredCleanupHTTPResponse(resp)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	return c.Patch(c.settingsTarget, t)
 }
 
 // This action shall add a resource block to a system.

--- a/schemas/computersystem_test.go
+++ b/schemas/computersystem_test.go
@@ -491,6 +491,151 @@ func TestBootOption(t *testing.T) {
 	}
 }
 
+// computerSystemBodyWithSettings is a Dell iDRAC10-style ComputerSystem where
+// @Redfish.Settings directs Boot updates to a separate Settings URI.
+var computerSystemBodyWithSettings = `{
+	"@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
+	"@odata.id": "/redfish/v1/Systems/System.Embedded.1",
+	"@odata.type": "#ComputerSystem.v1_20_0.ComputerSystem",
+	"Id": "System.Embedded.1",
+	"Name": "System",
+	"SystemType": "Physical",
+	"AssetTag": "",
+	"Manufacturer": "Dell Inc.",
+	"Model": "PowerEdge R570",
+	"@Redfish.Settings": {
+		"SettingsObject": {
+			"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Settings"
+		},
+		"SupportedApplyTimes": ["Immediate", "OnReset"]
+	},
+	"Boot": {
+		"BootSourceOverrideEnabled": "Disabled",
+		"BootSourceOverrideMode": "UEFI",
+		"BootSourceOverrideTarget": "None",
+		"BootSourceOverrideTarget@Redfish.AllowableValues": [
+			"None",
+			"Pxe",
+			"Hdd",
+			"Cd",
+			"BiosSetup",
+			"UefiTarget",
+			"UefiHttp"
+		]
+	},
+	"Actions": {
+		"#ComputerSystem.Reset": {
+			"target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
+			"ResetType@Redfish.AllowableValues": [
+				"On",
+				"ForceOff",
+				"ForceRestart",
+				"GracefulShutdown",
+				"PushPowerButton"
+			]
+		}
+	}
+}`
+
+// TestSetBootWithSettings verifies that SetBoot sends the PATCH request to the
+// @Redfish.Settings URI when it is present (e.g., Dell iDRAC10).
+func TestSetBootWithSettings(t *testing.T) {
+	var result ComputerSystem
+	err := json.NewDecoder(strings.NewReader(computerSystemBodyWithSettings)).Decode(&result)
+	if err != nil {
+		t.Fatalf("Error decoding JSON: %s", err)
+	}
+
+	// Verify settingsTarget was parsed correctly
+	if result.settingsTarget != "/redfish/v1/Systems/System.Embedded.1/Settings" {
+		t.Fatalf("Expected settingsTarget to be '/redfish/v1/Systems/System.Embedded.1/Settings', got '%s'",
+			result.settingsTarget)
+	}
+
+	testClient := &TestClient{}
+	result.SetClient(testClient)
+
+	boot := &Boot{
+		BootSourceOverrideTarget:  PxeBootSource,
+		BootSourceOverrideEnabled: OnceBootSourceOverrideEnabled,
+	}
+	err = result.SetBoot(boot)
+	if err != nil {
+		t.Fatalf("Error calling SetBoot: %s", err)
+	}
+
+	calls := testClient.CapturedCalls()
+	// Settings path requires GET (for ETag) + PATCH = 2 calls
+	if len(calls) != 2 {
+		t.Fatalf("Expected 2 calls (GET + PATCH), got %d", len(calls))
+	}
+
+	// First call: GET to Settings URI to fetch ETag
+	if calls[0].Action != http.MethodGet {
+		t.Errorf("Expected first call to be GET, got %s", calls[0].Action)
+	}
+	if calls[0].URL != "/redfish/v1/Systems/System.Embedded.1/Settings" {
+		t.Errorf("Expected GET to Settings URI, got '%s'", calls[0].URL)
+	}
+
+	// Second call: PATCH to Settings URI with boot payload
+	if calls[1].Action != http.MethodPatch {
+		t.Errorf("Expected second call to be PATCH, got %s", calls[1].Action)
+	}
+	if calls[1].URL != "/redfish/v1/Systems/System.Embedded.1/Settings" {
+		t.Errorf("Expected PATCH to Settings URI '/redfish/v1/Systems/System.Embedded.1/Settings', got '%s'",
+			calls[1].URL)
+	}
+	if !strings.Contains(calls[1].Payload, "Pxe") {
+		t.Errorf("Expected payload to contain 'Pxe', got: %s", calls[1].Payload)
+	}
+}
+
+// TestSetBootWithoutSettings verifies that SetBoot sends the PATCH request to
+// the system ODataID when @Redfish.Settings is not present (standard BMCs).
+func TestSetBootWithoutSettings(t *testing.T) {
+	var result ComputerSystem
+	err := json.NewDecoder(strings.NewReader(computerSystemBody)).Decode(&result)
+	if err != nil {
+		t.Fatalf("Error decoding JSON: %s", err)
+	}
+
+	// Without @Redfish.Settings, settingsTarget should fall back to ODataID
+	if result.settingsTarget != "/redfish/v1/Systems/System-1" {
+		t.Fatalf("Expected settingsTarget to be '/redfish/v1/Systems/System-1', got '%s'",
+			result.settingsTarget)
+	}
+
+	testClient := &TestClient{}
+	result.SetClient(testClient)
+
+	boot := &Boot{
+		BootSourceOverrideTarget:  PxeBootSource,
+		BootSourceOverrideEnabled: OnceBootSourceOverrideEnabled,
+	}
+	err = result.SetBoot(boot)
+	if err != nil {
+		t.Fatalf("Error calling SetBoot: %s", err)
+	}
+
+	calls := testClient.CapturedCalls()
+	if len(calls) != 1 {
+		t.Fatalf("Expected 1 call, got %d", len(calls))
+	}
+
+	// The PATCH must go to the system ODataID directly
+	if calls[0].Action != http.MethodPatch {
+		t.Errorf("Expected PATCH action, got %s", calls[0].Action)
+	}
+	if calls[0].URL != "/redfish/v1/Systems/System-1" {
+		t.Errorf("Expected PATCH to system URI '/redfish/v1/Systems/System-1', got '%s'",
+			calls[0].URL)
+	}
+	if !strings.Contains(calls[0].Payload, "Pxe") {
+		t.Errorf("Expected payload to contain 'Pxe', got: %s", calls[0].Payload)
+	}
+}
+
 // TestSystemSupportedResetTypes tests getting supported reset types for a chassis.
 func TestSystemSupportedResetTypes(t *testing.T) {
 	var result ComputerSystem

--- a/schemas/entity.go
+++ b/schemas/entity.go
@@ -123,7 +123,7 @@ func (e *Entity) Get(c Client, uri string, payload any) error {
 
 	// if the entity already has an etag, don't override it, but otherwise pull from the HTTP header
 	if etag := resp.Header.Get("Etag"); etag != "" && e.ODataEtag == "" {
-		e.ODataEtag = etag
+		e.ODataEtag = sanitizeETag(etag)
 	}
 	e.SetClient(c)
 
@@ -152,6 +152,15 @@ func (e *Entity) Post(uri string, payload any) error {
 // Callers must close the response body when done.
 func (e *Entity) PostWithResponse(uri string, payload any) (*http.Response, error) {
 	return e.client.PostWithHeaders(uri, payload, e.Headers())
+}
+
+// sanitizeETag strips the "-gzip" suffix that some servers append to ETags
+// for gzip-compressed responses, which causes If-Match mismatches.
+func sanitizeETag(etag string) string {
+	if strings.HasSuffix(etag, `-gzip"`) {
+		return strings.TrimSuffix(etag, `-gzip"`) + `"`
+	}
+	return etag
 }
 
 // Headers generates the appropriate Headers including etag if configured.
@@ -476,7 +485,7 @@ func DecodeGenericEntity[T any, PT GenericSchemaObjectPointer[T]](c Client, resp
 	}
 
 	if etag := resp.Header.Get("Etag"); etag != "" && entity.GetETag() == "" {
-		entity.SetETag(etag)
+		entity.SetETag(sanitizeETag(etag))
 	}
 	entity.SetClient(c)
 	return entity, nil


### PR DESCRIPTION
SetBoot() was always sending PATCH to the system ODataID, ignoring the @Redfish.Settings annotation. Dell iDRAC10 marks Boot as read-only on the main resource and requires updates via the Settings URI.

Changes:
- SetBoot() now uses settingsTarget (from @Redfish.Settings) with ETag concurrency control
- Added sanitizeETag() to strip the "-gzip" suffix from ETags (some servers append this for gzip responses)
- Falls back to ODataID when @Redfish.Settings is absent (backward compatible)

Tested on Dell PowerEdge R470 (iDRAC10): SetBoot PXE and Cd both pass.