### PR TITLE
Keep order to parallel object retrieval

### DIFF
--- a/schemas/collection.go
+++ b/schemas/collection.go
@@ -175,18 +175,16 @@ func CollectResourceCollection[T any, PT interface {
 	*T
 	SchemaObject
 }](get func(PT, ...QueryGroupOption), entities []PT, queryOpts ...QueryGroupOption) {
-	// Only allow three concurrent requests to avoid overwhelming the service
-	limiter := make(chan struct{}, 3)
+	// Concurrency is bounded at the HTTP layer by the client's
+	// MaxConcurrentRequests setting, so no additional cap is applied here.
 	var wg sync.WaitGroup
 
 	for _, itemLink := range entities {
 		wg.Add(1)
-		limiter <- struct{}{}
 
 		go func(itemLink PT, _ ...QueryGroupOption) {
 			defer wg.Done()
 			get(itemLink)
-			<-limiter
 		}(itemLink, queryOpts...)
 	}
 
@@ -197,55 +195,48 @@ func GetCollectionObjects[T any, PT interface {
 	*T
 	SchemaObject
 }](c Client, uri string, queryOpts ...QueryGroupOption) ([]*T, error) {
-	var result []*T
 	if uri == "" {
-		return result, nil
+		return nil, nil
 	}
 
-	type GetResult struct {
-		Item  *T
-		Link  string
-		Error error
-	}
-
-	ch := make(chan GetResult)
 	collectionError := NewCollectionError()
-	get := func(entity PT, opts ...QueryGroupOption) {
-		if entity != nil && entity.GetID() != "" {
-			// if the entity has any ExtendedInfo, we assume it's an error
-			var err error
-			extendedInfo := entity.GetExtendedInfo()
-			if len(extendedInfo) > 0 {
-				errE := &Error{}
-				for i := range extendedInfo {
-					errE.ExtendedInfos = append(errE.ExtendedInfos, ErrExtendedInfo(extendedInfo[i]))
-				}
-				err = errE
-			}
 
-			entity.SetClient(c)
-
-			ch <- GetResult{Item: entity, Link: entity.GetODataID(), Error: err}
-		} else if entity != nil && entity.GetODataID() != "" {
-			link := entity.GetODataID()
-			entity, err := GetObject[T, PT](c, link, opts...)
-			ch <- GetResult{Item: entity, Link: link, Error: err}
-		}
+	// Gather the member entities in the order the service returned them, then
+	// resolve each concurrently into a slice indexed by that position so the
+	// result preserves the service's ordering regardless of fetch completion
+	// order.
+	members, err := collectMembers[T, PT](c, uri, queryOpts...)
+	if err != nil {
+		collectionError.Failures[uri] = err
 	}
 
-	go func() {
-		err := CollectListGeneric(get, c, uri, queryOpts...)
-		if err != nil {
-			collectionError.Failures[uri] = err
-		}
-		close(ch)
-	}()
+	type memberResult struct {
+		item *T
+		link string
+		err  error
+	}
 
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
-		} else {
-			result = append(result, r.Item)
+	// One goroutine per member, gated at the HTTP layer by the client
+	// semaphore (MaxConcurrentRequests).
+	results := make([]memberResult, len(members))
+	var wg sync.WaitGroup
+	for i, entity := range members {
+		wg.Add(1)
+		go func(i int, entity PT) {
+			defer wg.Done()
+			item, link, err := resolveMember[T, PT](c, entity, queryOpts...)
+			results[i] = memberResult{item: item, link: link, err: err}
+		}(i, entity)
+	}
+	wg.Wait()
+
+	var result []*T
+	for _, r := range results {
+		switch {
+		case r.err != nil:
+			collectionError.Failures[r.link] = r.err
+		case r.item != nil:
+			result = append(result, r.item)
 		}
 	}
 
@@ -254,4 +245,76 @@ func GetCollectionObjects[T any, PT interface {
 	}
 
 	return result, collectionError
+}
+
+// collectMembers gathers all member entities of a collection in the order the
+// service returned them, following pagination and falling back from $expand to
+// a plain query if the expanded request fails.
+func collectMembers[T any, PT interface {
+	*T
+	SchemaObject
+}](c Client, link string, queryOpts ...QueryGroupOption) ([]PT, error) {
+	collection, err := GetResourceCollection[T, PT](c, link, queryOpts...)
+	if err != nil {
+		// allow for auto-fallback from $expand to regular
+		// this will only run on the first query, not future pages
+		builtOpts := BuildQueryGroup(c, queryOpts...).QueryCollection
+		if builtOpts.expand != ExpandNone && builtOpts.expandFallback {
+			queryWithoutExpand := queryOpts
+			queryWithoutExpand = append(queryWithoutExpand,
+				WithCollectionQueryOpts(WithExpand(ExpandNone)))
+			collection, err = GetResourceCollection[T, PT](c, link, queryWithoutExpand...)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
+	}
+
+	members := collection.Members
+	if collection.MembersNextLink != "" {
+		next, err := collectMembers[T, PT](c, collection.MembersNextLink)
+		members = append(members, next...)
+		if err != nil {
+			return members, err
+		}
+	}
+	return members, nil
+}
+
+// resolveMember turns a collection member entity into a fully populated object.
+// A member returned inline (already carrying an ID) is used as-is; otherwise it
+// is fetched from its @odata.id. It returns the resolved object, the member
+// link (for error reporting), and any error.
+func resolveMember[T any, PT interface {
+	*T
+	SchemaObject
+}](c Client, entity PT, opts ...QueryGroupOption) (item *T, link string, err error) {
+	if entity == nil {
+		return nil, "", nil
+	}
+
+	if entity.GetID() != "" {
+		// if the entity has any ExtendedInfo, we assume it's an error
+		extendedInfo := entity.GetExtendedInfo()
+		if len(extendedInfo) > 0 {
+			errE := &Error{}
+			for i := range extendedInfo {
+				errE.ExtendedInfos = append(errE.ExtendedInfos, ErrExtendedInfo(extendedInfo[i]))
+			}
+			err = errE
+		}
+
+		entity.SetClient(c)
+		return entity, entity.GetODataID(), err
+	}
+
+	if entity.GetODataID() != "" {
+		link = entity.GetODataID()
+		item, err = GetObject[T, PT](c, link, opts...)
+		return item, link, err
+	}
+
+	return nil, "", nil
 }

--- a/schemas/collection_test.go
+++ b/schemas/collection_test.go
@@ -7,6 +7,8 @@ package schemas
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 )
@@ -52,6 +54,50 @@ func TestCollection(t *testing.T) {
 		endpoint := fmt.Sprintf(linkRoot, i+1)
 		if item != endpoint {
 			t.Errorf("Expected link to '%s', got '%s'", endpoint, item)
+		}
+	}
+}
+
+// TestGetCollectionObjectsOrder verifies that GetCollectionObjects returns
+// members in the order the service returned them, even though each member is
+// resolved concurrently.
+func TestGetCollectionObjectsOrder(t *testing.T) {
+	const count = 25
+
+	var members strings.Builder
+	for i := 1; i <= count; i++ {
+		if i > 1 {
+			members.WriteString(",")
+		}
+		fmt.Fprintf(&members,
+			`{"@odata.id":"/redfish/v1/Systems/System-%d","Id":"%d"}`, i, i)
+	}
+	body := fmt.Sprintf(
+		`{"@odata.id":"/redfish/v1/Systems","Members@odata.count":%d,"Members":[%s]}`,
+		count, members.String())
+
+	client := &TestClient{
+		CustomReturnForActions: map[string][]any{
+			http.MethodGet: {
+				&http.Response{
+					StatusCode: 200,
+					Body:       io.NopCloser(strings.NewReader(body)),
+				},
+			},
+		},
+	}
+
+	systems, err := GetCollectionObjects[ComputerSystem](client, "/redfish/v1/Systems")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(systems) != count {
+		t.Fatalf("expected %d members, got %d", count, len(systems))
+	}
+	for i, s := range systems {
+		want := fmt.Sprintf("%d", i+1)
+		if s.ID != want {
+			t.Errorf("member %d out of order: expected Id %q, got %q", i, want, s.ID)
 		}
 	}
 }

--- a/schemas/entity.go
+++ b/schemas/entity.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"sync"
 )
 
 // Entity provides the basis for all Redfish and Swordfish objects.
@@ -535,42 +536,37 @@ func DecodeGenericEntity[T any, PT GenericSchemaObjectPointer[T]](c Client, resp
 }
 
 // GetObjects retrieves multiple API objects concurrently from the service.
+// Results are returned in the same order as uris; failures are collected in
+// the returned CollectionError. Concurrency is bounded by the client's
+// MaxConcurrentRequests setting (enforced at the HTTP layer).
 func GetObjects[T any, PT interface {
 	*T
 	SchemaObject
 }](c Client, uris []string) ([]*T, error) {
-	var result []*T
 	if len(uris) == 0 {
-		return result, nil
+		return nil, nil
 	}
 
-	type GetResult struct {
-		Item  *T
-		Link  string
-		Error error
+	// One goroutine per uri, gated at the HTTP layer by the client semaphore.
+	items := make([]*T, len(uris))
+	errs := make([]error, len(uris))
+	var wg sync.WaitGroup
+	for i, link := range uris {
+		wg.Add(1)
+		go func(i int, link string) {
+			defer wg.Done()
+			items[i], errs[i] = GetObject[T, PT](c, link)
+		}(i, link)
 	}
+	wg.Wait()
 
-	ch := make(chan GetResult)
+	var result []*T
 	collectionError := NewCollectionError()
-
-	// Worker function to get a single object
-	get := func(link string) {
-		entity, err := GetObject[T, PT](c, link)
-		ch <- GetResult{Item: entity, Link: link, Error: err}
-	}
-
-	// Start workers for each URI
-	go func() {
-		CollectCollection(get, uris)
-		close(ch)
-	}()
-
-	// Process results
-	for r := range ch {
-		if r.Error != nil {
-			collectionError.Failures[r.Link] = r.Error
+	for i, link := range uris {
+		if errs[i] != nil {
+			collectionError.Failures[link] = errs[i]
 		} else {
-			result = append(result, r.Item)
+			result = append(result, items[i])
 		}
 	}
 


### PR DESCRIPTION
There is nothing in the spec that defines a deterministic order of results, so the stance so far has been to allow our concurrent collection of objects to just be whatever order we process them, expecting the library consumer to perform sorting based on their specific criteria.

Though service-side implementations are free to process in whatever order they wish, we can at least keep that order on our side. This changes the concurrent collection to collect into a positional index.

We also had a cap on this concurrent collection in addition to the overal MaxConcurrentRequests. This would limit collect based on the lesser of the two - either the hard coded limit of 3 or a lesser value of MacConcurrentRequests. This was partially done to make sure object collection couldn't overwhelm a system, but on revisiting it, I don't think there is much need since the MaxConcurrentRequests applies to all requests to the Redfish system. So this also removes that collection cap while we're at it.

Closes: #549