### PR TITLE
Add live Dell iDRAC health checks

### DIFF
--- a/oem/dell/idrac_monitor.go
+++ b/oem/dell/idrac_monitor.go
@@ -8,149 +8,220 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
+	"net/http"
+	"syscall"
 	"time"
 
+	"github.com/stmcginnis/gofish"
 	"github.com/stmcginnis/gofish/schemas"
 )
 
-// iDRACMonitor monitors iDRAC responsiveness and can trigger resets
-type iDRACMonitor struct {
-	service        *schemas.Entity // Using Entity as base for service access
+const (
+	defaultIDRACMonitorTimeout       = 30 * time.Second
+	defaultIDRACMonitorMaxRetries    = 3
+	defaultIDRACMonitorRetryInterval = time.Second
+)
+
+// IDRACMonitor monitors iDRAC responsiveness and can trigger resets.
+type IDRACMonitor struct {
+	service        *schemas.Entity
 	manager        *Manager
 	timeout        time.Duration
 	maxRetries     int
+	retryInterval  time.Duration
 	resetOnTimeout bool
 }
 
-// iDRACMonitorConfig configures the iDRAC monitor
-type iDRACMonitorConfig struct {
-	// Timeout for individual requests
+// IDRACMonitorConfig configures the iDRAC monitor.
+type IDRACMonitorConfig struct {
+	// Timeout is the maximum duration of an individual health check. A value of
+	// zero disables the per-request timeout.
 	Timeout time.Duration
-	// Maximum number of retries before considering iDRAC unresponsive
+	// MaxRetries is the number of retries after the initial attempt.
 	MaxRetries int
-	// Whether to automatically reset iDRAC when unresponsive
+	// RetryInterval is the base delay between attempts. Each subsequent delay is
+	// increased linearly. A value of zero disables the delay.
+	RetryInterval time.Duration
+	// ResetOnTimeout enables a graceful iDRAC reset after all health checks fail.
 	ResetOnTimeout bool
 }
 
-// NewiDRACMonitor creates a new iDRAC monitor
-func NewiDRACMonitor(service *schemas.Entity, manager *Manager, config *iDRACMonitorConfig) *iDRACMonitor {
-	if config == nil {
-		config = &iDRACMonitorConfig{
-			Timeout:        30 * time.Second,
-			MaxRetries:     3,
-			ResetOnTimeout: false,
-		}
+// NewIDRACMonitor creates a new iDRAC monitor. If service is nil, the manager
+// resource is used for health checks.
+func NewIDRACMonitor(service *schemas.Entity, manager *Manager, config *IDRACMonitorConfig) *IDRACMonitor {
+	effectiveConfig := IDRACMonitorConfig{
+		Timeout:       defaultIDRACMonitorTimeout,
+		MaxRetries:    defaultIDRACMonitorMaxRetries,
+		RetryInterval: defaultIDRACMonitorRetryInterval,
+	}
+	if config != nil {
+		effectiveConfig = *config
 	}
 
-	return &iDRACMonitor{
+	return &IDRACMonitor{
 		service:        service,
 		manager:        manager,
-		timeout:        config.Timeout,
-		maxRetries:     config.MaxRetries,
-		resetOnTimeout: config.ResetOnTimeout,
+		timeout:        effectiveConfig.Timeout,
+		maxRetries:     max(effectiveConfig.MaxRetries, 0),
+		retryInterval:  max(effectiveConfig.RetryInterval, 0),
+		resetOnTimeout: effectiveConfig.ResetOnTimeout,
 	}
 }
 
-// CheckHealth performs a health check on the iDRAC
-func (im *iDRACMonitor) CheckHealth(ctx context.Context) error {
-	// Create a context with timeout
-	_, cancel := context.WithTimeout(ctx, im.timeout)
-	defer cancel()
+// NewiDRACMonitor creates a new iDRAC monitor.
+// Deprecated: Use NewIDRACMonitor.
+func NewiDRACMonitor(service *schemas.Entity, manager *Manager, config *IDRACMonitorConfig) *IDRACMonitor {
+	return NewIDRACMonitor(service, manager, config)
+}
 
-	// Try to get basic manager information as a health check
-	// For now, just check if we can access the manager
-	if im.manager == nil || im.manager.ID == "" {
-		return errors.New("health check failed: manager not accessible")
+// CheckHealth verifies that the configured iDRAC resource responds to a GET.
+func (m *IDRACMonitor) CheckHealth(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("health check failed: context is nil")
+	}
+
+	resource, err := m.healthResource()
+	if err != nil {
+		return err
+	}
+	resourceClient := resource.GetClient()
+	if resourceClient == nil {
+		return errors.New("health check failed: resource has no client")
+	}
+	client, ok := resourceClient.(*gofish.APIClient)
+	if !ok {
+		return errors.New("health check failed: resource client is not an APIClient")
+	}
+
+	requestContext := ctx
+	if m.timeout > 0 {
+		var cancel context.CancelFunc
+		requestContext, cancel = context.WithTimeout(ctx, m.timeout)
+		defer cancel()
+	}
+
+	resp, err := client.WithContext(requestContext).Get(resource.ODataID)
+	defer schemas.DeferredCleanupHTTPResponse(resp)
+	if err != nil {
+		return fmt.Errorf("health check failed: %w", err)
 	}
 
 	return nil
 }
 
-// ExecuteWithRetry executes a function with retry logic and timeout detection
-func (im *iDRACMonitor) ExecuteWithRetry(ctx context.Context, operation func() error) error {
-	var lastErr error
-
-	for attempt := 0; attempt <= im.maxRetries; attempt++ {
-		// Check iDRAC health before attempting operation
-		if healthErr := im.CheckHealth(ctx); healthErr != nil {
-			if attempt == im.maxRetries {
-				if im.resetOnTimeout {
-					// Try to reset iDRAC before giving up
-					resetErr := im.manager.ResetiDRAC(GracefuliDRACReset)
-					if resetErr != nil {
-						return fmt.Errorf("iDRAC unresponsive after %d attempts, reset also failed: %w", im.maxRetries+1, resetErr)
-					}
-					return fmt.Errorf("iDRAC was unresponsive, performed reset but operation failed")
-				}
-				return fmt.Errorf("iDRAC unresponsive after %d attempts: %w", im.maxRetries+1, healthErr)
-			}
-			// Wait before retry
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(time.Duration(attempt+1) * time.Second):
-				continue
-			}
+func (m *IDRACMonitor) healthResource() (*schemas.Entity, error) {
+	if m.service != nil {
+		if m.service.ODataID == "" {
+			return nil, errors.New("health check failed: service has no @odata.id")
 		}
-
-		// Execute the operation
-		if err := operation(); err != nil {
-			lastErr = err
-			// If it's a network error or timeout, retry
-			if isRetryableError(err) {
-				continue
-			}
-			// Non-retryable error, return immediately
-			return err
-		}
-
-		// Success
-		return nil
+		return m.service, nil
 	}
-
-	return lastErr
+	if m.manager == nil {
+		return nil, errors.New("health check failed: manager is not configured")
+	}
+	if m.manager.ODataID == "" {
+		return nil, errors.New("health check failed: manager has no @odata.id")
+	}
+	return &m.manager.Entity, nil
 }
 
-// isRetryableError determines if an error is worth retrying
-func isRetryableError(err error) bool {
-	if err == nil {
-		return false
+// ExecuteWithRetry executes an operation after checking iDRAC health. Network
+// and service availability errors are retried according to the monitor config.
+func (m *IDRACMonitor) ExecuteWithRetry(ctx context.Context, operation func() error) error {
+	if operation == nil {
+		return errors.New("operation is nil")
 	}
 
-	// Check for context timeout
+	attempts := m.maxRetries + 1
+	for attempt := 0; attempt < attempts; attempt++ {
+		if err := m.CheckHealth(ctx); err != nil {
+			if !isRetryableError(err) {
+				return err
+			}
+			if attempt == attempts-1 {
+				return m.handleUnhealthyIDRAC(attempts, err)
+			}
+			if err := m.waitForRetry(ctx, attempt); err != nil {
+				return err
+			}
+			continue
+		}
+
+		err := operation()
+		if err == nil {
+			return nil
+		}
+		if !isRetryableError(err) {
+			return err
+		}
+		if attempt == attempts-1 {
+			return fmt.Errorf("operation failed after %d attempts: %w", attempts, err)
+		}
+		if err := m.waitForRetry(ctx, attempt); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *IDRACMonitor) handleUnhealthyIDRAC(attempts int, healthErr error) error {
+	if !m.resetOnTimeout {
+		return fmt.Errorf("iDRAC unresponsive after %d attempts: %w", attempts, healthErr)
+	}
+	if m.manager == nil {
+		return fmt.Errorf("iDRAC unresponsive after %d attempts and reset is unavailable: %w", attempts, healthErr)
+	}
+	if err := m.manager.ResetiDRAC(GracefuliDRACReset); err != nil {
+		return fmt.Errorf("iDRAC unresponsive after %d attempts, reset also failed: %w", attempts, err)
+	}
+	return fmt.Errorf("iDRAC unresponsive after %d attempts; graceful reset performed: %w", attempts, healthErr)
+}
+
+func (m *IDRACMonitor) waitForRetry(ctx context.Context, attempt int) error {
+	delay := time.Duration(attempt+1) * m.retryInterval
+	if delay <= 0 {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			return nil
+		}
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// isRetryableError determines whether an operation error is transient.
+func isRetryableError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return false
+	}
 	if errors.Is(err, context.DeadlineExceeded) {
 		return true
 	}
 
-	// Check for HTTP timeout or connection errors
-	errStr := err.Error()
-	retryableErrors := []string{
-		"timeout",
-		"connection refused",
-		"connection reset",
-		"no such host",
-		"network is unreachable",
-		"i/o timeout",
+	var redfishErr *schemas.Error
+	if errors.As(err, &redfishErr) {
+		status := redfishErr.HTTPReturnedStatusCode
+		return status == http.StatusRequestTimeout || status == http.StatusTooManyRequests || status >= http.StatusInternalServerError
 	}
 
-	for _, retryable := range retryableErrors {
-		if containsIgnoreCase(errStr, retryable) {
-			return true
-		}
+	var networkErr net.Error
+	if errors.As(err, &networkErr) && networkErr.Timeout() {
+		return true
 	}
 
-	return false
-}
-
-// containsIgnoreCase checks if a string contains a substring (case insensitive)
-func containsIgnoreCase(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || containsIgnoreCase(s[1:], substr) || (s != "" && substr != "" && toLower(s[0]) == toLower(substr[0]) && containsIgnoreCase(s[1:], substr[1:])))
-}
-
-// toLower converts a byte to lowercase
-func toLower(b byte) byte {
-	if b >= 'A' && b <= 'Z' {
-		return b + ('a' - 'A')
-	}
-	return b
+	return errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.ENETUNREACH) ||
+		errors.Is(err, syscall.EHOSTUNREACH)
 }

--- a/oem/dell/idrac_monitor_test.go
+++ b/oem/dell/idrac_monitor_test.go
@@ -7,86 +7,301 @@ package dell
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
+	"github.com/stmcginnis/gofish"
 	"github.com/stmcginnis/gofish/schemas"
 )
 
-func TestIDRACMonitor_CheckHealth(t *testing.T) {
-	// Create a mock manager
-	baseManager := schemas.Manager{}
-	baseManager.ID = "iDRAC.Embedded.1"
-	manager := &Manager{Manager: baseManager}
+const (
+	idracManagerURI        = "/redfish/v1/Managers/iDRAC.Embedded.1"
+	monitorServiceRootBody = "{\"@odata.id\":\"/redfish/v1/\",\"Id\":\"RootService\",\"Name\":\"Root Service\"}"
+)
 
-	// Create monitor
-	config := &iDRACMonitorConfig{
-		Timeout:        5 * time.Second,
-		MaxRetries:     2,
-		ResetOnTimeout: false,
+func TestIDRACMonitorCheckHealth(t *testing.T) {
+	var requestedURI string
+	client := newMonitorAPIClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requestedURI = r.URL.Path
+		writeHealthOK(t, w)
+	})
+	monitor := NewIDRACMonitor(nil, newMonitorManager(client), &IDRACMonitorConfig{
+		Timeout: time.Second,
+	})
+
+	if err := monitor.CheckHealth(context.Background()); err != nil {
+		t.Fatalf("health check failed: %v", err)
 	}
-
-	monitor := NewiDRACMonitor(nil, manager, config)
-
-	// Test with valid manager
-	ctx := context.Background()
-	err := monitor.CheckHealth(ctx)
-	if err != nil {
-		t.Errorf("Health check failed unexpectedly: %v", err)
+	if requestedURI != idracManagerURI {
+		t.Errorf("health check requested %q, expected %q", requestedURI, idracManagerURI)
 	}
 }
 
-func TestIDRACMonitor_ExecuteWithRetry(t *testing.T) {
-	baseManager := schemas.Manager{}
-	baseManager.ID = "iDRAC.Embedded.1"
-	manager := &Manager{Manager: baseManager}
-
-	config := &iDRACMonitorConfig{
-		Timeout:        1 * time.Second,
-		MaxRetries:     1,
-		ResetOnTimeout: false,
-	}
-
-	monitor := NewiDRACMonitor(nil, manager, config)
-
-	ctx := context.Background()
-
-	// Test successful operation
-	callCount := 0
-	err := monitor.ExecuteWithRetry(ctx, func() error {
-		callCount++
-		return nil
+func TestIDRACMonitorCheckHealthTimeout(t *testing.T) {
+	client := newMonitorAPIClient(t, func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	})
+	monitor := NewIDRACMonitor(nil, newMonitorManager(client), &IDRACMonitorConfig{
+		Timeout: 10 * time.Millisecond,
 	})
 
-	if err != nil {
-		t.Errorf("Expected operation to succeed, got error: %v", err)
+	err := monitor.CheckHealth(context.Background())
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+}
+
+func TestIDRACMonitorCheckHealthValidation(t *testing.T) {
+	managerWithoutClient := newMonitorManager(nil)
+	managerWithUnsupportedClient := newMonitorManager(&schemas.TestClient{})
+
+	tests := []struct {
+		name    string
+		monitor *IDRACMonitor
+		ctx     context.Context
+		want    string
+	}{
+		{
+			name:    "nil context",
+			monitor: NewIDRACMonitor(nil, managerWithoutClient, nil),
+			want:    "context is nil",
+		},
+		{
+			name:    "missing manager",
+			monitor: NewIDRACMonitor(nil, nil, nil),
+			ctx:     context.Background(),
+			want:    "manager is not configured",
+		},
+		{
+			name: "missing resource URI",
+			monitor: NewIDRACMonitor(nil, &Manager{
+				Manager: schemas.Manager{},
+			}, nil),
+			ctx:  context.Background(),
+			want: "manager has no @odata.id",
+		},
+		{
+			name:    "missing client",
+			monitor: NewIDRACMonitor(nil, managerWithoutClient, nil),
+			ctx:     context.Background(),
+			want:    "resource has no client",
+		},
+		{
+			name:    "client is not APIClient",
+			monitor: NewIDRACMonitor(nil, managerWithUnsupportedClient, nil),
+			ctx:     context.Background(),
+			want:    "resource client is not an APIClient",
+		},
 	}
 
-	if callCount != 1 {
-		t.Errorf("Expected operation to be called once, got %d calls", callCount)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.monitor.CheckHealth(test.ctx)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("expected error containing %q, got %v", test.want, err)
+			}
+		})
+	}
+}
+
+func TestIDRACMonitorExecuteWithRetry(t *testing.T) {
+	var healthChecks atomic.Int32
+	client := newMonitorAPIClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		healthChecks.Add(1)
+		writeHealthOK(t, w)
+	})
+	monitor := NewIDRACMonitor(nil, newMonitorManager(client), &IDRACMonitorConfig{
+		MaxRetries: 2,
+	})
+
+	operations := 0
+	err := monitor.ExecuteWithRetry(context.Background(), func() error {
+		operations++
+		if operations < 3 {
+			return context.DeadlineExceeded
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("operation failed: %v", err)
+	}
+	if operations != 3 {
+		t.Errorf("operation called %d times, expected 3", operations)
+	}
+	if healthChecks.Load() != 3 {
+		t.Errorf("health checked %d times, expected 3", healthChecks.Load())
+	}
+}
+
+func TestIDRACMonitorExecuteWithRetryStopsOnPermanentError(t *testing.T) {
+	client := newMonitorAPIClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		writeHealthOK(t, w)
+	})
+	monitor := NewIDRACMonitor(nil, newMonitorManager(client), &IDRACMonitorConfig{
+		MaxRetries: 3,
+	})
+
+	operations := 0
+	expectedErr := errors.New("invalid request")
+	err := monitor.ExecuteWithRetry(context.Background(), func() error {
+		operations++
+		return expectedErr
+	})
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected permanent operation error, got %v", err)
+	}
+	if operations != 1 {
+		t.Errorf("operation called %d times, expected 1", operations)
+	}
+}
+
+func TestIDRACMonitorExecuteWithRetryHonorsCancellation(t *testing.T) {
+	client := newMonitorAPIClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		writeHealthOK(t, w)
+	})
+	monitor := NewIDRACMonitor(nil, newMonitorManager(client), &IDRACMonitorConfig{
+		MaxRetries:    2,
+		RetryInterval: time.Hour,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+
+	operations := 0
+	err := monitor.ExecuteWithRetry(ctx, func() error {
+		operations++
+		cancel()
+		return context.DeadlineExceeded
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
+	}
+	if operations != 1 {
+		t.Errorf("operation called %d times, expected 1", operations)
+	}
+}
+
+func TestIDRACMonitorUnhealthyRetries(t *testing.T) {
+	var healthChecks atomic.Int32
+	client := newMonitorAPIClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		healthChecks.Add(1)
+		http.Error(w, "temporarily unavailable", http.StatusServiceUnavailable)
+	})
+	monitor := NewIDRACMonitor(nil, newMonitorManager(client), &IDRACMonitorConfig{
+		MaxRetries: 2,
+	})
+
+	operations := 0
+	err := monitor.ExecuteWithRetry(context.Background(), func() error {
+		operations++
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "iDRAC unresponsive after 3 attempts") {
+		t.Fatalf("expected unresponsive error, got %v", err)
+	}
+	if healthChecks.Load() != 3 {
+		t.Errorf("health checked %d times, expected 3", healthChecks.Load())
+	}
+	if operations != 0 {
+		t.Errorf("operation called %d times, expected 0", operations)
+	}
+}
+
+func TestIDRACMonitorUnhealthyStopsOnPermanentError(t *testing.T) {
+	var healthChecks atomic.Int32
+	client := newMonitorAPIClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		healthChecks.Add(1)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	})
+	monitor := NewIDRACMonitor(nil, newMonitorManager(client), &IDRACMonitorConfig{
+		MaxRetries: 2,
+	})
+
+	err := monitor.ExecuteWithRetry(context.Background(), func() error {
+		t.Fatal("operation should not run after a failed health check")
+		return nil
+	})
+	var redfishErr *schemas.Error
+	if !errors.As(err, &redfishErr) || redfishErr.HTTPReturnedStatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected unauthorized Redfish error, got %v", err)
+	}
+	if healthChecks.Load() != 1 {
+		t.Errorf("health checked %d times, expected 1", healthChecks.Load())
 	}
 }
 
 func TestIsRetryableError(t *testing.T) {
+	timeoutError := &net.DNSError{IsTimeout: true}
 	tests := []struct {
-		name     string
-		err      error
-		expected bool
+		name string
+		err  error
+		want bool
 	}{
-		{"nil error", nil, false},
-		{"timeout error", context.DeadlineExceeded, true},
-		{"connection refused", errors.New("connection refused"), true},
-		{"network unreachable", errors.New("network is unreachable"), true},
-		{"i/o timeout", errors.New("i/o timeout"), true},
-		{"regular error", errors.New("some other error"), false},
+		{name: "nil", err: nil},
+		{name: "canceled context", err: context.Canceled},
+		{name: "deadline exceeded", err: context.DeadlineExceeded, want: true},
+		{name: "network timeout", err: timeoutError, want: true},
+		{name: "connection refused", err: fmt.Errorf("dial failed: %w", syscall.ECONNREFUSED), want: true},
+		{name: "HTTP 429", err: schemas.ConstructError(http.StatusTooManyRequests, nil), want: true},
+		{name: "HTTP 503", err: schemas.ConstructError(http.StatusServiceUnavailable, nil), want: true},
+		{name: "HTTP 400", err: schemas.ConstructError(http.StatusBadRequest, nil)},
+		{name: "permanent error", err: errors.New("invalid request")},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := isRetryableError(tt.err)
-			if result != tt.expected {
-				t.Errorf("isRetryableError(%v) = %v, expected %v", tt.err, result, tt.expected)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := isRetryableError(test.err); got != test.want {
+				t.Errorf("isRetryableError(%v) = %t, expected %t", test.err, got, test.want)
 			}
 		})
+	}
+}
+
+func newMonitorAPIClient(t *testing.T, healthHandler http.HandlerFunc) *gofish.APIClient {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case schemas.DefaultServiceRoot:
+			w.Header().Set("Content-Type", "application/json")
+			if _, err := w.Write([]byte(monitorServiceRootBody)); err != nil {
+				t.Errorf("failed to write service root response: %v", err)
+			}
+		case idracManagerURI:
+			healthHandler(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := gofish.Connect(gofish.ClientConfig{
+		Endpoint:   server.URL,
+		HTTPClient: server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("failed to create API client: %v", err)
+	}
+	return client
+}
+
+func newMonitorManager(client schemas.Client) *Manager {
+	manager := schemas.Manager{}
+	manager.ODataID = idracManagerURI
+	manager.ID = "iDRAC.Embedded.1"
+	manager.SetClient(client)
+	return &Manager{Manager: manager}
+}
+
+func writeHealthOK(t *testing.T, w http.ResponseWriter) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := w.Write([]byte("{}")); err != nil {
+		t.Errorf("failed to write health response: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Export `IDRACMonitor` and `IDRACMonitorConfig`, and add the conventionally named `NewIDRACMonitor` constructor.
- Replace the cached manager ID check with a live GET against the configured service or manager resource.
- Enforce the configured health-check timeout with the existing `APIClient.WithContext` mechanism.
- Retry only transient network errors, HTTP 408/429/5xx responses, and deadline expirations.
- Add configurable retry intervals and comprehensive tests for health checks, retries, cancellation, and permanent failures.

## Problem

The monitor introduced in #488 creates a timeout context but never uses it. `CheckHealth` currently reports success whenever a previously loaded manager has a non-empty ID, even if iDRAC is no longer reachable. The configuration type is also unexported, so external callers cannot supply non-default settings.

Operation retry detection additionally relies on recursive, case-insensitive matching of error strings. That can misclassify errors and does not distinguish transient Redfish responses from permanent client errors.

## Implementation

The monitor obtains the `APIClient` attached to the selected Redfish resource and performs the health request with:

```go
client.WithContext(requestContext).Get(resource.ODataID)
```

This reuses the existing client request path, including authentication, transport configuration, concurrency limiting, and context cancellation. No generic client methods or interfaces are added.

Health and operation retries now:

- stop immediately for cancellation and permanent errors;
- retry timeouts, common connection failures, HTTP 408/429, and HTTP 5xx;
- apply a context-aware linear retry delay; and
- only consider an automatic reset after transient health failures exhaust all attempts.

## Compatibility and scope

The existing `NewiDRACMonitor` constructor remains as a deprecated compatibility wrapper. The existing reset API is unchanged.

The branch is rebased onto current `main`, including #554. The PR changes only the Dell iDRAC monitor and its tests.

Live health checks require the resource to use the standard `gofish.APIClient`; a clear error is returned for a missing or different client implementation.

## Testing

- `make test`
- `make lint`
- `go test -race ./oem/dell`
- `git diff --check`