### PR TITLE
Add object Refresh method for conditional Get

### DIFF
--- a/client.go
+++ b/client.go
@@ -613,6 +613,15 @@ func (c *APIClient) runRawRequestWithHeaders(method, url string, payloadBuffer i
 		}
 	}
 
+	// A 304 Not Modified is the successful outcome of a conditional GET: the
+	// caller sent If-None-Match and their cached representation is still valid.
+	// Return the response intact (so the caller can read the Etag header) along
+	// with a sentinel so it can be told apart from a real error. Backward
+	// compatible: callers that don't send If-None-Match never receive a 304.
+	if resp.StatusCode == http.StatusNotModified {
+		return resp, schemas.ErrNotModified
+	}
+
 	if resp.StatusCode != 200 && resp.StatusCode != 201 && resp.StatusCode != 202 && resp.StatusCode != 204 {
 		defer schemas.DeferredCleanupHTTPResponse(resp)
 		payload, err := io.ReadAll(resp.Body)

--- a/client_test.go
+++ b/client_test.go
@@ -182,6 +182,47 @@ func TestConnectDefaultContextCancel(t *testing.T) {
 	}
 }
 
+// TestGetWithHeadersNotModified verifies that a 304 Not Modified response to a
+// conditional GET is reported as schemas.ErrNotModified with the response left
+// intact so the caller can read the Etag for cache bookkeeping.
+func TestGetWithHeadersNotModified(t *testing.T) {
+	const etag = `"abc123"`
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("If-None-Match") != etag {
+			t.Errorf("expected If-None-Match %q, got %q", etag, r.Header.Get("If-None-Match"))
+		}
+		w.Header().Set("Etag", etag)
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	defer ts.Close()
+
+	client := &APIClient{
+		ctx:        context.Background(),
+		endpoint:   ts.URL,
+		HTTPClient: ts.Client(),
+		sem:        make(chan bool, 1),
+	}
+
+	resp, err := client.GetWithHeaders("/redfish/v1/Chassis/1/Thermal",
+		map[string]string{"If-None-Match": etag})
+	if resp != nil {
+		defer schemas.DeferredCleanupHTTPResponse(resp)
+	}
+
+	if !errors.Is(err, schemas.ErrNotModified) {
+		t.Fatalf("expected schemas.ErrNotModified, got %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected the response to be returned intact on 304, got nil")
+	}
+	if got := resp.Header.Get("Etag"); got != etag {
+		t.Errorf("expected Etag %q on 304 response, got %q", etag, got)
+	}
+	if resp.StatusCode != http.StatusNotModified {
+		t.Errorf("expected status %d, got %d", http.StatusNotModified, resp.StatusCode)
+	}
+}
+
 func TestClientRunRawRequestNoURL(t *testing.T) {
 	client := APIClient{sem: make(chan bool, 1)}
 

--- a/example_test.go
+++ b/example_test.go
@@ -5,8 +5,10 @@
 package gofish_test
 
 import (
+	"errors"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/stmcginnis/gofish"
 	"github.com/stmcginnis/gofish/schemas"
@@ -180,6 +182,98 @@ func Example_queryThermal() {
 			fmt.Printf("  Fan:  %-30s  %d %s\n", fan.Name, *fan.Reading, fan.ReadingUnits)
 		}
 	}
+}
+
+// Example_pollThermalConditionally shows how to poll a resource efficiently with
+// a conditional GET. schemas.Refresh re-fetches the object using its own ETag as
+// If-None-Match; when the service reports no change it returns
+// schemas.ErrNotModified and the existing object stays valid, avoiding the JSON
+// parse and most of the bytes on the wire. This is the intended pattern for
+// polling fleets of BMCs for resources that change infrequently.
+func Example_pollThermalConditionally() {
+	c, err := gofish.Connect(gofish.ClientConfig{
+		Endpoint: "https://bmc-ip",
+		Username: "my-username",
+		Password: "my-password",
+		Insecure: true,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer c.Logout()
+
+	chassis, err := c.Service.Chassis()
+	if err != nil || len(chassis) == 0 {
+		log.Print(err)
+		return
+	}
+
+	// Initial fetch captures the resource and its ETag.
+	thermal, err := chassis[0].Thermal()
+	if err != nil {
+		log.Print(err)
+		return
+	}
+
+	// Poll on an interval; only re-parse when the BMC reports a change.
+	for range time.Tick(30 * time.Second) {
+		refreshed, err := schemas.Refresh(thermal)
+		switch {
+		case errors.Is(err, schemas.ErrNotModified):
+			continue // unchanged since last poll; keep using the cached object
+		case err != nil:
+			log.Printf("error refreshing thermal: %v", err)
+			continue
+		}
+
+		thermal = refreshed
+		for i := range thermal.Temperatures {
+			if temp := &thermal.Temperatures[i]; temp.ReadingCelsius != nil {
+				fmt.Printf("%s: %.1f °C\n", temp.Name, *temp.ReadingCelsius)
+			}
+		}
+	}
+}
+
+// Example_conditionalReload shows schemas.Reload, the general form of a
+// conditional GET where the caller supplies the request headers directly. Use it
+// when you cache ETags outside the object, or when a vendor requires an unquoted
+// ETag in If-None-Match. schemas.Refresh is the convenience wrapper over this.
+func Example_conditionalReload() {
+	c, err := gofish.Connect(gofish.ClientConfig{
+		Endpoint: "https://bmc-ip",
+		Username: "my-username",
+		Password: "my-password",
+		Insecure: true,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer c.Logout()
+
+	chassis, err := c.Service.Chassis()
+	if err != nil || len(chassis) == 0 {
+		log.Print(err)
+		return
+	}
+
+	power, err := chassis[0].Power()
+	if err != nil {
+		log.Print(err)
+		return
+	}
+
+	power, err = schemas.Reload(power, map[string]string{"If-None-Match": power.GetETag()})
+	if errors.Is(err, schemas.ErrNotModified) {
+		fmt.Println("power metrics unchanged")
+		return
+	}
+	if err != nil {
+		log.Print(err)
+		return
+	}
+
+	fmt.Printf("refreshed power resource: %s\n", power.Name)
 }
 
 // Example_queryManagers shows how to list BMC/management controller details,

--- a/schemas/entity.go
+++ b/schemas/entity.go
@@ -452,6 +452,7 @@ func handleSimpleField(payload map[string]any, fieldName string, original, updat
 // SchemaObject defines the minimum interface required for API objects.
 type SchemaObject interface {
 	SetClient(Client)
+	GetClient() Client
 	GetETag() string
 	SetETag(string)
 	GetID() string
@@ -475,6 +476,48 @@ func GetObject[T any, PT GenericSchemaObjectPointer[T]](c Client, uri string, op
 	}
 
 	return DecodeGenericEntity[T, PT](c, resp)
+}
+
+// Reload re-fetches obj from its own @odata.id using obj's client and the given
+// headers, returning a freshly decoded instance. It is the building block for
+// conditional GETs: pass an "If-None-Match" header and, when the service replies
+// 304 Not Modified, Reload returns the original obj unchanged together with
+// ErrNotModified (check with errors.Is(err, ErrNotModified)). On any other error
+// the original obj is likewise returned so callers can safely write
+// obj, err = Reload(obj, ...) without nil-ing out a still-valid value.
+func Reload[T any, PT GenericSchemaObjectPointer[T]](obj PT, headers map[string]string, opts ...QueryGroupOption) (PT, error) {
+	c := obj.GetClient()
+	if c == nil {
+		return obj, fmt.Errorf("cannot reload %T: no client is set on the object", obj)
+	}
+
+	uri := obj.GetODataID()
+	if uri == "" {
+		return obj, fmt.Errorf("cannot reload %T: object has no @odata.id", obj)
+	}
+
+	resp, err := c.GetWithHeaders(BuildQuery(c, uri, false, opts...), headers)
+	defer DeferredCleanupHTTPResponse(resp)
+	if err != nil {
+		return obj, err
+	}
+
+	return DecodeGenericEntity[T, PT](c, resp)
+}
+
+// Refresh performs a conditional GET for obj keyed on its current ETag, the
+// common case for polling resources that change infrequently. When the service
+// reports the resource is unchanged it returns the original obj together with
+// ErrNotModified; otherwise it returns the updated resource. If obj has no ETag
+// there is nothing to condition on, so Refresh falls back to an unconditional
+// reload. Vendors needing the stripEtagQuotes workaround should call Reload with
+// a hand-built If-None-Match header instead.
+func Refresh[T any, PT GenericSchemaObjectPointer[T]](obj PT) (PT, error) {
+	var headers map[string]string
+	if etag := obj.GetETag(); etag != "" {
+		headers = map[string]string{"If-None-Match": etag}
+	}
+	return Reload[T, PT](obj, headers)
 }
 
 // DecodeGenericEntity attempts to decode an HTTP response into an Entity struct

--- a/schemas/http.go
+++ b/schemas/http.go
@@ -16,6 +16,13 @@ import (
 var (
 	ErrIsEmpty    = errors.New("value is empty")
 	ErrIsNegative = errors.New("value is negative")
+
+	// ErrNotModified is returned for a conditional GET (If-None-Match) when the
+	// service responds with 304 Not Modified, indicating the caller's cached
+	// representation is still current. The HTTP response is returned intact
+	// alongside this sentinel so callers can read the Etag header for cache
+	// bookkeeping. Detect it with errors.Is(err, schemas.ErrNotModified).
+	ErrNotModified = errors.New("gofish: resource not modified")
 )
 
 // CleanupHTTPResponse MUST be called for any HTTP response to ensure that it is properly closed.

--- a/schemas/reload_test.go
+++ b/schemas/reload_test.go
@@ -1,0 +1,177 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package schemas
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+const reloadThermalURI = "/redfish/v1/Chassis/1/Thermal"
+
+// notModifiedCall returns a 304 Not Modified response carrying an Etag header,
+// as a service would answer a conditional GET whose If-None-Match still matches.
+func notModifiedCall(etag string) *http.Response {
+	header := make(http.Header)
+	header.Set("Etag", etag)
+	return &http.Response{
+		Status:     "304 Not Modified",
+		StatusCode: http.StatusNotModified,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Body:       io.NopCloser(strings.NewReader("")),
+		Header:     header,
+	}
+}
+
+// okCall returns a 200 response with the given body and Etag header.
+func okCall(body, etag string) *http.Response {
+	header := make(http.Header)
+	if etag != "" {
+		header.Set("Etag", etag)
+	}
+	return &http.Response{
+		Status:        "200 OK",
+		StatusCode:    200,
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Body:          io.NopCloser(strings.NewReader(body)),
+		ContentLength: int64(len(body)),
+		Header:        header,
+	}
+}
+
+// TestRefreshNotModified verifies Refresh sends the object's ETag as
+// If-None-Match and, on a 304, returns the original object unchanged along with
+// ErrNotModified.
+func TestRefreshNotModified(t *testing.T) {
+	const etag = `"v1"`
+	obj := &Entity{ODataID: reloadThermalURI, Name: "Thermal", ODataEtag: etag}
+
+	testClient := &TestClient{
+		CustomReturnForActions: map[string][]any{
+			http.MethodGet: {notModifiedCall(etag)},
+		},
+	}
+	obj.SetClient(testClient)
+
+	got, err := Refresh(obj)
+	if !errors.Is(err, ErrNotModified) {
+		t.Fatalf("expected ErrNotModified, got %v", err)
+	}
+	if got != obj {
+		t.Errorf("expected the original object back on 304, got a different value")
+	}
+	if got.Name != "Thermal" || got.GetETag() != etag {
+		t.Errorf("object should be unchanged on 304, got Name=%q ETag=%q", got.Name, got.GetETag())
+	}
+
+	calls := testClient.CapturedCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if calls[0].URL != reloadThermalURI {
+		t.Errorf("expected GET %q, got %q", reloadThermalURI, calls[0].URL)
+	}
+	if inm := calls[0].CustomHeaders["If-None-Match"]; inm != etag {
+		t.Errorf("expected If-None-Match %q, got %q", etag, inm)
+	}
+}
+
+// TestRefreshModified verifies Refresh returns the updated resource when the
+// service reports a change (200 with a fresh body and ETag).
+func TestRefreshModified(t *testing.T) {
+	obj := &Entity{ODataID: reloadThermalURI, Name: "Thermal", ODataEtag: `"v1"`}
+
+	const updated = `{"@odata.id":"` + reloadThermalURI + `","Id":"Thermal","Name":"Thermal Updated"}`
+	testClient := &TestClient{
+		CustomReturnForActions: map[string][]any{
+			http.MethodGet: {okCall(updated, `"v2"`)},
+		},
+	}
+	obj.SetClient(testClient)
+
+	got, err := Refresh(obj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Name != "Thermal Updated" {
+		t.Errorf("expected updated Name, got %q", got.Name)
+	}
+	if got.GetETag() != `"v2"` {
+		t.Errorf("expected refreshed ETag \"v2\", got %q", got.GetETag())
+	}
+	if got.GetClient() == nil {
+		t.Error("refreshed object should have its client set")
+	}
+}
+
+// TestRefreshNoETag verifies that without an ETag Refresh falls back to an
+// unconditional reload (no If-None-Match header).
+func TestRefreshNoETag(t *testing.T) {
+	obj := &Entity{ODataID: reloadThermalURI, Name: "Thermal"}
+
+	const body = `{"@odata.id":"` + reloadThermalURI + `","Id":"Thermal","Name":"Thermal"}`
+	testClient := &TestClient{
+		CustomReturnForActions: map[string][]any{
+			http.MethodGet: {okCall(body, "")},
+		},
+	}
+	obj.SetClient(testClient)
+
+	if _, err := Refresh(obj); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	calls := testClient.CapturedCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if _, ok := calls[0].CustomHeaders["If-None-Match"]; ok {
+		t.Errorf("expected no If-None-Match header, got %q", calls[0].CustomHeaders["If-None-Match"])
+	}
+}
+
+// TestReloadWithHeaders verifies Reload forwards caller-supplied headers verbatim.
+func TestReloadWithHeaders(t *testing.T) {
+	obj := &Entity{ODataID: reloadThermalURI, Name: "Thermal", ODataEtag: `"v1"`}
+
+	testClient := &TestClient{
+		CustomReturnForActions: map[string][]any{
+			http.MethodGet: {notModifiedCall(`"v1"`)},
+		},
+	}
+	obj.SetClient(testClient)
+
+	headers := map[string]string{"If-None-Match": "unquoted-v1"}
+	_, err := Reload[Entity](obj, headers)
+	if !errors.Is(err, ErrNotModified) {
+		t.Fatalf("expected ErrNotModified, got %v", err)
+	}
+
+	calls := testClient.CapturedCalls()
+	if inm := calls[0].CustomHeaders["If-None-Match"]; inm != "unquoted-v1" {
+		t.Errorf("expected caller header forwarded verbatim, got %q", inm)
+	}
+}
+
+// TestReloadNoClient and TestReloadNoODataID cover the guard clauses.
+func TestReloadGuards(t *testing.T) {
+	noClient := &Entity{ODataID: reloadThermalURI}
+	if _, err := Reload[Entity](noClient, nil); err == nil {
+		t.Error("expected error when no client is set")
+	}
+
+	noURI := &Entity{}
+	noURI.SetClient(&TestClient{})
+	if _, err := Reload[Entity](noURI, nil); err == nil {
+		t.Error("expected error when object has no @odata.id")
+	}
+}

--- a/schemas/testclient.go
+++ b/schemas/testclient.go
@@ -135,6 +135,11 @@ func (c *TestClient) performAction(action, url string, payload any, customHeader
 	}
 
 	resp := customReturnForAction.(*http.Response)
+	// Mirror the real client: a 304 is a successful conditional-GET response
+	// returned intact alongside the ErrNotModified sentinel.
+	if resp.StatusCode == http.StatusNotModified {
+		return resp, ErrNotModified
+	}
 	if resp.StatusCode != 200 && resp.StatusCode != 201 && resp.StatusCode != 202 && resp.StatusCode != 204 {
 		defer DeferredCleanupHTTPResponse(resp)
 		payload, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
There are a lot of times where you have an object and need to periodically re-fetch it to check if anything has changed or if a certain condition has been met. Fetching the full object when nothing has changed adds network and BMC overhead. There is the `If-Not-Match` header that can be used to optimize this. If that header is sent, along with the ETag from the last object fetch, it will return 304 indicating it has not changed.

Unfortunately the current GetObject handling does not handle this well. But since we always need to have an initial Get of the object, which includes its etag, we know we'll have an existing copy where it's needed for checking if it has changed. This adds a `Refresh` method that will try to fetch the object. If it has not changed, then the caller will just get the same object back. If it _has_ changed, then it will update the object to its current system state.

Thanks to @jskswamy for pointing out this gap and the initial idea for how to address it.

Closes: #527 