### PR TITLE
Handle updated SMC Syslog format

### DIFF
--- a/oem/smc/syslog.go
+++ b/oem/smc/syslog.go
@@ -11,6 +11,11 @@ import (
 	"github.com/stmcginnis/gofish/schemas"
 )
 
+type SyslogServer struct {
+	ServerIP string `json:"ServerIP"`
+	Port     *int   `json:"Port"`
+}
+
 // Syslog is an instance of a Syslog object.
 type Syslog struct {
 	schemas.Entity
@@ -18,6 +23,14 @@ type Syslog struct {
 	Enabled bool   `json:"EnableSyslog"`
 	Server  string `json:"SyslogServer"`
 	Port    int    `json:"SyslogPortNumber"`
+
+	// Servers is populated for both formats. On firmware that reports a
+	// singular server it holds the values from the first entry.
+	Servers []SyslogServer `json:"-"`
+
+	// serverCollection records whether the BMC reported SyslogServer as a
+	// collection, which determines the shape of the update payload.
+	serverCollection bool
 
 	// RawData holds the original serialized JSON so we can compare updates.
 	RawData []byte
@@ -28,6 +41,7 @@ func (i *Syslog) UnmarshalJSON(b []byte) error {
 	type temp Syslog
 	var t struct {
 		temp
+		SyslogServer json.RawMessage
 	}
 
 	err := json.Unmarshal(b, &t)
@@ -36,6 +50,37 @@ func (i *Syslog) UnmarshalJSON(b []byte) error {
 	}
 
 	*i = Syslog(t.temp)
+
+	// Starting with BMC firmware versions Gen 13 1.10 and Gen 14 1.08 the
+	// SyslogServer changed from a singular string value to an array of
+	// SyslogServer entries.
+	if len(t.SyslogServer) != 0 {
+		var servers []SyslogServer
+		if err := json.Unmarshal(t.SyslogServer, &servers); err == nil {
+			i.Servers = servers
+			i.serverCollection = true
+
+			// Capture first server for backwards compatibility
+			if len(servers) > 0 {
+				i.Server = servers[0].ServerIP
+				i.Port = 0
+				if servers[0].Port != nil {
+					i.Port = *servers[0].Port
+				}
+			}
+		} else {
+			// Not a collection, fall back to the singular string value.
+			if err := json.Unmarshal(t.SyslogServer, &i.Server); err != nil {
+				return err
+			}
+
+			server := SyslogServer{ServerIP: i.Server}
+			if i.Port != 0 {
+				server.Port = &i.Port
+			}
+			i.Servers = []SyslogServer{server}
+		}
+	}
 
 	// This is a read/write object, so we need to save the raw object data for later
 	i.RawData = b
@@ -53,6 +98,10 @@ func (i *Syslog) Update() error {
 		return err
 	}
 
+	if i.serverCollection {
+		return i.updateServers(orig)
+	}
+
 	readWriteFields := []string{
 		"Enabled",
 		"EnableSyslog",
@@ -66,6 +115,38 @@ func (i *Syslog) Update() error {
 	currentElement := reflect.ValueOf(i).Elem()
 
 	return i.Entity.Update(originalElement, currentElement, readWriteFields)
+}
+
+// updateServers sends updates to firmware that reports SyslogServer as a
+// collection. Server and Port mirror the first collection entry, so a change
+// to either is folded into that entry before the collection is sent.
+func (i *Syslog) updateServers(orig *Syslog) error {
+	servers := make([]SyslogServer, len(i.Servers))
+	copy(servers, i.Servers)
+
+	if len(servers) > 0 {
+		if i.Server != orig.Server {
+			servers[0].ServerIP = i.Server
+		}
+		if i.Port != orig.Port {
+			port := i.Port
+			servers[0].Port = &port
+		}
+	}
+
+	payload := map[string]any{}
+	if i.Enabled != orig.Enabled {
+		payload["EnableSyslog"] = i.Enabled
+	}
+	if !reflect.DeepEqual(servers, orig.Servers) {
+		payload["SyslogServer"] = servers
+	}
+
+	if len(payload) == 0 {
+		return nil
+	}
+
+	return i.Patch(i.ODataID, payload)
 }
 
 // GetSyslog will get a Syslog instance from the service.

--- a/oem/smc/syslog_test.go
+++ b/oem/smc/syslog_test.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/stmcginnis/gofish/schemas"
 )
 
 var syslogBody = `{
@@ -19,6 +21,29 @@ var syslogBody = `{
   "SyslogServer": "localhost",
   "SyslogPortNumber": 514,
   "@odata.etag": "\"b27af6393687bb1810b00fe52874e053\""
+}`
+
+var updatedBody = `{
+  "@odata.type": "#Syslog.v1_0_2.Syslog",
+  "@odata.id": "/redfish/v1/Managers/1/Oem/Supermicro/Syslog",
+  "Id": "Syslog",
+  "Name": "Syslog",
+  "EnableSyslog": true,
+  "SyslogServer": [
+    {
+      "ServerIP": "syslog.xxxx.yyy",
+      "Port": 514
+    },
+    {
+      "ServerIP": null,
+      "Port": null
+    },
+    {
+      "ServerIP": null,
+      "Port": null
+    }
+  ],
+  "@odata.etag": "\"deb0534b5f0661ee3e0ea15dc3d6023b\""
 }`
 
 // TestSyslog tests the parsing of Syslog objects.
@@ -38,6 +63,155 @@ func TestSyslog(t *testing.T) {
 	}
 
 	if result.Server != "localhost" {
+		t.Errorf("Invalid server: %s", result.Server)
+	}
+
+	if result.Port != 514 {
+		t.Errorf("Invalid port: %d", result.Port)
+	}
+}
+
+// TestSyslogUpdate tests updates against firmware reporting a single server.
+func TestSyslogUpdate(t *testing.T) {
+	var result Syslog
+	if err := json.NewDecoder(strings.NewReader(syslogBody)).Decode(&result); err != nil {
+		t.Fatalf("Error decoding JSON: %s", err)
+	}
+
+	testClient := &schemas.TestClient{}
+	result.SetClient(testClient)
+	result.Server = "syslog.example.com"
+	result.Port = 1514
+
+	if err := result.Update(); err != nil {
+		t.Fatalf("Error making Update call: %s", err)
+	}
+
+	calls := testClient.CapturedCalls()
+	if len(calls) != 1 {
+		t.Fatalf("Expected 1 call, got %d", len(calls))
+	}
+
+	if !strings.Contains(calls[0].Payload, "SyslogServer:syslog.example.com") {
+		t.Errorf("Unexpected server update payload: %s", calls[0].Payload)
+	}
+
+	if !strings.Contains(calls[0].Payload, "SyslogPortNumber:1514") {
+		t.Errorf("Unexpected port update payload: %s", calls[0].Payload)
+	}
+}
+
+// TestNewSyslogUpdate tests updates against firmware reporting a collection of
+// servers.
+func TestNewSyslogUpdate(t *testing.T) {
+	var result Syslog
+	if err := json.NewDecoder(strings.NewReader(updatedBody)).Decode(&result); err != nil {
+		t.Fatalf("Error decoding JSON: %s", err)
+	}
+
+	testClient := &schemas.TestClient{}
+	result.SetClient(testClient)
+	result.Servers[1].ServerIP = "syslog2.example.com"
+
+	if err := result.Update(); err != nil {
+		t.Fatalf("Error making Update call: %s", err)
+	}
+
+	calls := testClient.CapturedCalls()
+	if len(calls) != 1 {
+		t.Fatalf("Expected 1 call, got %d", len(calls))
+	}
+
+	if !strings.Contains(calls[0].Payload, "SyslogServer:[") {
+		t.Errorf("Expected a SyslogServer collection payload: %s", calls[0].Payload)
+	}
+
+	if !strings.Contains(calls[0].Payload, "syslog2.example.com") {
+		t.Errorf("Unexpected server update payload: %s", calls[0].Payload)
+	}
+}
+
+// TestNewSyslogUpdateFoldsSingularFields tests that changes to the backwards
+// compatible Server and Port fields are applied to the first collection entry.
+func TestNewSyslogUpdateFoldsSingularFields(t *testing.T) {
+	var result Syslog
+	if err := json.NewDecoder(strings.NewReader(updatedBody)).Decode(&result); err != nil {
+		t.Fatalf("Error decoding JSON: %s", err)
+	}
+
+	testClient := &schemas.TestClient{}
+	result.SetClient(testClient)
+	result.Server = "syslog.example.com"
+	result.Port = 1514
+
+	if err := result.Update(); err != nil {
+		t.Fatalf("Error making Update call: %s", err)
+	}
+
+	calls := testClient.CapturedCalls()
+	if len(calls) != 1 {
+		t.Fatalf("Expected 1 call, got %d", len(calls))
+	}
+
+	if !strings.Contains(calls[0].Payload, "syslog.example.com") {
+		t.Errorf("Server change not folded into the collection: %s", calls[0].Payload)
+	}
+}
+
+// TestSyslogUpdateNoChanges tests that no request is sent when nothing changed.
+func TestSyslogUpdateNoChanges(t *testing.T) {
+	for name, body := range map[string]string{"singular": syslogBody, "collection": updatedBody} {
+		t.Run(name, func(t *testing.T) {
+			var result Syslog
+			if err := json.NewDecoder(strings.NewReader(body)).Decode(&result); err != nil {
+				t.Fatalf("Error decoding JSON: %s", err)
+			}
+
+			testClient := &schemas.TestClient{}
+			result.SetClient(testClient)
+
+			if err := result.Update(); err != nil {
+				t.Fatalf("Error making Update call: %s", err)
+			}
+
+			if calls := testClient.CapturedCalls(); len(calls) != 0 {
+				t.Errorf("Expected no calls, got %d", len(calls))
+			}
+		})
+	}
+}
+
+// TestNewSyslog tests the parsing of updated Syslog objects that contain an
+// array of syslog server entries.
+func TestNewSyslog(t *testing.T) {
+	var result Syslog
+	err := json.NewDecoder(strings.NewReader(updatedBody)).Decode(&result)
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+
+	if result.ID != "Syslog" {
+		t.Errorf("Received invalid ID: %s", result.ID)
+	}
+
+	if !result.Enabled {
+		t.Errorf("Invalid enable state: %t", result.Enabled)
+	}
+
+	if len(result.Servers) != 3 {
+		t.Errorf("Expected 3 syslog server entries, got %d", len(result.Servers))
+	}
+
+	if result.Servers[0].ServerIP != "syslog.xxxx.yyy" {
+		t.Errorf("Invalid server: %s", result.Server)
+	}
+
+	if *result.Servers[0].Port != 514 {
+		t.Errorf("Invalid port: %d", result.Port)
+	}
+
+	// Check backwards compatibility
+	if result.Server != "syslog.xxxx.yyy" {
 		t.Errorf("Invalid server: %s", result.Server)
 	}
 


### PR DESCRIPTION
Starting with BMC firmware versions Gen 13 1.10 and Gen 14 1.08 the format of the Syslog SyslogServer property changes from a singular string to a collection of syslog server entries. This adds handling to work with either format. For some backwards compatibility the first entry in the collection will be set as the older Server and Port field values.

Closes: #552 