### PR TITLE
Configurable request concurrency

### DIFF
--- a/schemas/collection.go
+++ b/schemas/collection.go
@@ -151,9 +151,10 @@ func CollectListGeneric[T any, PT interface {
 		}
 	}
 
-	CollectResourceCollection(get, collection.Members, queryOpts...)
+	collectionQuery := BuildQueryGroup(c, queryOpts...).QueryCollection
+	collectResourceCollection(get, collection.Members, collectionQuery.collectionRequestConcurrency, queryOpts...)
 	if collection.MembersNextLink != "" {
-		err := CollectListGeneric(get, c, collection.MembersNextLink)
+		err := CollectListGeneric(get, c, collection.MembersNextLink, queryOpts...)
 		if err != nil {
 			return err
 		}
@@ -163,22 +164,36 @@ func CollectListGeneric[T any, PT interface {
 
 // CollectCollection will retrieve a collection of entities from the Redfish service
 // when you already have the set of individual links in the collection.
-func CollectCollection(get func(string), links []string) {
+func CollectCollection(get func(string), links []string, queryOpts ...QueryGroupOption) {
 	linkEntities := []*Resource{}
 
 	for _, link := range links {
 		linkEntities = append(linkEntities, &Resource{Entity: Entity{ODataID: link}})
 	}
 
-	CollectResourceCollection(func(resource *Resource, _ ...QueryGroupOption) { get(resource.ODataID) }, linkEntities)
+	CollectResourceCollection(func(resource *Resource, _ ...QueryGroupOption) { get(resource.ODataID) }, linkEntities, queryOpts...)
 }
 
 func CollectResourceCollection[T any, PT interface {
 	*T
 	SchemaObject
 }](get func(PT, ...QueryGroupOption), entities []PT, queryOpts ...QueryGroupOption) {
-	// Only allow three concurrent requests to avoid overwhelming the service
-	limiter := make(chan struct{}, 3)
+	collectionQuery := QueryGroup{}
+	for _, opt := range queryOpts {
+		opt(&collectionQuery)
+	}
+	collectResourceCollection(get, entities, collectionQuery.QueryCollection.collectionRequestConcurrency, queryOpts...)
+}
+
+func collectResourceCollection[T any, PT interface {
+	*T
+	SchemaObject
+}](get func(PT, ...QueryGroupOption), entities []PT, concurrency int, queryOpts ...QueryGroupOption) {
+	if concurrency <= 0 {
+		concurrency = defaultCollectionRequestConcurrency
+	}
+
+	limiter := make(chan struct{}, concurrency)
 	var wg sync.WaitGroup
 
 	for _, itemLink := range entities {

--- a/schemas/collection.go
+++ b/schemas/collection.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 )
 
+const defaultCollectionRequestConcurrency = 3
+
 // Collection represents a collection of entity references.
 type Collection struct {
 	Name            string `json:"Name"`

--- a/schemas/collection_test.go
+++ b/schemas/collection_test.go
@@ -8,7 +8,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 var collectionBody = strings.NewReader(
@@ -54,4 +56,57 @@ func TestCollection(t *testing.T) {
 			t.Errorf("Expected link to '%s', got '%s'", endpoint, item)
 		}
 	}
+}
+
+func TestCollectResourceCollectionDefaultConcurrency(t *testing.T) {
+	resources := testCollectionResources(6)
+	maxActive := collectResourceCollectionMaxActive(resources)
+
+	if maxActive != defaultCollectionRequestConcurrency {
+		t.Errorf("Expected default concurrency %d, got %d", defaultCollectionRequestConcurrency, maxActive)
+	}
+}
+
+func TestCollectResourceCollectionConfiguredConcurrency(t *testing.T) {
+	resources := testCollectionResources(8)
+	concurrency := 5
+	maxActive := collectResourceCollectionMaxActive(
+		resources,
+		WithCollectionQueryOpts(WithCollectionRequestConcurrency(concurrency)),
+	)
+
+	if maxActive != concurrency {
+		t.Errorf("Expected configured concurrency %d, got %d", concurrency, maxActive)
+	}
+}
+
+func testCollectionResources(count int) []*Resource {
+	resources := make([]*Resource, 0, count)
+	for i := 0; i < count; i++ {
+		resources = append(resources, &Resource{Entity: Entity{ODataID: fmt.Sprintf("/redfish/v1/Systems/%d", i)}})
+	}
+	return resources
+}
+
+func collectResourceCollectionMaxActive(resources []*Resource, queryOpts ...QueryGroupOption) int {
+	var mu sync.Mutex
+	active := 0
+	maxActive := 0
+
+	CollectResourceCollection(func(_ *Resource, _ ...QueryGroupOption) {
+		mu.Lock()
+		active++
+		if active > maxActive {
+			maxActive = active
+		}
+		mu.Unlock()
+
+		time.Sleep(20 * time.Millisecond)
+
+		mu.Lock()
+		active--
+		mu.Unlock()
+	}, resources, queryOpts...)
+
+	return maxActive
 }

--- a/schemas/entity.go
+++ b/schemas/entity.go
@@ -518,7 +518,7 @@ func GetObjects[T any, PT interface {
 
 	// Start workers for each URI
 	go func() {
-		CollectCollection(get, uris)
+		CollectCollection(get, uris, c.GetSettings().DefaultQueryOptions...)
 		close(ch)
 	}()
 

--- a/schemas/odata.go
+++ b/schemas/odata.go
@@ -7,9 +7,10 @@ package schemas
 import "fmt"
 
 type Query struct {
-	expand         ExpandOption
-	expandLevel    int
-	expandFallback bool
+	expand                       ExpandOption
+	expandLevel                  int
+	expandFallback               bool
+	collectionRequestConcurrency int
 }
 
 type QueryGroup struct {
@@ -45,6 +46,12 @@ func WithExpandFallback(enable bool) func(*Query) {
 func WithExpandLevel(expandLevel int) func(*Query) {
 	return func(q *Query) {
 		q.expandLevel = expandLevel
+	}
+}
+
+func WithCollectionRequestConcurrency(concurrency int) func(*Query) {
+	return func(q *Query) {
+		q.collectionRequestConcurrency = concurrency
 	}
 }
 


### PR DESCRIPTION
resolves #535 

This allows request concurrency to be configurable from the caller, but still keep the default to 3, like how it is today.
