### PR TITLE
Workaround ZTE bug in processors

### DIFF
--- a/schemas/processor.go
+++ b/schemas/processor.go
@@ -587,6 +587,7 @@ func (p *Processor) UnmarshalJSON(b []byte) error {
 		SubProcessors          Link `json:"SubProcessors"`
 
 		MaxSpeedMHz any
+		Socket      any // ZTE bug
 	}
 
 	err := json.Unmarshal(b, &tmp)
@@ -620,6 +621,7 @@ func (p *Processor) UnmarshalJSON(b []byte) error {
 	p.subProcessors = tmp.SubProcessors.String()
 
 	p.MaxSpeedMHz = toInt(tmp.MaxSpeedMHz)
+	p.Socket = parseString(tmp.Socket)
 
 	// This is a read/write object, so we need to save the raw object data for later
 	p.RawData = b

--- a/schemas/processor_test.go
+++ b/schemas/processor_test.go
@@ -362,6 +362,24 @@ var invalidProcessorBody = strings.NewReader(
 		"TotalThreads": 32
 	  }`)
 
+var processorBodyWithSocketInt = strings.NewReader(
+	`{
+		"@odata.context":"/redfish/v1/$metadata#Processor.Processor",
+		"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.2",
+		"@odata.type":"#Processor.v1_3_1.Processor",
+		"Description":"Represents the properties of a Processor attached to this System",
+		"Id":"CPU.Socket.2",
+		"InstructionSet":"x86-64",
+		"Manufacturer":"Intel",
+		"MaxSpeedMHz":"4000",
+		"Model":"Intel(R) Xeon(R) Gold 6136 CPU @ 3.00GHz",
+		"Name":"CPU 2",
+		"ProcessorType":"CPU",
+		"Socket":2,
+		"TotalCores":12,
+		"TotalThreads":24
+	 }`)
+
 // TestProcessor tests the parsing of Processor objects.
 func TestProcessor(t *testing.T) {
 	var result Processor
@@ -435,6 +453,20 @@ func TestMaxSpeedMHzString(t *testing.T) {
 
 	if *result.MaxSpeedMHz != 4000 {
 		t.Errorf("Expected MaxSpeedMhz to be 4000 but got %d", *result.MaxSpeedMHz)
+	}
+}
+
+// TestSocketInt tests the parsing of Processor object ZTE bug workaround.
+func TestSocketInt(t *testing.T) {
+	var result Processor
+	err := json.NewDecoder(processorBodyWithSocketInt).Decode(&result)
+
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+
+	if result.Socket != "2" {
+		t.Errorf("Received invalid socket: %s", result.ID)
 	}
 }
 


### PR DESCRIPTION
Redfish spec defines `socket` as a string, but some ZTE systems return it as an integer. This adds a workaround to the parsing of the processor responses to handle this.

Closes: #532