### PR TITLE
schemas: preserve collection member order

### DIFF
--- a/schemas/collection.go
+++ b/schemas/collection.go
@@ -193,65 +193,129 @@ func CollectResourceCollection[T any, PT interface {
 	wg.Wait()
 }
 
+// extendedInfoToError converts a slice of Message into a *Error.
+func extendedInfoToError(ext []Message) *Error {
+	errE := &Error{}
+	for i := range ext {
+		errE.ExtendedInfos = append(errE.ExtendedInfos, ErrExtendedInfo(ext[i]))
+	}
+	return errE
+}
+
+// collectMemberLinks walks all pages of a typed collection starting at uri,
+// returning the ordered list of member @odata.id links. queryOpts are applied
+// only to the first page; subsequent pages follow MembersNextLink verbatim.
+// Inline-expanded members that carry ExtendedInfo are recorded as errors and
+// excluded from the returned links. Inline-expanded members with a valid Id
+// but no ExtendedInfo are re-fetched individually by GetCollectionObjects to
+// guarantee server-provided ordering; this is an intentional trade-off.
+func collectMemberLinks[T any, PT interface {
+	*T
+	SchemaObject
+}](c Client, uri string, collectionError *CollectionError, queryOpts ...QueryGroupOption) []string {
+	var links []string
+	next := uri
+	firstPage := true
+	for next != "" {
+		var collection *ResourceCollectionGeneric[PT]
+		var err error
+		if firstPage {
+			collection, err = GetResourceCollection[T, PT](c, next, queryOpts...)
+			firstPage = false
+		} else {
+			collection, err = GetResourceCollection[T, PT](c, next)
+		}
+		if err != nil {
+			collectionError.Failures[next] = err
+			break
+		}
+		for _, m := range collection.Members {
+			if m == nil {
+				continue
+			}
+			odataID := m.GetODataID()
+			if odataID == "" {
+				continue
+			}
+			// Inline-expanded member with ExtendedInfo is an error; skip fetch.
+			if m.GetID() != "" {
+				if ext := m.GetExtendedInfo(); len(ext) > 0 {
+					collectionError.Failures[odataID] = extendedInfoToError(ext)
+					continue
+				}
+			}
+			links = append(links, odataID)
+		}
+		next = collection.MembersNextLink
+	}
+	return links
+}
+
+// GetCollectionObjects retrieves all members of a Redfish collection at uri,
+// preserving the server-provided Members order. The returned slice is dense
+// (no nil holes); failed fetches are recorded in the returned CollectionError.
 func GetCollectionObjects[T any, PT interface {
 	*T
 	SchemaObject
 }](c Client, uri string, queryOpts ...QueryGroupOption) ([]*T, error) {
-	var result []*T
 	if uri == "" {
-		return result, nil
+		return make([]*T, 0), nil
 	}
 
-	type GetResult struct {
-		Item  *T
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
 	collectionError := NewCollectionError()
-	get := func(entity PT, opts ...QueryGroupOption) {
-		if entity != nil && entity.GetID() != "" {
-			// if the entity has any ExtendedInfo, we assume it's an error
-			var err error
-			extendedInfo := entity.GetExtendedInfo()
-			if len(extendedInfo) > 0 {
-				errE := &Error{}
-				for i := range extendedInfo {
-					errE.ExtendedInfos = append(errE.ExtendedInfos, ErrExtendedInfo(extendedInfo[i]))
-				}
-				err = errE
-			}
+	links := collectMemberLinks[T, PT](c, uri, collectionError, queryOpts...)
 
-			entity.SetClient(c)
+	if len(links) == 0 {
+		if collectionError.Empty() {
+			return make([]*T, 0), nil
+		}
+		return make([]*T, 0), collectionError
+	}
 
-			ch <- GetResult{Item: entity, Link: entity.GetODataID(), Error: err}
-		} else if entity != nil && entity.GetODataID() != "" {
-			link := entity.GetODataID()
-			entity, err := GetObject[T, PT](c, link, opts...)
-			ch <- GetResult{Item: entity, Link: link, Error: err}
+	// Fetch all members concurrently into a preallocated indexed slice.
+	// First occurrence of a duplicate link wins.
+	result := make([]*T, len(links))
+	index := make(map[string]int, len(links))
+	for i, l := range links {
+		if _, exists := index[l]; !exists {
+			index[l] = i
 		}
 	}
 
-	go func() {
-		err := CollectListGeneric(get, c, uri, queryOpts...)
+	var mu sync.Mutex
+	get := func(link string) {
+		entity, err := GetObject[T, PT](c, link, queryOpts...)
+		mu.Lock()
+		defer mu.Unlock()
 		if err != nil {
-			collectionError.Failures[uri] = err
+			collectionError.Failures[link] = err
+			return
 		}
-		close(ch)
-	}()
+		if entity == nil {
+			return
+		}
+		if extInfo := PT(entity).GetExtendedInfo(); len(extInfo) > 0 {
+			collectionError.Failures[link] = extendedInfoToError(extInfo)
+			return
+		}
+		if idx, ok := index[PT(entity).GetODataID()]; ok {
+			result[idx] = entity
+		} else if idx, ok := index[link]; ok {
+			result[idx] = entity
+		}
+	}
+	CollectCollection(get, links)
 
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
+	// Compact to a dense slice preserving relative order.
+	dense := make([]*T, 0, len(result))
+	for _, it := range result {
+		if it != nil {
+			dense = append(dense, it)
 		}
 	}
 
 	if collectionError.Empty() {
-		return result, nil
+		return dense, nil
 	}
-
-	return result, collectionError
+	return dense, collectionError
 }

--- a/schemas/collection_test.go
+++ b/schemas/collection_test.go
@@ -5,8 +5,11 @@
 package schemas
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 )
@@ -52,6 +55,74 @@ func TestCollection(t *testing.T) {
 		endpoint := fmt.Sprintf(linkRoot, i+1)
 		if item != endpoint {
 			t.Errorf("Expected link to '%s', got '%s'", endpoint, item)
+		}
+	}
+}
+
+// TestGetCollectionObjectsOrder verifies that GetCollectionObjects preserves
+// the server-provided Members order regardless of concurrent fetch completion
+// order. The collection page lists members as /3, /1, /2 (deliberately
+// non-sequential) and the test asserts the returned slice matches that order.
+func TestGetCollectionObjectsOrder(t *testing.T) {
+	// Collection page: members listed as 3, 1, 2 to prove ordering is driven
+	// by the collection page, not by HTTP response arrival order.
+	collectionPage := `{
+		"@odata.id": "/redfish/v1/Items",
+		"@odata.type": "#ItemCollection.ItemCollection",
+		"Name": "Items",
+		"Members@odata.count": 3,
+		"Members": [
+			{"@odata.id": "/redfish/v1/Items/3"},
+			{"@odata.id": "/redfish/v1/Items/1"},
+			{"@odata.id": "/redfish/v1/Items/2"}
+		]
+	}`
+
+	makeItemBody := func(id string) string {
+		return `{"@odata.id": "/redfish/v1/Items/` + id + `", "Id": "` + id + `", "Name": "Item ` + id + `"}`
+	}
+
+	makeResp := func(body string) *http.Response {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewBufferString(body)),
+		}
+	}
+
+	// GET responses in call order:
+	//   0: collection page
+	//   1: /Items/3
+	//   2: /Items/1
+	//   3: /Items/2
+	testClient := &TestClient{
+		CustomReturnForActions: map[string][]any{
+			http.MethodGet: {
+				makeResp(collectionPage),
+				makeResp(makeItemBody("3")),
+				makeResp(makeItemBody("1")),
+				makeResp(makeItemBody("2")),
+			},
+		},
+	}
+
+	results, err := GetCollectionObjects[Resource, *Resource](testClient, "/redfish/v1/Items")
+	if err != nil {
+		t.Fatalf("GetCollectionObjects returned unexpected error: %v", err)
+	}
+
+	wantOrder := []string{
+		"/redfish/v1/Items/3",
+		"/redfish/v1/Items/1",
+		"/redfish/v1/Items/2",
+	}
+
+	if len(results) != len(wantOrder) {
+		t.Fatalf("Expected %d results, got %d", len(wantOrder), len(results))
+	}
+
+	for i, want := range wantOrder {
+		if got := results[i].ODataID; got != want {
+			t.Errorf("results[%d]: want ODataID %q, got %q", i, want, got)
 		}
 	}
 }

