### PR TITLE
Add AccountService.CreateAccountParams method

### DIFF
--- a/schemas/accountservice.go
+++ b/schemas/accountservice.go
@@ -494,6 +494,83 @@ func (a *AccountService) Roles() ([]*Role, error) {
 	return GetCollectionObjects[Role](a.client, a.roles)
 }
 
+// CreateAccountParameters holds the properties to set when creating a new
+// Redfish user account. Any property left at its zero value is omitted from
+// the create request, so the service applies its own default.
+type CreateAccountParameters struct {
+	// UserName shall contain the username for this account.
+	UserName string `json:"UserName"`
+	// Password shall contain the password for this account, and must conform to
+	// the configured password requirements.
+	Password string `json:"Password"`
+	// RoleID shall contain the 'RoleId' of the role resource configured for this
+	// account, typically one of 'Administrator', 'Operator', or 'ReadOnly'.
+	RoleID string `json:"RoleId,omitempty"`
+	// Enabled shall indicate whether the account is enabled. If 'true', the user
+	// can log in. If 'false', the account is disabled.
+	Enabled *bool `json:"Enabled,omitempty"`
+	// AccountExpiration shall contain the date and time when this account
+	// expires. The service shall disable or delete an account that has expired.
+	//
+	// Version added: v1.8.0
+	AccountExpiration string `json:"AccountExpiration,omitempty"`
+	// AccountTypes shall contain the manager services that the account is allowed
+	// to access. If not provided, the service typically defaults to 'Redfish'.
+	//
+	// Version added: v1.4.0
+	AccountTypes []AccountTypes `json:"AccountTypes,omitempty"`
+	// OEMAccountTypes shall contain the OEM account types for this account. It is
+	// only valid when AccountTypes contains 'OEM'.
+	//
+	// Version added: v1.4.0
+	OEMAccountTypes []string `json:"OEMAccountTypes,omitempty"`
+	// StrictAccountTypes shall indicate if the service needs to use the
+	// AccountTypes and OEMAccountTypes values exactly as specified, rejecting the
+	// request if it cannot. If not provided, the service assumes 'false'.
+	//
+	// Version added: v1.7.0
+	StrictAccountTypes *bool `json:"StrictAccountTypes,omitempty"`
+	// EmailAddress shall contain the email address associated with this account.
+	//
+	// Version added: v1.11.0
+	EmailAddress string `json:"EmailAddress,omitempty"`
+	// PhoneNumber shall contain the contact phone number associated with this
+	// account.
+	//
+	// Version added: v1.11.0
+	PhoneNumber string `json:"PhoneNumber,omitempty"`
+	// OneTimePasscodeDeliveryAddress shall contain the contact address for
+	// receiving one-time passcode messages for multi-factor authentication.
+	//
+	// Version added: v1.11.0
+	OneTimePasscodeDeliveryAddress string `json:"OneTimePasscodeDeliveryAddress,omitempty"`
+	// PasswordChangeRequired shall indicate whether the password must be changed
+	// before further access to the account is allowed. Setting this to 'true' can
+	// force a password change before first access of the account.
+	//
+	// Version added: v1.3.0
+	PasswordChangeRequired *bool `json:"PasswordChangeRequired,omitempty"`
+	// PasswordExpiration shall contain the date and time when this account
+	// password expires. If allowed by the service, this overrides the
+	// 'PasswordExpirationDays' property of the account service.
+	//
+	// Version added: v1.6.0
+	PasswordExpiration string `json:"PasswordExpiration,omitempty"`
+	// MFABypass shall contain the multi-factor authentication bypass settings for
+	// this account.
+	//
+	// Version added: v1.10.0
+	MFABypass *MFABypass `json:"MFABypass,omitempty"`
+	// SNMP shall contain the SNMP settings for this account when AccountTypes
+	// contains 'SNMP'.
+	//
+	// Version added: v1.4.0
+	SNMP *SNMPUserInfo `json:"SNMP,omitempty"`
+	// OEM gives the opportunity to specify any OEM specific properties. It should
+	// contain the vendor specific struct that goes inside the Oem object.
+	OEM any `json:"Oem,omitempty"`
+}
+
 // CreateAccount creates a new Redfish user account.
 //
 // `userName` is the new username to use.
