### PR TITLE
Handle numeric AccountService ETags

### DIFF
--- a/schemas/accountservice.go
+++ b/schemas/accountservice.go
@@ -8,6 +8,7 @@
 package schemas
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -400,15 +401,44 @@ type AccountService struct {
 	RawData []byte
 }
 
+type accountServiceODataEtag string
+
+func (e *accountServiceODataEtag) UnmarshalJSON(b []byte) error {
+	b = bytes.TrimSpace(b)
+	if bytes.Equal(b, []byte("null")) {
+		*e = ""
+		return nil
+	}
+
+	if len(b) > 0 && b[0] == '"' {
+		var value string
+		if err := json.Unmarshal(b, &value); err != nil {
+			return fmt.Errorf("invalid AccountService @odata.etag: %w", err)
+		}
+
+		*e = accountServiceODataEtag(value)
+		return nil
+	}
+
+	var value json.Number
+	if err := json.Unmarshal(b, &value); err != nil {
+		return fmt.Errorf("AccountService @odata.etag must be a string, number, or null: %w", err)
+	}
+
+	*e = accountServiceODataEtag(value.String())
+	return nil
+}
+
 // UnmarshalJSON unmarshals a AccountService object from the raw JSON.
 func (a *AccountService) UnmarshalJSON(b []byte) error {
 	type temp AccountService
 	var tmp struct {
 		temp
-		Accounts                           Link `json:"Accounts"`
-		AdditionalExternalAccountProviders Link `json:"AdditionalExternalAccountProviders"`
-		PrivilegeMap                       Link `json:"PrivilegeMap"`
-		Roles                              Link `json:"Roles"`
+		ODataEtag                          accountServiceODataEtag `json:"@odata.etag"`
+		Accounts                           Link                    `json:"Accounts"`
+		AdditionalExternalAccountProviders Link                    `json:"AdditionalExternalAccountProviders"`
+		PrivilegeMap                       Link                    `json:"PrivilegeMap"`
+		Roles                              Link                    `json:"Roles"`
 	}
 
 	err := json.Unmarshal(b, &tmp)
@@ -417,6 +447,7 @@ func (a *AccountService) UnmarshalJSON(b []byte) error {
 	}
 
 	*a = AccountService(tmp.temp)
+	a.ODataEtag = string(tmp.ODataEtag)
 
 	// Extract the links to other entities for later
 	a.accounts = tmp.Accounts.String()

--- a/schemas/accountservice_test.go
+++ b/schemas/accountservice_test.go
@@ -295,6 +295,64 @@ func TestAccountService(t *testing.T) {
 	}
 }
 
+func TestAccountServiceNumericODataEtag(t *testing.T) {
+	body := strings.Replace(
+		accountServiceBody,
+		`"@odata.etag": "\"126793801710\""`,
+		`"@odata.etag": 87422082150`,
+		1,
+	)
+
+	var result AccountService
+	err := json.Unmarshal([]byte(body), &result)
+	if err != nil {
+		t.Fatalf("Error decoding JSON: %s", err)
+	}
+
+	if result.ODataEtag != "87422082150" {
+		t.Errorf("Received invalid OData ETag: %s", result.ODataEtag)
+	}
+
+	if result.ID != "RemoteAccountService" {
+		t.Errorf("Received invalid ID: %s", result.ID)
+	}
+
+	if result.accounts != "/redfish/v1/AccountService/Accounts" {
+		t.Errorf("Received invalid Accounts: %s", result.accounts)
+	}
+}
+
+func TestAccountServiceODataEtagTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		wantEtag string
+		wantErr  bool
+	}{
+		{name: "string", body: `{"@odata.etag":"W/\"123\""}`, wantEtag: `W/"123"`},
+		{name: "number", body: `{"@odata.etag":87422082150}`, wantEtag: "87422082150"},
+		{name: "null", body: `{"@odata.etag":null}`},
+		{name: "missing", body: `{}`},
+		{name: "boolean", body: `{"@odata.etag":true}`, wantErr: true},
+		{name: "object", body: `{"@odata.etag":{}}`, wantErr: true},
+		{name: "array", body: `{"@odata.etag":[]}`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result AccountService
+			err := json.Unmarshal([]byte(tt.body), &result)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Unmarshal() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if result.ODataEtag != tt.wantEtag {
+				t.Errorf("ODataEtag = %q, want %q", result.ODataEtag, tt.wantEtag)
+			}
+		})
+	}
+}
+
 // TestAccountServiceUpdate tests the Update call for the account service.
 func TestAccountServiceUpdate(t *testing.T) {
 	var result AccountService


### PR DESCRIPTION
Some Redfish implementations return `AccountService.@odata.etag` as a JSON number. This currently fails because `Entity.ODataEtag` is a string.

Accept string, number, null, or a missing value for AccountService ETags and normalize numbers to their string representation. Other JSON types remain invalid, and the public API is unchanged.

Tests:
- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `go vet ./...`

Fixes #545