--- a/schemas/entity.go
+++ b/schemas/entity.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"sync"
 )
 
 // Entity provides the basis for all Redfish and Swordfish objects.
@@ -492,47 +493,53 @@ func DecodeGenericEntity[T any, PT GenericSchemaObjectPointer[T]](c Client, resp
 }
 
 // GetObjects retrieves multiple API objects concurrently from the service.
+// The returned slice is dense (no nil entries) and preserves the caller-supplied
+// URI order — not HTTP response arrival order. Failed fetches are recorded in
+// the returned CollectionError; successful results preserve input order.
 func GetObjects[T any, PT interface {
 	*T
 	SchemaObject
 }](c Client, uris []string) ([]*T, error) {
-	var result []*T
 	if len(uris) == 0 {
-		return result, nil
+		return make([]*T, 0), nil
 	}
 
-	type GetResult struct {
-		Item  *T
-		Link  string
-		Error error
+	// Preallocate result slice and build URI-to-index map so concurrent
+	// fetches can write back into the original position, preserving the
+	// caller-supplied order.
+	result := make([]*T, len(uris))
+	index := make(map[string]int, len(uris))
+	for i, u := range uris {
+		index[u] = i
 	}
 
-	ch := make(chan GetResult)
+	var mu sync.Mutex
 	collectionError := NewCollectionError()
 
-	// Worker function to get a single object
 	get := func(link string) {
 		entity, err := GetObject[T, PT](c, link)
-		ch <- GetResult{Item: entity, Link: link, Error: err}
+		mu.Lock()
+		defer mu.Unlock()
+		if err != nil {
+			collectionError.Failures[link] = err
+		} else if idx, ok := index[link]; ok {
+			result[idx] = entity
+		}
 	}
 
-	// Start workers for each URI
-	go func() {
-		CollectCollection(get, uris)
-		close(ch)
-	}()
+	CollectCollection(get, uris)
 
-	// Process results
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
+	// Compact to a dense slice that preserves relative order but contains no
+	// nil holes (callers should not need to nil-check every element).
+	dense := make([]*T, 0, len(result))
+	for _, it := range result {
+		if it != nil {
+			dense = append(dense, it)
 		}
 	}
 
 	if collectionError.Empty() {
-		return result, nil
+		return dense, nil
 	}
-	return result, collectionError
+	return dense, collectionError
 }


### PR DESCRIPTION
`GetCollectionObjects` and `GetObjects` fetch collection members concurrently but return them in HTTP response completion order, not the order listed in the collection’s `Members` array. This makes slice ordering dependent on hardware and timing.

### Background

On Dell iDRAC10, the VirtualMedia collection exposes two slots. Only `VirtualMedia/1` is bootable via the standard `BootSourceOverrideTarget=Cd`, and consumers like `bmclib` typically select the first returned slot. Because gofish returned collection members in completion order, `ComputerSystem.VirtualMedia()` was non-deterministic and frequently returned `VirtualMedia/2` first, causing ISO mounts to land on the non-bootable slot and the host to fail to boot.

### Change

`GetCollectionObjects` and `GetObjects` now preserve member order by writing results into a preallocated slice at the original member index (link → index map). Results are compacted to a dense slice before returning. Concurrency is unchanged.

A helper (`collectMemberLinks`) walks collection pages to collect member links in server order before dispatching concurrent fetches.

### Testing

* Hardware repro against Dell R470 iDRAC10 calling `systems[0].VirtualMedia()` 20 times:

  * main: `VirtualMedia/1` first 9/20 (wrong slot ~55%)
  * this branch: `VirtualMedia/1` first 20/20
* Added unit test `TestGetCollectionObjectsOrder` (members `/3, /1, /2` → results match that order). 
