### PR TITLE
Add PatchWithTask and UpdateBiosAttributesApplyAtWithTask

### DIFF
--- a/schemas/bios.go
+++ b/schemas/bios.go
@@ -176,6 +176,13 @@ func (bi *Bios) AllowedAttributeUpdateApplyTimes() []SettingsApplyTime {
 
 // UpdateBiosAttributesApplyAt is used to update attribute values and set apply time together
 func (bi *Bios) UpdateBiosAttributesApplyAt(attrs SettingsAttributes, applyTime SettingsApplyTime) error {
+	_, err := bi.UpdateBiosAttributesApplyAtWithTask(attrs, applyTime)
+	return err
+}
+
+// UpdateBiosAttributesApplyAtWithTask is used to update attribute values and set apply time
+// together. It returns a TaskMonitorInfo when the service processes the update asynchronously.
+func (bi *Bios) UpdateBiosAttributesApplyAtWithTask(attrs SettingsAttributes, applyTime SettingsApplyTime) (*TaskMonitorInfo, error) {
 	payload := make(map[string]any)
 
 	// Get a representation of the object's original state so we can find what
@@ -183,7 +190,7 @@ func (bi *Bios) UpdateBiosAttributesApplyAt(attrs SettingsAttributes, applyTime 
 	original := new(Bios)
 	err := original.UnmarshalJSON(bi.rawData)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	for key := range attrs {
@@ -196,30 +203,27 @@ func (bi *Bios) UpdateBiosAttributesApplyAt(attrs SettingsAttributes, applyTime 
 	resp, err := bi.GetClient().Get(bi.settingsTarget)
 	defer DeferredCleanupHTTPResponse(resp)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	// If there are any allowed updates, try to send updates to the system and
-	// return the result.
-	if len(payload) > 0 {
-		data := map[string]any{"Attributes": payload}
-		if applyTime != "" {
-			data["@Redfish.SettingsApplyTime"] = map[string]string{"ApplyTime": string(applyTime)}
-		}
-
-		var header = make(map[string]string)
-		if resp.Header["Etag"] != nil {
-			header["If-Match"] = resp.Header["Etag"][0]
-		}
-
-		resp, err = bi.GetClient().PatchWithHeaders(bi.settingsTarget, data, header)
-		defer DeferredCleanupHTTPResponse(resp)
-		if err != nil {
-			return err
-		}
+	// If there are no allowed updates, there is nothing to send.
+	if len(payload) == 0 {
+		return nil, nil
 	}
 
-	return nil
+	data := map[string]any{"Attributes": payload}
+	if applyTime != "" {
+		data["@Redfish.SettingsApplyTime"] = map[string]string{"ApplyTime": string(applyTime)}
+	}
+
+	header := make(map[string]string)
+	if resp.Header["Etag"] != nil {
+		header["If-Match"] = resp.Header["Etag"][0]
+	}
+
+	patchResp, taskInfo, err := PatchWithTask(bi.client, bi.settingsTarget, data, header)
+	defer DeferredCleanupHTTPResponse(patchResp)
+	return taskInfo, err
 }
 
 // UpdateBiosAttributes is used to update attribute values.

--- a/schemas/bios_test.go
+++ b/schemas/bios_test.go
@@ -5,7 +5,10 @@
 package schemas
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 )
@@ -248,5 +251,77 @@ func TestUpdateBiosAttributesApplyAt(t *testing.T) {
 
 	if !strings.Contains(calls[1].Payload, "@Redfish.SettingsApplyTime") {
 		t.Error("Expected 'SettingsApplyTime' to be present")
+	}
+}
+
+// TestUpdateBiosAttributesApplyAtWithTask tests that UpdateBiosAttributesApplyAtWithTask
+// returns a TaskMonitorInfo when the service processes the update asynchronously.
+func TestUpdateBiosAttributesApplyAtWithTask(t *testing.T) {
+	var result Bios
+	err := json.NewDecoder(strings.NewReader(biosBody)).Decode(&result)
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+
+	testClient := &TestClient{
+		CustomReturnForActions: map[string][]any{
+			http.MethodPatch: {
+				&http.Response{
+					StatusCode: http.StatusAccepted,
+					Header:     http.Header{"Location": []string{"/redfish/v1/TaskService/Tasks/1"}},
+					Body:       io.NopCloser(bytes.NewBufferString("")),
+				},
+			},
+		},
+	}
+	result.SetClient(testClient)
+
+	update := SettingsAttributes{"AssetTag": "test"}
+	taskInfo, err := result.UpdateBiosAttributesApplyAtWithTask(update, AtMaintenanceWindowStartSettingsApplyTime)
+	if err != nil {
+		t.Errorf("Error making UpdateBiosAttributesApplyAtWithTask call: %s", err)
+	}
+
+	if taskInfo == nil {
+		t.Fatal("Expected a TaskMonitorInfo to be returned, got nil")
+	}
+	if taskInfo.TaskMonitor != "/redfish/v1/TaskService/Tasks/1" {
+		t.Errorf("Unexpected task monitor URI: %s", taskInfo.TaskMonitor)
+	}
+
+	calls := testClient.CapturedCalls()
+	if len(calls) != 2 {
+		t.Errorf("Expected two calls to be made, captured: %v", calls)
+	}
+
+	if !strings.Contains(calls[1].Payload, "AssetTag") {
+		t.Errorf("Unexpected update payload: %s", calls[1].Payload)
+	}
+
+	if !strings.Contains(calls[1].Payload, "@Redfish.SettingsApplyTime") {
+		t.Error("Expected 'SettingsApplyTime' to be present")
+	}
+}
+
+// TestUpdateBiosAttributesApplyAtWithTaskSync tests that UpdateBiosAttributesApplyAtWithTask
+// returns a nil TaskMonitorInfo when the service applies the update synchronously.
+func TestUpdateBiosAttributesApplyAtWithTaskSync(t *testing.T) {
+	var result Bios
+	err := json.NewDecoder(strings.NewReader(biosBody)).Decode(&result)
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+
+	testClient := &TestClient{}
+	result.SetClient(testClient)
+
+	update := SettingsAttributes{"AssetTag": "test"}
+	taskInfo, err := result.UpdateBiosAttributesApplyAtWithTask(update, AtMaintenanceWindowStartSettingsApplyTime)
+	if err != nil {
+		t.Errorf("Error making UpdateBiosAttributesApplyAtWithTask call: %s", err)
+	}
+
+	if taskInfo != nil {
+		t.Errorf("Expected no TaskMonitorInfo for a synchronous update, got: %v", taskInfo)
 	}
 }

--- a/schemas/task_monitor.go
+++ b/schemas/task_monitor.go
@@ -79,6 +79,50 @@ func postObjectWithTask[T any,
 	return entity, nil, err
 }
 
+func PatchObject[T any,
+	PT GenericSchemaObjectPointer[T],
+](c Client, uri string, payload any, headers map[string]string) (*T, *TaskMonitorInfo, error) {
+	return patchObjectWithTask[T, PT](c, uri, payload, headers)
+}
+
+func PatchWithTask(c Client, uri string, payload any, headers map[string]string) (*http.Response, *TaskMonitorInfo, error) {
+	resp, err := c.PatchWithHeaders(uri, payload, headers)
+
+	// If 412 Precondition Failed, retry without If-Match header.
+	// Some BMC implementations (e.g., Dell iDRAC10) reject If-Match
+	// on PATCH endpoints.
+	if err != nil && Is412PreconditionFailed(err) {
+		DeferredCleanupHTTPResponse(resp)
+		delete(headers, "If-Match")
+		resp, err = c.PatchWithHeaders(uri, payload, headers)
+	}
+
+	if err != nil {
+		defer DeferredCleanupHTTPResponse(resp)
+		return nil, nil, err
+	}
+
+	if resp.StatusCode == http.StatusAccepted {
+		defer DeferredCleanupHTTPResponse(resp)
+		taskMonitorInfo := ParseTaskMonitorInfo(c, resp)
+		return nil, taskMonitorInfo, nil
+	}
+	return resp, nil, nil
+}
+
+func patchObjectWithTask[T any,
+	PT GenericSchemaObjectPointer[T],
+](c Client, uri string, payload any, headers map[string]string) (*T, *TaskMonitorInfo, error) {
+	resp, taskMonitor, err := PatchWithTask(c, uri, payload, headers)
+	defer DeferredCleanupHTTPResponse(resp)
+	if taskMonitor != nil {
+		return nil, taskMonitor, err
+	}
+
+	entity, err := DecodeGenericEntity[T, PT](c, resp)
+	return entity, nil, err
+}
+
 func ParseTaskMonitorInfo(c Client, resp *http.Response) *TaskMonitorInfo {
 	// https://www.dmtf.org/sites/default/files/standards/documents/DSP0266_1.23.0.html#asynchronous-operations
 	// When a client issues a request that results in a long-running operation,

--- a/schemas/task_monitor_test.go
+++ b/schemas/task_monitor_test.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
+//nolint:dupl
 package schemas
 
 import (
@@ -206,6 +207,227 @@ func TestPostWithTask(t *testing.T) { //nolint: funlen
 			}
 		})
 	}
+}
+
+func TestPatchWithTask(t *testing.T) { //nolint: funlen
+	tests := map[string]struct {
+		response         http.Response
+		expectedTask     *TaskMonitorInfo
+		expectedResponse bool
+		expectedErr      string
+	}{
+		"patch with sync response": {
+			response: http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewBufferString("{}")),
+			},
+			expectedResponse: true,
+		},
+		"patch with task monitor location": {
+			response: http.Response{
+				StatusCode: http.StatusAccepted,
+				Header: http.Header{
+					"Location": []string{"/TaskMonitor/1"},
+				},
+				Body: io.NopCloser(bytes.NewBufferString("garbage")),
+			},
+			expectedTask: &TaskMonitorInfo{
+				TaskMonitor: "/TaskMonitor/1",
+			},
+		},
+		"patch with task monitor location and retry after seconds": {
+			response: http.Response{
+				StatusCode: http.StatusAccepted,
+				Header: http.Header{
+					"Location": []string{"/TaskMonitor/1"},
+					// Retry-After is tested separately, use an absolute time to avoid delta diffs
+					"Retry-After": []string{"Wed, 21 Oct 2015 07:28:00 GMT"},
+				},
+				Body: io.NopCloser(bytes.NewBufferString("garbage")),
+			},
+			expectedTask: &TaskMonitorInfo{
+				TaskMonitor: "/TaskMonitor/1",
+				RetryAfter:  time.Date(2015, 10, 21, 7, 28, 0, 0, time.UTC),
+			},
+		},
+		"patch with task monitor location, retry after and task body": {
+			response: http.Response{
+				StatusCode: http.StatusAccepted,
+				Header: http.Header{
+					"Location": []string{"/TaskMonitor/1"},
+					// Retry-After is tested separately, use an absolute time to avoid delta diffs
+					"Retry-After": []string{"Wed, 21 Oct 2015 07:28:00 GMT"},
+				},
+				Body: io.NopCloser(
+					bytes.NewBufferString(
+						`{"@odata.id": "/TaskService/Tasks/1", "@odata.type": "Task"}`,
+					),
+				),
+			},
+			expectedTask: &TaskMonitorInfo{
+				TaskMonitor: "/TaskMonitor/1",
+				RetryAfter:  time.Date(2015, 10, 21, 7, 28, 0, 0, time.UTC),
+				Task: &Task{
+					Entity: Entity{
+						ODataID: "/TaskService/Tasks/1",
+					},
+					ODataType: "Task", // not actually the spec string
+				},
+			},
+		},
+		"patch with error response": {
+			response: http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       io.NopCloser(bytes.NewBufferString("{}")),
+			},
+			expectedErr: "500: {}",
+		},
+	}
+
+	// Additional tests for 412 Precondition Failed fallback
+	t.Run("patch succeeds on first try without fallback", func(t *testing.T) {
+		c := &TestClient{
+			CustomReturnForActions: map[string][]any{
+				http.MethodPatch: {
+					&http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(bytes.NewBufferString("{}")),
+					},
+				},
+			},
+		}
+		res, _, err := PatchWithTask(c, "/redfish/v1/Systems/1", map[string]string{}, map[string]string{"If-Match": `W/"gen-1"`})
+		RequireNoError(t, err)
+		if res == nil {
+			t.Fatal("expected response, got nil")
+		}
+		calls := c.CapturedCalls()
+		if len(calls) != 1 {
+			t.Fatalf("expected 1 call (no fallback), got %d", len(calls))
+		}
+	})
+
+	t.Run("patch retries without If-Match on 412", func(t *testing.T) {
+		c := &TestClient{
+			CustomReturnForActions: map[string][]any{
+				http.MethodPatch: {
+					&http.Response{
+						StatusCode: http.StatusPreconditionFailed,
+						Body:       io.NopCloser(bytes.NewBufferString(`{"error":{"code":"Base.1.18.PreconditionFailed","message":"ETag mismatch"}}`)),
+					},
+					&http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(bytes.NewBufferString("{}")),
+					},
+				},
+			},
+		}
+		headers := map[string]string{"If-Match": `W/"gen-1"`}
+		res, _, err := PatchWithTask(c, "/redfish/v1/Systems/1", map[string]string{}, headers)
+		RequireNoError(t, err)
+		if res == nil {
+			t.Fatal("expected response, got nil")
+		}
+		calls := c.CapturedCalls()
+		if len(calls) != 2 {
+			t.Fatalf("expected 2 calls (412 + retry), got %d", len(calls))
+		}
+		// Verify If-Match was removed on retry
+		if _, ok := headers["If-Match"]; ok {
+			t.Error("expected If-Match to be removed from headers after 412 fallback")
+		}
+	})
+
+	t.Run("patch 412 fallback still fails with different error", func(t *testing.T) {
+		c := &TestClient{
+			CustomReturnForActions: map[string][]any{
+				http.MethodPatch: {
+					&http.Response{
+						StatusCode: http.StatusPreconditionFailed,
+						Body:       io.NopCloser(bytes.NewBufferString(`{"error":{"code":"Base.1.18.PreconditionFailed","message":"ETag mismatch"}}`)),
+					},
+					&http.Response{
+						StatusCode: http.StatusBadRequest,
+						Body:       io.NopCloser(bytes.NewBufferString(`{"error":{"code":"Base.1.18.GeneralError","message":"Bad request"}}`)),
+					},
+				},
+			},
+		}
+		_, _, err := PatchWithTask(c, "/redfish/v1/Systems/1", map[string]string{}, map[string]string{"If-Match": `W/"gen-1"`})
+		RequireErrorContains(t, err, "400")
+		calls := c.CapturedCalls()
+		if len(calls) != 2 {
+			t.Fatalf("expected 2 calls (412 + retry), got %d", len(calls))
+		}
+	})
+
+	testURI := "/redfish/v1/Systems/1"
+	testPayload := map[string]string{}
+	var testHeaders map[string]string
+
+	for name, test := range tests {
+		test := test // to support older go
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			c := &TestClient{
+				CustomReturnForActions: map[string][]any{
+					http.MethodPatch: {&test.response},
+				},
+			}
+
+			res, taskMonitorInfo, err := PatchWithTask(c, testURI, testPayload, testHeaders)
+			if test.expectedErr != "" {
+				RequireErrorContains(t, err, test.expectedErr)
+			} else {
+				RequireNoError(t, err)
+			}
+
+			if test.expectedTask != nil && test.expectedTask.Task != nil {
+				test.expectedTask.Task.SetClient(c)
+			}
+
+			if test.expectedResponse {
+				AssertEqual(t, &test.response, res)
+			} else if test.expectedTask != nil {
+				AssertEqualMsg(t, test.expectedTask.TaskMonitor, taskMonitorInfo.TaskMonitor,
+					"expected task monitor %q, actual %q",
+					test.expectedTask.TaskMonitor, taskMonitorInfo.TaskMonitor)
+				if test.expectedTask.Task != nil {
+					AssertEqualMsg(t, test.expectedTask.Task.ID, taskMonitorInfo.Task.ID,
+						"expected task ID [%q], actual [%q]",
+						test.expectedTask.Task.ID, taskMonitorInfo.Task.ID)
+				}
+			}
+		})
+	}
+}
+
+func TestPatchObject(t *testing.T) {
+	raw := `{"PowerState": "On"}`
+	c := &TestClient{
+		CustomReturnForActions: map[string][]any{
+			http.MethodPatch: {
+				&http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBufferString(raw)),
+				},
+			},
+		},
+	}
+
+	expected := &ComputerSystem{
+		PowerState: "On",
+		RawData:    []byte(raw),
+	}
+	expected.SetClient(c)
+
+	object, taskMonitor, err := PatchObject[ComputerSystem](c, "/redfish/v1/Systems/1", map[string]string{}, nil)
+	RequireNoError(t, err)
+	if taskMonitor != nil {
+		t.Fatalf("expected no task monitor, got %v", taskMonitor)
+	}
+	AssertEqual(t, expected, object)
 }
 
 func TestWaitForTaskMonitor(t *testing.T) { //nolint: funlen


### PR DESCRIPTION
Based on the discussion in #472, this PR adds `PatchWithTask` and `UpdateBiosAttributesApplyAtWithTask`.

Since `UpdateBiosAttributesApplyAt` is the only place I observed a BMC to return a task monitor on a PATCH method, this PR only adds `...WithTask` for this function. That being said, other cases can be added later on pretty easily.

Closes: #472