### PR TITLE
Workaround Inspur MemoryLocation Channel bug

### DIFF
--- a/schemas/memory.go
+++ b/schemas/memory.go
@@ -1007,6 +1007,26 @@ type MemoryLocation struct {
 	Socket *int `json:",omitempty"`
 }
 
+func (ml *MemoryLocation) UnmarshalJSON(b []byte) error {
+	type temp MemoryLocation
+	var tmp struct {
+		temp
+
+		// Workaround for Inspur and Kaytus bug
+		Channel any
+	}
+
+	err := json.Unmarshal(b, &tmp)
+	if err != nil {
+		return err
+	}
+
+	*ml = MemoryLocation(tmp.temp)
+	ml.Channel = toInt(tmp.Channel)
+
+	return nil
+}
+
 // PowerManagementPolicy shall contain properties that describe the power
 // management policy for this resource.
 type PowerManagementPolicy struct {

--- a/schemas/memory_test.go
+++ b/schemas/memory_test.go
@@ -88,6 +88,21 @@ var memoryBody = `{
 		"VendorID": "Generic"
 	}`
 
+var memoryBadBody = `{
+		"@odata.context": "/redfish/v1/$metadata#Memory.Memory",
+		"@odata.id": "/redfish/v1/Systems/System-1/Memory/NVRAM4",
+		"@odata.type": "#Memory.v1_2_0.Memory",
+		"Name": "Memory",
+		"Id": "NVRAM4",
+		"MemoryLocation": {
+			"Channel": "1",
+			"MemoryController": 2,
+			"Slot": 3,
+			"Socket": 4
+		},
+		"VendorID": "Inspur"
+	}`
+
 // TestMemory tests the parsing of Memory objects.
 func TestMemory(t *testing.T) {
 	var result Memory
@@ -154,5 +169,18 @@ func TestMemoryUpdate(t *testing.T) {
 
 	if !strings.Contains(calls[0].Payload, "SecurityState:Frozen") {
 		t.Errorf("Unexpected SecurityState update payload: %s", calls[0].Payload)
+	}
+}
+
+func TestBadMemory(t *testing.T) {
+	var result Memory
+	err := json.NewDecoder(strings.NewReader(memoryBadBody)).Decode(&result)
+
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+
+	if *result.MemoryLocation.Channel != 1 {
+		t.Errorf("Invalid MemoryLocation channel conversion, expected 1, got %v", result.MemoryLocation.Channel)
 	}
 }


### PR DESCRIPTION
The spec declares the channel as an optional integer value, but some systems return the value as a string. This adds a workaround to handle that string and attempt to convert it to the correct data type.

Related: #560 