### PR TITLE
Schemas: change LocationIndicatorActive to *bool to distinguish missing vs false

### DIFF
--- a/schemas/chassis.go
+++ b/schemas/chassis.go
@@ -314,7 +314,7 @@ type Chassis struct {
 	// functional view of this chassis, such as a 'ComputerSystem' resource.
 	//
 	// Version added: v1.14.0
-	LocationIndicatorActive bool
+	LocationIndicatorActive *bool `json:",omitempty"`
 	// LogServices shall contain a link to a resource collection of type
 	// 'LogServiceCollection'.
 	logServices string

--- a/schemas/circuit.go
+++ b/schemas/circuit.go
@@ -338,7 +338,7 @@ type Circuit struct {
 	// reflect the implementation of the locating function.
 	//
 	// Version added: v1.1.0
-	LocationIndicatorActive bool
+	LocationIndicatorActive *bool `json:",omitempty"`
 	// NominalFrequencyHz shall contain the nominal frequency for this circuit, in
 	// hertz units.
 	//

--- a/schemas/computersystem.go
+++ b/schemas/computersystem.go
@@ -669,7 +669,7 @@ type ComputerSystem struct {
 	// resource.
 	//
 	// Version added: v1.13.0
-	LocationIndicatorActive bool
+	LocationIndicatorActive *bool `json:",omitempty"`
 	// LogServices shall contain a link to a resource collection of type
 	// 'LogServiceCollection'.
 	logServices string

--- a/schemas/drive.go
+++ b/schemas/drive.go
@@ -286,7 +286,7 @@ type Drive struct {
 	// reflect the implementation of the locating function.
 	//
 	// Version added: v1.11.0
-	LocationIndicatorActive bool
+	LocationIndicatorActive *bool `json:",omitempty"`
 	// Manufacturer shall contain the name of the organization responsible for
 	// producing the drive. This organization may be the entity from whom the drive
 	// is purchased, but this is not necessarily true.

--- a/schemas/outlet.go
+++ b/schemas/outlet.go
@@ -135,7 +135,7 @@ type Outlet struct {
 	// reflect the implementation of the locating function.
 	//
 	// Version added: v1.1.0
-	LocationIndicatorActive bool
+	LocationIndicatorActive *bool `json:",omitempty"`
 	// NominalVoltage shall contain the nominal voltage for this outlet, in volt
 	// units.
 	NominalVoltage NominalVoltageType

--- a/schemas/outlet_test.go
+++ b/schemas/outlet_test.go
@@ -99,7 +99,7 @@ func TestOutlet(t *testing.T) {
 	assertEquals(t, "/redfish/v1/PowerEquipment/RackPDUs/1/Sensors/VoltageA1", result.PolyPhaseVoltage.Line1ToNeutral.DataSourceURI)
 	assertEquals(t, "/redfish/v1/PowerEquipment/RackPDUs/1/Branches/A", result.branchCircuit)
 
-	if !result.LocationIndicatorActive {
+	if !*result.LocationIndicatorActive {
 		t.Error("Expected location indicator to be active")
 	}
 

--- a/schemas/switch.go
+++ b/schemas/switch.go
@@ -80,7 +80,7 @@ type Switch struct {
 	// reflect the implementation of the locating function.
 	//
 	// Version added: v1.4.0
-	LocationIndicatorActive bool
+	LocationIndicatorActive *bool `json:",omitempty"`
 	// LogServices shall contain a link to a resource collection of type
 	// 'LogServiceCollection'.
 	logServices string


### PR DESCRIPTION
## Description
Currently, `LocationIndicatorActive` is typed as a primitive `bool`. When interacting with older BMCs that do not support this property (omitting it from the Redfish JSON payload), Go defaults the value to `false`. 

This makes it impossible for clients to distinguish between:
1. A system where the location LED is explicitly turned **off** (`false`).
2. A system that **does not support** `LocationIndicatorActive` at all (where the client must fall back to the older `IndicatorLED` property).

## Use-case
This fix addresses issues like the one [in metal-stack/go-hal#92](https://github.com/metal-stack/go-hal/issues/92).

Newer Dell iDRAC9 firmware deprecates the `IndicatorLED` property. It only accepts `Lit` or `Blinking` for `IndicatorLED` and explicitly rejects `Off` with a `400 Bad Request`, unlike older Dell BMCs. Switching to `LocationIndicatorActive` for newer servers cleanly solves this. With this change, downstream clients will be able to check for nil to know whether to patch `LocationIndicatorActive` or fall back to `IndicatorLED`, safely maintaining backwards compatibility with older BMCs.

## Proposed Changes
- Changed `LocationIndicatorActive` from `bool` to `*bool` with `json:",omitempty"` across all core schemas that also implement the legacy `IndicatorLED` property (`Chassis`, `ComputerSystem`, `Drive`, `Switch`, `Outlet`, and `Circuit`).
- Updated existing test assertions to safely dereference the pointer.