### PR TITLE
Add Dell iDRAC reset action discovery

### DIFF
--- a/oem/dell/idrac_monitor_test.go
+++ b/oem/dell/idrac_monitor_test.go
@@ -13,12 +13,6 @@ import (
 	"github.com/stmcginnis/gofish/schemas"
 )
 
-func TestIDRACReset(t *testing.T) {
-	// This would require a mock server, for now just test the basic functionality exists
-	// The actual implementation would need integration testing with a real or mocked iDRAC
-	t.Skip("Skipping iDRAC reset test - requires integration testing with real iDRAC or comprehensive mocking")
-}
-
 func TestIDRACMonitor_CheckHealth(t *testing.T) {
 	// Create a mock manager
 	baseManager := schemas.Manager{}

--- a/oem/dell/idrac_service.go
+++ b/oem/dell/idrac_service.go
@@ -5,48 +5,96 @@
 package dell
 
 import (
+	"encoding/json"
 	"errors"
-	"strconv"
+	"fmt"
 
 	"github.com/stmcginnis/gofish/schemas"
 )
 
-// iDRACResetType defines the type of reset to perform
-type iDRACResetType string
+// IDRACResetType defines the type of reset to perform.
+type IDRACResetType string
 
 const (
-	// GracefuliDRACReset performs a graceful reset of the iDRAC
-	GracefuliDRACReset iDRACResetType = "Graceful"
-	// ForceiDRACReset performs a forced reset of the iDRAC
-	ForceiDRACReset iDRACResetType = "Force"
+	// GracefuliDRACReset performs a graceful reset of the iDRAC.
+	GracefuliDRACReset IDRACResetType = "Graceful"
+	// ForceiDRACReset performs a forced reset of the iDRAC.
+	ForceiDRACReset IDRACResetType = "Force"
 )
 
-// iDRACResetRequest represents the body for iDRAC reset action
+// iDRACResetRequest represents the body for the iDRAC reset action.
 type iDRACResetRequest struct {
-	Force iDRACResetType `json:"Force"`
+	Force IDRACResetType `json:"Force"`
 }
 
-// ResetiDRAC performs a reset of the iDRAC card
-//
-// resetType specifies whether to perform a graceful or forced reset
-func (m *Manager) ResetiDRAC(resetType iDRACResetType) error {
-	request := iDRACResetRequest{
-		Force: resetType,
+// IDRACCardService represents Dell's DelliDRACCardService OEM resource.
+type IDRACCardService struct {
+	schemas.Entity
+
+	iDRACResetTarget string
+}
+
+// UnmarshalJSON unmarshals an IDRACCardService and its action targets.
+func (s *IDRACCardService) UnmarshalJSON(b []byte) error {
+	type temp IDRACCardService
+	var payload struct {
+		temp
+		Actions struct {
+			IDRACReset schemas.ActionTarget `json:"#DelliDRACCardService.iDRACReset"`
+		}
 	}
 
-	// Use the standard action target for iDRAC reset as documented
-	target := "/redfish/v1/Dell/Managers/iDRAC.Embedded.1/DelliDRACCardService/Actions/DelliDRACCardService.iDRACReset"
+	if err := json.Unmarshal(b, &payload); err != nil {
+		return err
+	}
 
-	resp, err := m.PostWithResponse(target, request)
+	*s = IDRACCardService(payload.temp)
+	s.iDRACResetTarget = payload.Actions.IDRACReset.Target
+	return nil
+}
+
+// Reset performs a graceful or forced iDRAC reset. A non-nil task monitor is
+// returned when the service accepts the reset asynchronously.
+func (s *IDRACCardService) Reset(resetType IDRACResetType) (*schemas.TaskMonitorInfo, error) {
+	if resetType != GracefuliDRACReset && resetType != ForceiDRACReset {
+		return nil, fmt.Errorf("invalid iDRAC reset type: %s", resetType)
+	}
+	if s.iDRACResetTarget == "" {
+		return nil, errors.New("iDRAC reset is not supported by this service")
+	}
+
+	request := iDRACResetRequest{Force: resetType}
+	resp, taskInfo, err := schemas.PostWithTask(
+		s.GetClient(), s.iDRACResetTarget, request, s.Headers(), false,
+	)
 	defer schemas.DeferredCleanupHTTPResponse(resp)
 	if err != nil {
-		return errors.New("failed to reset iDRAC: " + err.Error())
+		return nil, fmt.Errorf("failed to reset iDRAC: %w", err)
 	}
 
-	// Check for successful response codes (200, 201, etc.)
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return errors.New("iDRAC reset failed with status code: " + strconv.Itoa(resp.StatusCode))
+	return taskInfo, nil
+}
+
+// GetIDRACCardService gets an IDRACCardService from the service.
+func GetIDRACCardService(c schemas.Client, uri string) (*IDRACCardService, error) {
+	return schemas.GetObject[IDRACCardService](c, uri)
+}
+
+// ResetIDRAC performs a graceful or forced reset using the action advertised
+// by Dell's iDRAC card service. A non-nil task monitor indicates an asynchronous
+// response.
+func (m *Manager) ResetIDRAC(resetType IDRACResetType) (*schemas.TaskMonitorInfo, error) {
+	service, err := m.IDRACCardService()
+	if err != nil {
+		return nil, err
 	}
 
-	return nil
+	return service.Reset(resetType)
+}
+
+// ResetiDRAC performs a reset of the iDRAC card and retains the original API.
+// Use ResetIDRAC when the asynchronous task monitor is needed.
+func (m *Manager) ResetiDRAC(resetType IDRACResetType) error {
+	_, err := m.ResetIDRAC(resetType)
+	return err
 }

--- a/oem/dell/idrac_service_test.go
+++ b/oem/dell/idrac_service_test.go
@@ -1,0 +1,183 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package dell
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stmcginnis/gofish"
+	"github.com/stmcginnis/gofish/schemas"
+)
+
+const (
+	iDRACCardServiceURI = "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService"
+	iDRACResetURI       = iDRACCardServiceURI + "/Actions/DelliDRACCardService.iDRACReset"
+)
+
+func TestManagerResetIDRAC(t *testing.T) { //nolint:funlen
+	tests := []struct {
+		name             string
+		resetType        IDRACResetType
+		status           int
+		useCompatibility bool
+		expectTask       bool
+		expectError      bool
+	}{
+		{
+			name:             "synchronous forced reset through compatibility method",
+			resetType:        ForceiDRACReset,
+			status:           http.StatusOK,
+			useCompatibility: true,
+		},
+		{
+			name:      "created response completes synchronously",
+			resetType: ForceiDRACReset,
+			status:    http.StatusCreated,
+		},
+		{
+			name:       "asynchronous graceful reset returns task monitor",
+			resetType:  GracefuliDRACReset,
+			status:     http.StatusAccepted,
+			expectTask: true,
+		},
+		{
+			name:        "server error is returned",
+			resetType:   GracefuliDRACReset,
+			status:      http.StatusInternalServerError,
+			expectError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var postedResetType IDRACResetType
+			var serviceRequests int
+			var resetRequests int
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == schemas.DefaultServiceRoot:
+					_, _ = w.Write([]byte(`{"@odata.id":"/redfish/v1/","Id":"RootService","Name":"Root Service"}`))
+				case r.Method == http.MethodGet && r.URL.Path == iDRACCardServiceURI:
+					serviceRequests++
+					_, _ = fmt.Fprintf(w, `{
+						"@odata.id": %q,
+						"Id": "DelliDRACCardService",
+						"Actions": {
+							"#DelliDRACCardService.iDRACReset": {"target": %q}
+						}
+					}`, iDRACCardServiceURI, iDRACResetURI)
+				case r.Method == http.MethodPost && r.URL.Path == iDRACResetURI:
+					resetRequests++
+					var request iDRACResetRequest
+					if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+						t.Errorf("failed to decode reset request: %v", err)
+					}
+					postedResetType = request.Force
+					if test.status == http.StatusAccepted {
+						w.Header().Set("Location", "/redfish/v1/TaskService/TaskMonitors/1")
+						w.WriteHeader(test.status)
+						_, _ = w.Write([]byte(`{"@odata.id":"/redfish/v1/TaskService/Tasks/1","TaskState":"Running"}`))
+						return
+					}
+					w.WriteHeader(test.status)
+				default:
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+
+			client, err := gofish.Connect(gofish.ClientConfig{
+				Endpoint:   server.URL,
+				HTTPClient: server.Client(),
+			})
+			if err != nil {
+				t.Fatalf("failed to connect test client: %v", err)
+			}
+
+			manager := newDellManagerForIDRACReset(t, client)
+			var taskInfo *schemas.TaskMonitorInfo
+			if test.useCompatibility {
+				err = manager.ResetiDRAC(test.resetType)
+			} else {
+				taskInfo, err = manager.ResetIDRAC(test.resetType)
+			}
+			if test.expectError {
+				if err == nil || !strings.Contains(err.Error(), "500") {
+					t.Fatalf("expected server error, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("failed to reset iDRAC: %v", err)
+			}
+
+			if serviceRequests != 1 || resetRequests != 1 {
+				t.Fatalf("expected one service GET and one reset POST, got %d and %d", serviceRequests, resetRequests)
+			}
+			if postedResetType != test.resetType {
+				t.Errorf("expected reset type %q, got %q", test.resetType, postedResetType)
+			}
+			if test.expectTask {
+				if taskInfo == nil {
+					t.Fatal("expected task monitor, got nil")
+				}
+				if taskInfo.TaskMonitor != "/redfish/v1/TaskService/TaskMonitors/1" {
+					t.Errorf("unexpected task monitor URI: %s", taskInfo.TaskMonitor)
+				}
+				if taskInfo.Task == nil || taskInfo.Task.TaskState != schemas.RunningTaskState {
+					t.Errorf("unexpected task representation: %#v", taskInfo.Task)
+				}
+			} else if taskInfo != nil {
+				t.Errorf("expected synchronous response, got task: %#v", taskInfo)
+			}
+		})
+	}
+}
+
+func TestIDRACCardServiceResetValidation(t *testing.T) {
+	service := &IDRACCardService{}
+
+	if _, err := service.Reset(IDRACResetType("Invalid")); err == nil || !strings.Contains(err.Error(), "invalid iDRAC reset type") {
+		t.Fatalf("expected invalid reset type error, got %v", err)
+	}
+
+	if _, err := service.Reset(GracefuliDRACReset); err == nil || !strings.Contains(err.Error(), "not supported") {
+		t.Fatalf("expected unsupported reset error, got %v", err)
+	}
+}
+
+func TestManagerIDRACCardServiceUnsupported(t *testing.T) {
+	manager := &Manager{}
+	if _, err := manager.IDRACCardService(); err == nil || !strings.Contains(err.Error(), "not supported") {
+		t.Fatalf("expected unsupported service error, got %v", err)
+	}
+}
+
+func newDellManagerForIDRACReset(t *testing.T, client schemas.Client) *Manager {
+	t.Helper()
+
+	manager := &schemas.Manager{
+		RawData: []byte(`{}`),
+		OEMLinks: json.RawMessage(fmt.Sprintf(`{
+			"Dell": {
+				"DelliDRACCardService": {"@odata.id": %q}
+			}
+		}`, iDRACCardServiceURI)),
+	}
+	manager.SetClient(client)
+
+	dellManager, err := FromManager(manager)
+	if err != nil {
+		t.Fatalf("failed to convert Dell manager: %v", err)
+	}
+	return dellManager
+}

--- a/oem/dell/manager.go
+++ b/oem/dell/manager.go
@@ -16,6 +16,7 @@ type Manager struct {
 	schemas.Manager
 
 	importSystemConfigTarget string
+	iDRACCardService         string
 
 	// DellServiceLinks are the links to the Dell attribute resources found under
 	// Links.Oem.Dell.DellAttributes of the manager.
@@ -119,7 +120,8 @@ func FromManager(manager *schemas.Manager) (*Manager, error) {
 
 	type oemLinks struct {
 		Dell struct {
-			DellAttributes schemas.Links `json:"DellAttributes"`
+			DellAttributes       schemas.Links `json:"DellAttributes"`
+			DelliDRACCardService schemas.Link  `json:"DelliDRACCardService"`
 		} `json:"Dell"`
 	}
 	var links oemLinks
@@ -129,8 +131,18 @@ func FromManager(manager *schemas.Manager) (*Manager, error) {
 		}
 	}
 	m.DellServiceLinks = links.Dell.DellAttributes.ToStrings()
+	m.iDRACCardService = links.Dell.DelliDRACCardService.String()
 
 	return &m, nil
+}
+
+// IDRACCardService gets the Dell iDRAC card service linked by this manager.
+func (m *Manager) IDRACCardService() (*IDRACCardService, error) {
+	if m.iDRACCardService == "" {
+		return nil, errors.New("iDRAC card service is not supported by this manager")
+	}
+
+	return GetIDRACCardService(m.GetClient(), m.iDRACCardService)
 }
 
 // validateImportSystemConfigurationBody validates required fields in ImportSystemConfigurationBody

--- a/oem/dell/manager_test.go
+++ b/oem/dell/manager_test.go
@@ -303,6 +303,10 @@ func TestDellManager(t *testing.T) {
 		t.Errorf("Invalid ImportSystemConfig link: %s", result.importSystemConfigTarget)
 	}
 
+	if result.iDRACCardService != "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService" {
+		t.Errorf("Invalid iDRAC card service link: %s", result.iDRACCardService)
+	}
+
 	expectedAttributes := []string{
 		"/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellAttributes/iDRAC.Embedded.1",
 		"/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellAttributes/System.Embedded.1",


### PR DESCRIPTION
## Summary

- Discover the Dell `DelliDRACCardService` through the manager OEM links.
- Read the `#DelliDRACCardService.iDRACReset` target advertised by the service instead of posting to a fixed URI.
- Add the task-aware `ResetIDRAC` API while retaining `ResetiDRAC` as a compatibility wrapper.
- Validate reset types and add coverage for resource discovery, synchronous responses, asynchronous task monitors, and error cases.

## Motivation

The existing implementation constructs a fixed Dell OEM action URI containing a specific manager identifier. Redfish resources advertise both the related OEM service and its action target, so following those links avoids assumptions about the service path and manager name. It also allows callers to receive the task monitor returned when iDRAC accepts a reset asynchronously.

Dell documents the action on the [`DelliDRACCardService`](https://developer.dell.com/apis/1796449a-cc87-4882-925b-6241fbf1bfea/versions/1.30.xx/whats-new-9350m0) API.

## Compatibility

The existing `ResetiDRAC` method remains available and delegates to the new implementation. Existing reset constants are retained, with their type exported as `IDRACResetType`. Callers that need asynchronous task information can use `ResetIDRAC`.

## Testing

- `go test ./oem/dell`
- `make test`
- `make lint`
- `git diff --check`