@@ -503,19 +580,24 @@ func (a *AccountService) Roles() ([]*Role, error) {
 // `roleID` is the role to assign to the user, typically one of `Administrator`, `Operator`, or `ReadOnly`.
 //
 // Returns the created user account that can then be updated for things like setting `passwordChangeRequried`, etc.
+//
+// Use CreateAccountParams to set any of the other account properties, such as
+// OEM extensions, at creation time.
 func (accountservice *AccountService) CreateAccount(userName, password, roleID string) (*ManagerAccount, error) {
-	t := struct {
-		UserName string
-		Enabled  bool
-		Password string
-		RoleID   string `json:"RoleId"`
-	}{
+	enabled := true
+	return accountservice.CreateAccountParams(&CreateAccountParameters{
 		UserName: userName,
-		Enabled:  true,
 		Password: password,
 		RoleID:   roleID,
-	}
+		Enabled:  &enabled,
+	})
+}
 
+// CreateAccountParams creates a new Redfish user account from the given
+// parameters. Properties left unset in `params` are not sent to the service.
+//
+// Returns the created user account.
+func (accountservice *AccountService) CreateAccountParams(params *CreateAccountParameters) (*ManagerAccount, error) {
 	baseEntity := &accountservice.Entity
 
 	// The proper ETag for creating an account is found at `/AccountService/Accounts`
@@ -530,7 +612,7 @@ func (accountservice *AccountService) CreateAccount(userName, password, roleID s
 		baseEntity = accountsEntity
 	}
 
-	resp, err := baseEntity.PostWithResponse(accountservice.accounts, t)
+	resp, err := baseEntity.PostWithResponse(accountservice.accounts, params)
 	defer DeferredCleanupHTTPResponse(resp)
 	if err != nil {
 		return nil, err

--- a/schemas/accountservice_test.go
+++ b/schemas/accountservice_test.go
@@ -6,6 +6,8 @@ package schemas
 
 import (
 	"encoding/json"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 )
@@ -323,5 +325,79 @@ func TestAccountServiceUpdate(t *testing.T) {
 
 	if !strings.Contains(calls[0].Payload, "AccountLockoutCounterResetEnabled") {
 		t.Errorf("Unexpected update payload: %s", calls[0].Payload)
+	}
+}
+
+// TestAccountServiceCreateAccount checks the payload sent for both the simple
+// and the parameter-based account creation calls.
+func TestAccountServiceCreateAccount(t *testing.T) {
+	var result AccountService
+	if err := json.NewDecoder(strings.NewReader(accountServiceBody)).Decode(&result); err != nil {
+		t.Fatalf("Error decoding JSON: %s", err)
+	}
+
+	createdAccount := func() *http.Response {
+		return &http.Response{
+			Status:     "201 Created",
+			StatusCode: 201,
+			Body:       io.NopCloser(strings.NewReader(`{"@odata.id": "/redfish/v1/AccountService/Accounts/3", "UserName": "gofish"}`)),
+		}
+	}
+
+	testClient := &TestClient{
+		CustomReturnForActions: map[string][]any{
+			http.MethodPost: {createdAccount()},
+		},
+	}
+	result.SetClient(testClient)
+	result.disableEtagMatch = true
+
+	if _, err := result.CreateAccount("gofish", "n0tmypassword", "Administrator"); err != nil {
+		t.Errorf("Error making CreateAccount call: %s", err)
+	}
+
+	calls := testClient.CapturedCalls()
+	if len(calls) != 1 {
+		t.Fatalf("Expected one call to be made, captured: %v", calls)
+	}
+	if calls[0].URL != result.accounts {
+		t.Errorf("Unexpected create URL: %s", calls[0].URL)
+	}
+	for _, expected := range []string{"UserName:gofish", "Password:n0tmypassword", "RoleId:Administrator", "Enabled:true"} {
+		if !strings.Contains(calls[0].Payload, expected) {
+			t.Errorf("Expected %q in create payload: %s", expected, calls[0].Payload)
+		}
+	}
+	// Unset optional properties should not be sent.
+	if strings.Contains(calls[0].Payload, "PasswordChangeRequired") {
+		t.Errorf("Unset properties should be omitted from create payload: %s", calls[0].Payload)
+	}
+
+	testClient.Reset()
+	testClient.CustomReturnForActions[http.MethodPost] = []any{createdAccount()}
+	passwordChangeRequired := true
+	_, err := result.CreateAccountParams(&CreateAccountParameters{
+		UserName:               "gofish",
+		Password:               "n0tmypassword",
+		RoleID:                 "Administrator",
+		PasswordChangeRequired: &passwordChangeRequired,
+		AccountTypes:           []AccountTypes{RedfishAccountTypes},
+		OEM:                    map[string]any{"Contoso": map[string]any{"Widget": true}},
+	})
+	if err != nil {
+		t.Errorf("Error making CreateAccountParams call: %s", err)
+	}
+
+	calls = testClient.CapturedCalls()
+	if len(calls) != 1 {
+		t.Fatalf("Expected one call to be made, captured: %v", calls)
+	}
+	for _, expected := range []string{"PasswordChangeRequired:true", "AccountTypes:[Redfish]", "Oem:map[Contoso:map[Widget:true]]"} {
+		if !strings.Contains(calls[0].Payload, expected) {
+			t.Errorf("Expected %q in create payload: %s", expected, calls[0].Payload)
+		}
+	}
+	if strings.Contains(calls[0].Payload, "Enabled") {
+		t.Errorf("Unset properties should be omitted from create payload: %s", calls[0].Payload)
 	}
 }


### PR DESCRIPTION
There are some systems where it's necessary to pass in OEM values to account creation for certain use cases. There are also other optional standard properties that can be used in the initial call, rather than creating the account and updating it afterwards.

To support this, in addition to the existing `CreateAccount` method, this adds a `CreateAccountParams` that takes a `CreateAccountParameters` struct that can include these extra values.

Closes: #560