### PR TITLE
Restore manager OemLinks

### DIFF
--- a/oem/dell/manager.go
+++ b/oem/dell/manager.go
@@ -16,6 +16,10 @@ type Manager struct {
 	schemas.Manager
 
 	importSystemConfigTarget string
+
+	// DellServiceLinks are the links to the Dell attribute resources found under
+	// Links.Oem.Dell.DellAttributes of the manager.
+	DellServiceLinks []string
 }
 
 type ISCExecutionMode string
@@ -112,6 +116,19 @@ func FromManager(manager *schemas.Manager) (*Manager, error) {
 	}
 
 	m.importSystemConfigTarget = tmp.Actions.Oem.ImportSystemConfiguration.Target
+
+	type oemLinks struct {
+		Dell struct {
+			DellAttributes schemas.Links `json:"DellAttributes"`
+		} `json:"Dell"`
+	}
+	var links oemLinks
+	if len(manager.OEMLinks) > 0 {
+		if err := json.Unmarshal(manager.OEMLinks, &links); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal Dell OEM manager links: %w", err)
+		}
+	}
+	m.DellServiceLinks = links.Dell.DellAttributes.ToStrings()
 
 	return &m, nil
 }

--- a/oem/dell/manager_test.go
+++ b/oem/dell/manager_test.go
@@ -302,4 +302,18 @@ func TestDellManager(t *testing.T) {
 	if result.importSystemConfigTarget != "/redfish/v1/Managers/iDRAC.Embedded.1/Actions/Oem/EID_674_Manager.ImportSystemConfiguration" {
 		t.Errorf("Invalid ImportSystemConfig link: %s", result.importSystemConfigTarget)
 	}
+
+	expectedAttributes := []string{
+		"/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellAttributes/iDRAC.Embedded.1",
+		"/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellAttributes/System.Embedded.1",
+		"/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellAttributes/LifecycleController.Embedded.1",
+	}
+	if len(result.DellServiceLinks) != len(expectedAttributes) {
+		t.Fatalf("Expected %d DellServiceLinks, got %d", len(expectedAttributes), len(result.DellServiceLinks))
+	}
+	for i, want := range expectedAttributes {
+		if got := result.DellServiceLinks[i]; got != want {
+			t.Errorf("DellServiceLinks[%d]: expected %s, got %s", i, want, got)
+		}
+	}
 }

--- a/schemas/manager.go
+++ b/schemas/manager.go
@@ -269,6 +269,8 @@ type Manager struct {
 	// object contains shall conform to the Redfish Specification-described
 	// requirements.
 	OEM json.RawMessage `json:"Oem"`
+	// OEMLinks are all OEM data under the 'Links' section.
+	OEMLinks json.RawMessage
 	// OEMSecurityMode shall the OEM-specific security compliance mode(s) that the
 	// manager is currently configured to enforce. This property shall only be
 	// present if 'SecurityMode' contains 'OEM'.
@@ -458,16 +460,17 @@ func (m *Manager) UnmarshalJSON(b []byte) error {
 		UpdateSecurityMode ActionTarget `json:"#Manager.UpdateSecurityMode"`
 	}
 	type mLinks struct {
-		ActiveSoftwareImage Link  `json:"ActiveSoftwareImage"`
-		ManagedBy           Links `json:"ManagedBy"`
-		ManagerForChassis   Links `json:"ManagerForChassis"`
-		ManagerForFabrics   Links `json:"ManagerForFabrics"`
-		ManagerForManagers  Links `json:"ManagerForManagers"`
-		ManagerForServers   Links `json:"ManagerForServers"`
-		ManagerForSwitches  Links `json:"ManagerForSwitches"`
-		ManagerInChassis    Link  `json:"ManagerInChassis"`
-		SelectedNetworkPort Link  `json:"SelectedNetworkPort"`
-		SoftwareImages      Links `json:"SoftwareImages"`
+		ActiveSoftwareImage Link            `json:"ActiveSoftwareImage"`
+		ManagedBy           Links           `json:"ManagedBy"`
+		ManagerForChassis   Links           `json:"ManagerForChassis"`
+		ManagerForFabrics   Links           `json:"ManagerForFabrics"`
+		ManagerForManagers  Links           `json:"ManagerForManagers"`
+		ManagerForServers   Links           `json:"ManagerForServers"`
+		ManagerForSwitches  Links           `json:"ManagerForSwitches"`
+		ManagerInChassis    Link            `json:"ManagerInChassis"`
+		SelectedNetworkPort Link            `json:"SelectedNetworkPort"`
+		SoftwareImages      Links           `json:"SoftwareImages"`
+		OEM                 json.RawMessage `json:"Oem"`
 	}
 	var tmp struct {
 		temp
@@ -516,6 +519,7 @@ func (m *Manager) UnmarshalJSON(b []byte) error {
 	m.managerInChassis = tmp.Links.ManagerInChassis.String()
 	m.selectedNetworkPort = tmp.Links.SelectedNetworkPort.String()
 	m.softwareImages = tmp.Links.SoftwareImages.ToStrings()
+	m.OEMLinks = tmp.Links.OEM
 	m.certificates = tmp.Certificates.String()
 	m.dedicatedNetworkPorts = tmp.DedicatedNetworkPorts.String()
 	m.ethernetInterfaces = tmp.EthernetInterfaces.String()


### PR DESCRIPTION
Since the switch to generated manager.go, the OemLinks field got lost.
Restore it, and while at it, also parse some of it for Dell.
I haven't hooked it up in the generator as I'm not sure exactly in which shape it is as it does not seem to be generating the current state of the files